### PR TITLE
Sanitize page parameter in admin asset loader

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -61,7 +61,7 @@ final class Admin
     }
 
     public function assets($hook): void {
-        $page = $_GET['page'] ?? '';
+        $page = isset($_GET['page']) ? sanitize_key($_GET['page']) : '';
         if (strpos($page, $this->slug) !== 0) return;
 
         // Activation de l'uploader média sur les pages concernées


### PR DESCRIPTION
## Summary
- sanitize `page` query parameter in admin asset loader using `sanitize_key`

## Testing
- `php -l supersede-css-jlg-enhanced/src/Admin/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7c5ba2444832eb819c41fff4a51ec