### PR TITLE
Use prepared statement for option export query

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -191,7 +191,11 @@ final class Routes {
     public function exportConfig(): \WP_REST_Response {
         global $wpdb;
         $options = [];
-        $results = $wpdb->get_results( "SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE 'ssc_%'" );
+        $sql = $wpdb->prepare(
+            "SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+            'ssc_%'
+        );
+        $results = $wpdb->get_results( $sql );
         foreach ($results as $result) {
             $options[$result->option_name] = maybe_unserialize($result->option_value);
         }


### PR DESCRIPTION
## Summary
- Use `$wpdb->prepare` for retrieving options with LIKE clause in exportConfig
- Continue assembling options from results

## Testing
- `php -l supersede-css-jlg-enhanced/src/Infra/Routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7c5c11160832eb0689d21e76f4ffb