### PR TITLE
Sanitize admin page query

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -61,7 +61,7 @@ final class Admin
     }
 
     public function assets($hook): void {
-        $page = $_GET['page'] ?? '';
+        $page = isset($_GET['page']) ? sanitize_key($_GET['page']) : '';
         if (strpos($page, $this->slug) !== 0) return;
 
         // Activation de l'uploader média sur les pages concernées


### PR DESCRIPTION
## Summary
- sanitize `$_GET['page']` in admin asset loader to prevent unsanitized input

## Testing
- `php -l supersede-css-jlg-enhanced/src/Admin/Admin.php`
- `php test_admin_assets.php` (stubbed WP environment to ensure assets enqueue)


------
https://chatgpt.com/codex/tasks/task_e_68c7c5cece98832e980d69dff742ca26