### PR TITLE
Handle multisite uninstall

### DIFF
--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -23,5 +23,9 @@ $ssc_options_to_delete = [
 
 // Boucle sur la liste et supprime chaque option
 foreach ($ssc_options_to_delete as $option_name) {
-    delete_option($option_name);
+    if (is_multisite()) {
+        delete_site_option($option_name);
+    } else {
+        delete_option($option_name);
+    }
 }


### PR DESCRIPTION
## Summary
- Use delete_site_option during uninstall when running on multisite

## Testing
- `php -l supersede-css-jlg-enhanced/uninstall.php`
- `php /tmp/test_uninstall_multisite.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7c5c8ce18832e9bf17c44c66f0aa8