### PR TITLE
Use esc_like when querying options

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -191,7 +191,10 @@ final class Routes {
     public function exportConfig(): \WP_REST_Response {
         global $wpdb;
         $options = [];
-        $sql = $wpdb->prepare("SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s", 'ssc_%');
+        $sql = $wpdb->prepare(
+            "SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+            \esc_like('ssc_') . '%'
+        );
         $results = $wpdb->get_results($sql);
         foreach ($results as $result) {
             $options[$result->option_name] = maybe_unserialize($result->option_value);


### PR DESCRIPTION
## Summary
- Safely query plugin options using `esc_like` in exportConfig

## Testing
- `php -l supersede-css-jlg-enhanced/src/Infra/Routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e98c52c832e96bcd345278f8353