### PR TITLE
Avoid autoloading large options

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -101,7 +101,7 @@ final class Routes {
             }
         }
 
-        update_option(sanitize_key($option_name), $css);
+        update_option(sanitize_key($option_name), $css, false);
         
         if (class_exists('\SSC\Infra\Logger')) {
             \SSC\Infra\Logger::add('css_saved', ['size' => strlen($css) . ' bytes', 'option' => $option_name]);
@@ -153,7 +153,7 @@ final class Routes {
             return new \WP_REST_Response(['ok' => false, 'message' => 'Invalid JSON.'], 400);
         }
 
-        update_option('ssc_avatar_glow_presets', $presets);
+        update_option('ssc_avatar_glow_presets', $presets, false);
         return new \WP_REST_Response(['ok' => true], 200);
     }
     
@@ -183,7 +183,7 @@ final class Routes {
             return new \WP_REST_Response(['ok' => false, 'message' => 'Invalid JSON.'], 400);
         }
 
-        update_option('ssc_presets', $presets);
+        update_option('ssc_presets', $presets, false);
         return new \WP_REST_Response(['ok' => true], 200);
     }
     


### PR DESCRIPTION
## Summary
- prevent autoloading of large saved CSS
- disable autoload for avatar glow and preset options
- ensure logger option uses autoload false

## Testing
- `php -l src/Infra/Routes.php`
- `php -l src/Infra/Logger.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e95cf98832e831a5f1cb4f65c69