### PR TITLE
Sanitize page content rendering

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -49,6 +49,7 @@ final class Admin
                 if (defined('WP_DEBUG') && WP_DEBUG) { echo '<pre>' . esc_html($e->getMessage() . "\n" . $e->getTraceAsString()) . '</pre>'; }
             }
             $page_content = ob_get_clean();
+            $page_content = wp_kses_post( $page_content );
             if (class_exists('\SSC\Admin\Layout')) { \SSC\Admin\Layout::render($page_content, $slug); } else { echo $page_content; }
         });
     }
@@ -57,6 +58,7 @@ final class Admin
         ob_start();
         if (class_exists('\SSC\Admin\Pages\Dashboard')) { (new \SSC\Admin\Pages\Dashboard())->render(); }
         $page_content = ob_get_clean();
+            $page_content = wp_kses_post( $page_content );
         if (class_exists('\SSC\Admin\Layout')) { \SSC\Admin\Layout::render($page_content, $this->slug); } else { echo $page_content; }
     }
 

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -59,7 +59,7 @@ class Layout {
                     <?php endforeach; ?>
                 </nav></aside>
                 <main class="ssc-main-content">
-                    <?php echo $page_content; // N'échappez pas cette variable, car elle contient du HTML rendu ?>
+                    <?php echo wp_kses_post( $page_content ); ?>
                 </main>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Ensure layout rendering escapes HTML output
- Sanitize module output before passing to Layout::render

## Testing
- `php -l src/Admin/Layout.php`
- `php -l src/Admin/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e8d7aa4832eb11746cbb7a8e565