### PR TITLE
Use wpdb esc_like for export config query pattern

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -191,9 +191,10 @@ final class Routes {
     public function exportConfig(): \WP_REST_Response {
         global $wpdb;
         $options = [];
+        $like_pattern = $wpdb->esc_like('ssc_') . '%';
         $sql = $wpdb->prepare(
             "SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
-            \esc_like('ssc_') . '%'
+            $like_pattern
         );
         $results = $wpdb->get_results($sql);
         foreach ($results as $result) {


### PR DESCRIPTION
## Summary
- build the options name LIKE pattern with `$wpdb->esc_like('ssc_') . '%'`
- reuse the escaped pattern in the `exportConfig` query

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c8489c35b8832e97b9eb76ee5b2e06