### PR TITLE
Handle slashed preset payloads

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -146,7 +146,12 @@ final class Routes {
     }
 
     public function saveAvatarGlowPresets(\WP_REST_Request $request): \WP_REST_Response {
-        $presets_json = $request->get_param('presets');
+        $presets_json = wp_unslash($request->get_param('presets'));
+
+        if (!is_string($presets_json)) {
+            return new \WP_REST_Response(['ok' => false, 'message' => 'Invalid JSON.'], 400);
+        }
+
         $presets = json_decode($presets_json, true);
 
         if (json_last_error() !== JSON_ERROR_NONE || !is_array($presets)) {
@@ -176,7 +181,12 @@ final class Routes {
     }
 
     public function savePresets(\WP_REST_Request $request): \WP_REST_Response {
-        $presets_json = $request->get_param('presets');
+        $presets_json = wp_unslash($request->get_param('presets'));
+
+        if (!is_string($presets_json)) {
+            return new \WP_REST_Response(['ok' => false, 'message' => 'Invalid JSON.'], 400);
+        }
+
         $presets = json_decode($presets_json, true);
 
         if (json_last_error() !== JSON_ERROR_NONE || !is_array($presets)) {


### PR DESCRIPTION
## Summary
- unslash preset parameters before decoding them for avatar glow and general presets
- validate the unslashed preset payload is a string prior to decoding

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c8489dcb84832e87864d4c359a70c5