### PR TITLE
Declare typed admin properties and require PHP 7.4

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -5,8 +5,8 @@ if (!defined('ABSPATH')) { exit; }
 
 final class Admin
 {
-    private $slug = 'supersede-css-jlg';
-    private $cap  = 'manage_options';
+    private string $slug = 'supersede-css-jlg';
+    private string $cap  = 'manage_options';
 
     public function __construct() {
         add_action('admin_menu', [$this, 'menu']);

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -3,6 +3,7 @@
  * Plugin Name: Supersede CSS JLG (Enhanced)
  * Description: Boîte à outils visuelle pour CSS avec presets, éditeurs live, tokens, et un centre de débogage amélioré.
  * Version: 10.0.5
+ * Requires PHP: 7.4
  * Author: JLG (Enhanced by AI)
  * Text Domain: supersede-css-jlg
  * Domain Path: /languages


### PR DESCRIPTION
## Summary
- type-hint the admin slug and capability properties as strings
- document the minimum PHP 7.4 requirement in the plugin header

## Testing
- php -l supersede-css-jlg-enhanced/src/Admin/Admin.php
- php -l supersede-css-jlg-enhanced/supersede-css-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c85d2ce420832e948aa2e4a3289244