### PR TITLE
Declare typed properties for admin slug and capability

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -5,10 +5,13 @@ if (!defined('ABSPATH')) { exit; }
 
 final class Admin
 {
-    private string $slug = 'supersede-css-jlg';
-    private string $cap  = 'manage_options';
+    private string $slug;
+    private string $cap;
 
     public function __construct() {
+        $this->slug = 'supersede-css-jlg';
+        $this->cap  = 'manage_options';
+
         add_action('admin_menu', [$this, 'menu']);
         add_action('admin_enqueue_scripts', [$this, 'assets']);
     }


### PR DESCRIPTION
## Summary
- declare the admin slug and capability properties as typed members
- initialize the slug and capability inside the constructor to retain their defaults

## Testing
- php -l supersede-css-jlg-enhanced/src/Admin/Admin.php

------
https://chatgpt.com/codex/tasks/task_e_68c86519c6e0832e9181a820a310723c