### PR TITLE
Ensure trailing blank lines in PHP files

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -127,3 +127,4 @@ final class Admin
         ]);
     }
 }
+

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -66,3 +66,4 @@ class Layout {
         <?php
     }
 }
+

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
@@ -69,3 +69,4 @@ class Tokens {
     <?php }
 }
 ?>
+

--- a/supersede-css-jlg-enhanced/src/Infra/Logger.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Logger.php
@@ -37,3 +37,4 @@ class Logger {
         delete_option(self::OPT);
     }
 }
+

--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -218,3 +218,4 @@ final class Routes {
         return new \WP_REST_Response(['css' => $css], 200);
     }
 }
+

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -54,3 +54,4 @@ add_action('plugins_loaded', function(){
 add_action('plugins_loaded', function() {
     load_plugin_textdomain('supersede-css-jlg', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
+

--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -29,3 +29,4 @@ foreach ($ssc_options_to_delete as $option_name) {
         delete_option($option_name);
     }
 }
+


### PR DESCRIPTION
## Summary
- add a trailing blank line to each targeted PHP file to satisfy formatting expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c86ae866e8832ea953284c64bf1d55