### PR TITLE
Sanitize inline CSS before enqueuing

### DIFF
--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -42,11 +42,13 @@ add_action('plugins_loaded', function(){
         $css_main = get_option('ssc_active_css', '');
         $css_tokens = get_option('ssc_tokens_css', '');
         $css = $css_tokens . "\n" . $css_main;
+        // Filtre le CSS pour prévenir l'injection de balises malveillantes avant l'ajout inline.
+        $css_filtered = wp_strip_all_tags($css);
 
-        if (!empty(trim($css))) {
+        if (!empty(trim($css_filtered))) {
             wp_register_style('ssc-styles-handle', false);
             wp_enqueue_style('ssc-styles-handle');
-            wp_add_inline_style('ssc-styles-handle', '/* Supersede CSS */' . $css);
+            wp_add_inline_style('ssc-styles-handle', '/* Supersede CSS */' . $css_filtered);
         }
     }, 99);
 });


### PR DESCRIPTION
## Summary
- sanitize the combined CSS before enqueueing to prevent malicious markup
- document the reason for filtering the inline CSS block

## Testing
- php -l supersede-css-jlg-enhanced/supersede-css-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c888ec4244832e945230d46f43769c