### PR TITLE
Sanitize logger data keys

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Logger.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Logger.php
@@ -58,9 +58,17 @@ class Logger {
             $data = ['value' => $data];
         }
 
+        $sanitized = [];
+
         foreach ($data as $key => $value) {
+            if (!is_string($key)) {
+                $key = (string) $key;
+            }
+
+            $key = sanitize_key($key);
+
             if (is_array($value)) {
-                $data[$key] = self::sanitizeLogData($value);
+                $sanitized[$key] = self::sanitizeLogData($value);
                 continue;
             }
 
@@ -76,10 +84,10 @@ class Logger {
                 $value = wp_json_encode($value);
             }
 
-            $data[$key] = sanitize_text_field((string) $value);
+            $sanitized[$key] = sanitize_text_field((string) $value);
         }
 
-        return $data;
+        return $sanitized;
     }
 
     public static function all(): array {


### PR DESCRIPTION
## Summary
- sanitize logger data keys before persisting them
- ensure nested arrays re-use sanitized keys while sanitizing scalar values

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Logger.php

------
https://chatgpt.com/codex/tasks/task_e_68c888eb2ec4832e9e0f90a7e96bfe33