### PR TITLE
Remove duplicate CSS option update

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -112,7 +112,6 @@ final class Routes {
         }
 
         update_option($option_name, $css_to_store, false);
-        update_option($option_name, $css_to_store, false);
 
         if (class_exists('\SSC\Infra\Logger')) {
             \SSC\Infra\Logger::add('css_saved', ['size' => strlen($css_to_store) . ' bytes', 'option' => $option_name]);


### PR DESCRIPTION
## Summary
- remove the redundant `update_option` call in `Routes::saveCss()` so the CSS option is updated only once

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c93080d3c0832ebd35a771904b5c7e