### PR TITLE
Align stable tag with plugin version

### DIFF
--- a/supersede-css-jlg-enhanced/readme.txt
+++ b/supersede-css-jlg-enhanced/readme.txt
@@ -1,5 +1,5 @@
 === Supersede CSS JLG (Enhanced) ===
-Stable tag: 10.0.0
+Stable tag: 10.0.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Description: Boîte à outils visuelle pour CSS avec presets, éditeurs live, tokens, et un centre de débogage amélioré.


### PR DESCRIPTION
## Summary
- update the `Stable tag` entry in the plugin readme to 10.0.5 so it matches `SSC_VERSION`

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9366add78832e80b7f0d5fe9be021