### PR TITLE
Protect REST routes with nonce validation

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/animation-studio.js
+++ b/supersede-css-jlg-enhanced/assets/js/animation-studio.js
@@ -76,7 +76,7 @@
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
-                data: { css, append: true },
+                data: { css, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('Animation appliquée !'));
         });

--- a/supersede-css-jlg-enhanced/assets/js/debug-center.js
+++ b/supersede-css-jlg-enhanced/assets/js/debug-center.js
@@ -12,6 +12,7 @@
             $.ajax({
                 url: SSC.rest.root + 'health',
                 method: 'GET',
+                data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(response => {
                 resultPane.text(JSON.stringify(response, null, 2));
@@ -34,6 +35,7 @@
             $.ajax({
                 url: SSC.rest.root + 'clear-log',
                 method: 'POST',
+                data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => {
                 window.sscToast('Journal effacé ! La page va se recharger.');
@@ -56,6 +58,7 @@
             $.ajax({
                 url: SSC.rest.root + 'reset-all-css',
                 method: 'POST',
+                data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => {
                 window.sscToast('Tout le CSS a été réinitialisé !');

--- a/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
+++ b/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
@@ -10,6 +10,7 @@
         $.ajax({
             url: SSC.rest.root + 'avatar-glow-presets',
             method: 'GET',
+            data: { _wpnonce: SSC.rest.nonce },
             beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
         }).done(response => {
             presets = response || {};
@@ -27,7 +28,7 @@
         return $.ajax({
             url: SSC.rest.root + 'avatar-glow-presets',
             method: 'POST',
-            data: { presets: JSON.stringify(presets) },
+            data: { presets: JSON.stringify(presets), _wpnonce: SSC.rest.nonce },
             beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
         });
     }
@@ -199,7 +200,7 @@ ${p.className}::before {
 ${$('#ssc-glow-css-output').text()}`;
 
              $.ajax({
-                url: SSC.rest.root + 'save-css', method: 'POST', data: { css: cssToApply, append: true },
+                url: SSC.rest.root + 'save-css', method: 'POST', data: { css: cssToApply, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('Le style du preset a été appliqué sur le site !'));
         });

--- a/supersede-css-jlg-enhanced/assets/js/gradient-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/gradient-editor.js
@@ -92,7 +92,7 @@
         $('#ssc-grad-copy').on('click', () => navigator.clipboard.writeText($('#ssc-grad-css').text()).then(() => window.sscToast('CSS copié !')));
         $('#ssc-grad-apply').on('click', () => {
              const css = $('#ssc-grad-css').text();
-             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
+             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
              }).done(() => window.sscToast('Dégradé appliqué !'));
         });
 

--- a/supersede-css-jlg-enhanced/assets/js/grid-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/grid-editor.js
@@ -41,7 +41,7 @@
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
-                data: { css, append: true },
+                data: { css, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('Grille appliquée !'));
         });

--- a/supersede-css-jlg-enhanced/assets/js/import-export.js
+++ b/supersede-css-jlg-enhanced/assets/js/import-export.js
@@ -23,6 +23,7 @@
             $.ajax({
                 url: SSC.rest.root + 'export-config',
                 method: 'GET',
+                data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(response => {
                 const jsonContent = JSON.stringify(response, null, 2);
@@ -43,6 +44,7 @@
             $.ajax({
                 url: SSC.rest.root + 'export-css',
                 method: 'GET',
+                data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(response => {
                 downloadFile('supersede-styles.css', response.css, 'text/css');

--- a/supersede-css-jlg-enhanced/assets/js/preset-designer.js
+++ b/supersede-css-jlg-enhanced/assets/js/preset-designer.js
@@ -7,6 +7,7 @@
         $.ajax({
             url: SSC.rest.root + 'presets',
             method: 'GET',
+            data: { _wpnonce: SSC.rest.nonce },
             beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
         }).done(response => {
             presets = response || {};
@@ -20,7 +21,7 @@
         return $.ajax({
             url: SSC.rest.root + 'presets',
             method: 'POST',
-            data: { presets: JSON.stringify(presets) },
+            data: { presets: JSON.stringify(presets), _wpnonce: SSC.rest.nonce },
             beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
         });
     }
@@ -171,7 +172,7 @@
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
-                data: { css, append: true },
+                data: { css, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast(`Preset "${preset.name}" appliqué sur le site !`));
         });

--- a/supersede-css-jlg-enhanced/assets/js/shadow-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/shadow-editor.js
@@ -85,7 +85,7 @@
         });
         $('#ssc-shadow-apply').on('click', () => {
             const css = $('#ssc-shadow-css').text();
-             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
+             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
              }).done(() => window.sscToast('Ombre appliquée !'));
         });
 

--- a/supersede-css-jlg-enhanced/assets/js/tokens.js
+++ b/supersede-css-jlg-enhanced/assets/js/tokens.js
@@ -107,7 +107,7 @@
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
-                data: { css: css, option_name: 'ssc_tokens_css', append: false },
+                data: { css: css, option_name: 'ssc_tokens_css', append: false, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('Tokens appliqués'));
         });

--- a/supersede-css-jlg-enhanced/assets/js/tron-grid.js
+++ b/supersede-css-jlg-enhanced/assets/js/tron-grid.js
@@ -86,7 +86,7 @@
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
-                data: { css: css, append: true },
+                data: { css: css, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('Grille animée appliquée !'));
         });

--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -72,7 +72,7 @@
             const fullCss = getFullCss();
             $.ajax({
                 url: SSC.rest.root + 'save-css', method: 'POST',
-                data: { css: fullCss, option_name: 'ssc_active_css' },
+                data: { css: fullCss, option_name: 'ssc_active_css', _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('CSS enregistré !'));
         });

--- a/supersede-css-jlg-enhanced/assets/js/visual-effects.js
+++ b/supersede-css-jlg-enhanced/assets/js/visual-effects.js
@@ -96,7 +96,7 @@
         $('#ssc-bg-type, #starColor, #starCount, #gradientSpeed').on('input change', generateBackgroundCSS);
         $('#ssc-bg-apply').on('click', () => {
              const css = $('#ssc-bg-css').text();
-             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
+             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
              }).done(() => window.sscToast('Fond animé appliqué !'));
         });
         
@@ -197,7 +197,7 @@
         $('#ssc-ecg-preset, #ssc-ecg-color, #ssc-ecg-top, #ssc-ecg-logo-size, #ssc-ecg-z-index').on('input', generateECGCSS);
         $('#ssc-ecg-apply').on('click', () => {
              const css = $('#ssc-ecg-css').text();
-             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
+             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
              }).done(() => window.sscToast('Effet ECG appliqué !'));
         });
         generateECGCSS();

--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -17,50 +17,50 @@ final class Routes {
     public function register(): void {
         register_rest_route('ssc/v1', '/save-css', [
             'methods' => 'POST',
-            'permission_callback' => function() { return current_user_can('manage_options'); },
+            'permission_callback' => [$this, 'authorizeRequest'],
             'callback' => [$this, 'saveCss'],
         ]);
 
         register_rest_route('ssc/v1', '/health', [
             'methods' => 'GET',
-            'permission_callback' => function() { return current_user_can('manage_options'); },
+            'permission_callback' => [$this, 'authorizeRequest'],
             'callback' => [$this, 'healthCheck'],
         ]);
 
         register_rest_route('ssc/v1', '/clear-log', [
             'methods' => 'POST',
-            'permission_callback' => function() { return current_user_can('manage_options'); },
+            'permission_callback' => [$this, 'authorizeRequest'],
             'callback' => [$this, 'clearLog'],
         ]);
 
         register_rest_route('ssc/v1', '/avatar-glow-presets', [
             [
                 'methods' => 'GET',
-                'permission_callback' => function() { return current_user_can('manage_options'); },
+                'permission_callback' => [$this, 'authorizeRequest'],
                 'callback' => [$this, 'getAvatarGlowPresets'],
             ],
             [
                 'methods' => 'POST',
-                'permission_callback' => function() { return current_user_can('manage_options'); },
+                'permission_callback' => [$this, 'authorizeRequest'],
                 'callback' => [$this, 'saveAvatarGlowPresets'],
             ]
         ]);
-        
+
         register_rest_route('ssc/v1', '/reset-all-css', [
             'methods' => 'POST',
-            'permission_callback' => function() { return current_user_can('manage_options'); },
+            'permission_callback' => [$this, 'authorizeRequest'],
             'callback' => [$this, 'resetAllCss'],
         ]);
 
         register_rest_route('ssc/v1', '/presets', [
             [
                 'methods' => 'GET',
-                'permission_callback' => function() { return current_user_can('manage_options'); },
+                'permission_callback' => [$this, 'authorizeRequest'],
                 'callback' => [$this, 'getPresets'],
             ],
             [
                 'methods' => 'POST',
-                'permission_callback' => function() { return current_user_can('manage_options'); },
+                'permission_callback' => [$this, 'authorizeRequest'],
                 'callback' => [$this, 'savePresets'],
             ]
         ]);
@@ -68,12 +68,12 @@ final class Routes {
         // NOUVEAUX ENDPOINTS POUR L'EXPORT
         register_rest_route('ssc/v1', '/export-config', [
             'methods' => 'GET',
-            'permission_callback' => function() { return current_user_can('manage_options'); },
+            'permission_callback' => [$this, 'authorizeRequest'],
             'callback' => [$this, 'exportConfig'],
         ]);
         register_rest_route('ssc/v1', '/export-css', [
             'methods' => 'GET',
-            'permission_callback' => function() { return current_user_can('manage_options'); },
+            'permission_callback' => [$this, 'authorizeRequest'],
             'callback' => [$this, 'exportCss'],
         ]);
     }
@@ -238,6 +238,11 @@ final class Routes {
             $css = '/* Aucun CSS actif trouvé. */';
         }
         return new \WP_REST_Response(['css' => $css], 200);
+    }
+
+    public function authorizeRequest(\WP_REST_Request $request): bool {
+        check_ajax_referer('wp_rest', '_wpnonce');
+        return current_user_can('manage_options');
     }
 
 }


### PR DESCRIPTION
## Summary
- gate every SSC REST endpoint behind a shared `authorizeRequest` permission callback that runs the REST nonce check before checking capabilities
- send the nonce with each admin AJAX request so the new server-side validation succeeds across health checks, preset management, CSS saves, and exports

## Testing
- php -l src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c94607cd4c832e81587b6592a56a74