### PR TITLE
Use plugin version for Sortable enqueue

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -177,7 +177,7 @@ final class Admin
 
         // SortableJS for Drag & Drop
         if ($page === $this->slug.'-shadow') {
-            wp_enqueue_script('ssc-sortable', SSC_PLUGIN_URL . 'assets/js/Sortable.min.js', [], null, true);
+            wp_enqueue_script('ssc-sortable', SSC_PLUGIN_URL . 'assets/js/Sortable.min.js', [], SSC_VERSION, true);
         }
 
         // Scripts spécifiques aux sous-pages


### PR DESCRIPTION
## Summary
- use the plugin version constant when enqueuing the Sortable script on the shadow admin page
- note that SSC_VERSION is defined in supersede-css-jlg.php

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c946069630832e9cc29e1c4bbc0923