### PR TITLE
Replace REST nonce check with manual verification

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -240,8 +240,20 @@ final class Routes {
         return new \WP_REST_Response(['css' => $css], 200);
     }
 
-    public function authorizeRequest(\WP_REST_Request $request): bool {
-        check_ajax_referer('wp_rest', '_wpnonce');
+    /**
+     * @return bool|\WP_Error
+     */
+    public function authorizeRequest(\WP_REST_Request $request) {
+        $nonce = $request->get_param('_wpnonce');
+
+        if (!is_string($nonce) || !wp_verify_nonce($nonce, 'wp_rest')) {
+            return new \WP_Error(
+                'rest_forbidden',
+                __('Invalid nonce.', 'supersede-css-jlg'),
+                ['status' => 403]
+            );
+        }
+
         return current_user_can('manage_options');
     }
 


### PR DESCRIPTION
## Summary
- replace the REST permission nonce check with a manual call to `wp_verify_nonce`
- return a `WP_Error` when nonce validation fails so callers receive a 403 response

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c94cccf444832ebebc0a478ddcfa81