### PR TITLE
Improve REST route authorization error handling

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -246,7 +246,7 @@ final class Routes {
     public function authorizeRequest(\WP_REST_Request $request) {
         $nonce = $request->get_param('_wpnonce');
 
-        if (!is_string($nonce) || !wp_verify_nonce($nonce, 'wp_rest')) {
+        if (!is_string($nonce)) {
             return new \WP_Error(
                 'rest_forbidden',
                 __('Invalid nonce.', 'supersede-css-jlg'),
@@ -254,7 +254,23 @@ final class Routes {
             );
         }
 
-        return current_user_can('manage_options');
+        if (!wp_verify_nonce($request->get_param('_wpnonce'), 'wp_rest')) {
+            return new \WP_Error(
+                'rest_forbidden',
+                __('Invalid nonce.', 'supersede-css-jlg'),
+                ['status' => 403]
+            );
+        }
+
+        if (!current_user_can('manage_options')) {
+            return new \WP_Error(
+                'rest_forbidden',
+                __('You are not allowed to access this endpoint.', 'supersede-css-jlg'),
+                ['status' => 403]
+            );
+        }
+
+        return true;
     }
 
 }


### PR DESCRIPTION
## Summary
- manually verify REST API nonces with `wp_verify_nonce` and surface a `WP_Error` when invalid
- return a `WP_Error` for users without `manage_options` so REST permission callbacks propagate errors

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c953e209b8832e868e0a69b2b16d78