### PR TITLE
Raise minimum PHP version to 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Supersede CSS JLG (Enhanced) is a visual toolkit for building CSS effects in Wor
 
 ## Installation
 
-1. Ensure your site runs **WordPress 5.8 or later** and **PHP 7.4+**. No additional dependencies are required.
+1. Ensure your site runs **WordPress 5.8 or later** and **PHP 8.0+**. No additional dependencies are required.
 2. Download or clone this repository.
 3. Upload the `supersede-css-jlg-enhanced` folder to `wp-content/plugins/`.
 4. In the WordPress admin, navigate to **Plugins → Supersede CSS JLG (Enhanced)** and click **Activate**.

--- a/supersede-css-jlg-enhanced/readme.txt
+++ b/supersede-css-jlg-enhanced/readme.txt
@@ -1,5 +1,6 @@
 === Supersede CSS JLG (Enhanced) ===
 Stable tag: 10.0.5
+Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Description: Boîte à outils visuelle pour CSS avec presets, éditeurs live, tokens, et un centre de débogage amélioré.

--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -265,7 +265,7 @@ final class Routes {
     /**
      * @return bool|\WP_Error
      */
-    public function authorizeRequest(\WP_REST_Request $request) {
+    public function authorizeRequest(\WP_REST_Request $request): bool|\WP_Error {
         $nonce = $request->get_param('_wpnonce');
 
         if (!is_string($nonce)) {

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Supersede CSS JLG (Enhanced)
  * Description: Boîte à outils visuelle pour CSS avec presets, éditeurs live, tokens, et un centre de débogage amélioré.
  * Version: 10.0.5
- * Requires PHP: 7.4
+ * Requires PHP: 8.0
  * Author: JLG (Enhanced by AI)
  * Text Domain: supersede-css-jlg
  * Domain Path: /languages


### PR DESCRIPTION
## Summary
- bump the plugin metadata and documentation to require PHP 8.0
- add a return type declaration to Routes::authorizeRequest matching its documented behaviour

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php


------
https://chatgpt.com/codex/tasks/task_e_68c967306fa8832e90b4182a8972eb7d