### PR TITLE
Sanitize admin page parameter retrieval

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -158,7 +158,8 @@ final class Admin
             return;
         }
 
-        $page = isset($_GET['page']) ? sanitize_key($_GET['page']) : '';
+        $page_input = filter_input(INPUT_GET, 'page', FILTER_SANITIZE_STRING);
+        $page = is_string($page_input) ? sanitize_key($page_input) : '';
         if (strpos($page, $this->slug) !== 0) return;
 
         // Activation de l'uploader média sur les pages concernées


### PR DESCRIPTION
## Summary
- replace direct access to `$_GET['page']` with `filter_input` when loading admin assets
- keep `sanitize_key()` validation and ensure the page slug matches the plugin slug

## Testing
- php -l src/Admin/Admin.php

------
https://chatgpt.com/codex/tasks/task_e_68c9672e412c832e86270af50355fdd2