### PR TITLE
Sanitize exported options in Routes exportConfig

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -249,6 +249,28 @@ final class Routes {
         foreach ($results as $result) {
             $options[$result->option_name] = maybe_unserialize($result->option_value);
         }
+
+        foreach ($options as $name => $value) {
+            if (is_string($value)) {
+                $options[$name] = sanitize_text_field($value);
+                continue;
+            }
+
+            if (is_array($value)) {
+                array_walk_recursive($value, static function (&$item): void {
+                    if (is_string($item)) {
+                        $item = wp_kses_post($item);
+                    }
+                });
+
+                $options[$name] = $value;
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $options[$name] = sanitize_text_field((string) $value);
+            }
+        }
         return new \WP_REST_Response($options, 200);
     }
 


### PR DESCRIPTION
## Summary
- sanitize serialized option values before returning them from exportConfig
- apply sanitize_text_field to scalar values and wp_kses_post to strings within arrays

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b33d77ec832ea171e93872b87b13