### PR TITLE
Sanitize admin page parameter with sanitize_text_field

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -158,7 +158,7 @@ final class Admin
             return;
         }
 
-        $page_input = filter_input(INPUT_GET, 'page', FILTER_SANITIZE_STRING);
+        $page_input = sanitize_text_field(filter_input(INPUT_GET, 'page', FILTER_UNSAFE_RAW));
         $page = is_string($page_input) ? sanitize_key($page_input) : '';
         if (strpos($page, $this->slug) !== 0) return;
 


### PR DESCRIPTION
## Summary
- sanitize the admin page query parameter using sanitize_text_field on raw input
- keep the subsequent sanitize_key guard to ensure valid page slugs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9b33962b4832e8a4d61789175a174