### PR TITLE
Refactor admin pages to render view templates

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/AbstractPage.php
+++ b/supersede-css-jlg-enhanced/src/Admin/AbstractPage.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace SSC\Admin;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+abstract class AbstractPage
+{
+    /**
+     * Render a view file located in the plugin's views directory.
+     */
+    protected function render_view(string $view, array $data = []): void
+    {
+        if (!defined('SSC_PLUGIN_DIR')) {
+            return;
+        }
+
+        $sanitized_view = trim($view, "/\t\n\r\0\x0B");
+        $sanitized_view = str_replace(['..', '\\'], '', $sanitized_view);
+
+        $view_file = SSC_PLUGIN_DIR . 'views/' . $sanitized_view . '.php';
+
+        if (!is_readable($view_file)) {
+            return;
+        }
+
+        if (!empty($data)) {
+            extract($data, EXTR_SKIP);
+        }
+
+        include $view_file;
+    }
+}

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/AnimationStudio.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/AnimationStudio.php
@@ -1,41 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class AnimationStudio {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>🎬 Animation Studio</h2>
-        <p>Choisissez un preset d'animation, personnalisez-le et appliquez-le à vos éléments.</p>
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Paramètres de l'Animation</h3>
-                <label><strong>Preset d'animation</strong></label>
-                <select id="ssc-anim-preset" class="regular-text">
-                    <option value="bounce">Bounce (Rebond)</option>
-                    <option value="pulse">Pulse (Pulsation)</option>
-                    <option value="fade-in">Fade In (Apparition)</option>
-                    <option value="slide-in-left">Slide In Left (Glisse depuis la gauche)</option>
-                </select>
-                <label style="margin-top:16px; display:block;"><strong>Durée (secondes)</strong></label>
-                <input type="range" id="ssc-anim-duration" min="0.1" max="5" value="1.5" step="0.1">
-                <span id="ssc-anim-duration-val">1.5s</span>
-                <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                    <button id="ssc-anim-apply" class="button button-primary">Appliquer</button>
-                    <button id="ssc-anim-copy" class="button">Copier CSS</button>
-                </div>
-                <h3 style="margin-top:24px;">Code CSS Généré</h3>
-                <p class="description">Appliquez la classe <code>.ssc-animated</code> et la classe du preset (ex: <code>.ssc-bounce</code>) à votre élément.</p>
-                <pre id="ssc-anim-css" class="ssc-code"></pre>
-            </div>
-            <div class="ssc-pane">
-                <h3>Aperçu en Direct</h3>
-                <div id="ssc-anim-preview-container" style="display:grid; place-items:center; height:200px;">
-                    <div id="ssc-anim-preview-box" style="width: 100px; height: 100px; background: var(--ssc-accent); border-radius: 12px;"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AnimationStudio extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('animation-studio');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/AvatarGlow.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/AvatarGlow.php
@@ -1,63 +1,19 @@
 <?php declare(strict_types=1);
-namespace SSC\Admin\Pages; if (!defined('ABSPATH')) { exit; }
-class AvatarGlow {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>✨ Gestionnaire de Presets Avatar Glow</h2>
-        <p>Créez et gérez des effets d'aura réutilisables pour vos rédacteurs. Chaque preset aura son propre nom de classe.</p>
-        
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Éditeur de Presets</h3>
-                <label><strong>Preset Actif</strong></label>
-                <div class="ssc-actions">
-                    <select id="ssc-glow-preset-select" class="regular-text" style="flex: 1;"></select>
-                    <button id="ssc-glow-new-preset" class="button">Nouveau</button>
-                </div>
 
-                <div id="ssc-glow-editor-fields">
-                    <hr>
-                    <div class="ssc-two">
-                        <div><label><strong>Nom du Preset</strong></label><input type="text" id="ssc-glow-preset-name" class="regular-text" placeholder="Aura Bleue Rapide"></div>
-                        <div><label><strong>Nom de la Classe CSS</strong></label><input type="text" id="ssc-glow-preset-class" class="regular-text" placeholder=".avatar-glow-blue"></div>
-                    </div>
-                    <p class="description">Le nom de la classe doit être unique et commencer par un point (ex: <code>.glow-team-1</code>).</p>
-                    <hr>
-                    
-                    <h4>Paramètres de l'Effet</h4>
-                    <label><strong>Couleur du dégradé</strong></label>
-                    <div class="ssc-actions">
-                        <span>Début :</span> <input type="color" id="ssc-glow-color1" value="#8b5cf6">
-                        <span>Fin :</span> <input type="color" id="ssc-glow-color2" value="#ec4899">
-                    </div>
-                    <label style="margin-top:16px;"><strong>Vitesse (secondes)</strong></label>
-                    <input type="range" id="ssc-glow-speed" min="1" max="20" value="5" step="0.5">
-                    <span id="ssc-glow-speed-val">5s</span>
-                    <label style="margin-top:16px;"><strong>Épaisseur (pixels)</strong></label>
-                    <input type="range" id="ssc-glow-thickness" min="2" max="12" value="4" step="1">
-                    <span id="ssc-glow-thickness-val">4px</span>
-                </div>
+namespace SSC\Admin\Pages;
 
-                <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                    <button id="ssc-glow-save-preset" class="button button-primary">Enregistrer ce Preset</button>
-                    <button id="ssc-glow-apply" class="button">Appliquer sur le site</button>
-                    <button id="ssc-glow-delete-preset" class="button button-link-delete" style="display: none;">Supprimer ce Preset</button>
-                </div>
-            </div>
-            
-            <div class="ssc-pane">
-                <h3>Aperçu en Direct</h3>
-                <div id="ssc-glow-preview-bg" style="display:grid; place-items:center; height:250px; background: #0b1020; border-radius: 12px; transition: background 0.3s; border: 1px solid var(--ssc-border);">
-                    <div id="ssc-glow-preview-container" style="width: 128px; height: 128px;">
-                        <img id="ssc-glow-preview-img" src="<?php echo esc_url(SSC_PLUGIN_URL . 'assets/images/placeholder-avatar.png'); ?>" alt="avatar" style="width:100%; height:100%; border-radius:50%; object-fit:cover;">
-                    </div>
-                </div>
-                <button id="ssc-glow-upload-btn" class="button" style="margin-top:16px;">Changer l'image d'avatar</button>
+use SSC\Admin\AbstractPage;
 
-                 <h4 style="margin-top:16px;">Comment l'utiliser ?</h4>
-                 <p class="description">Une fois le preset enregistré et appliqué, demandez à vos rédacteurs d'ajouter la classe <code id="ssc-glow-how-to-use-class">.avatar-glow-blue</code> au conteneur (la `div`) de leur image.</p>
-                 <pre id="ssc-glow-css-output" class="ssc-code"></pre>
-            </div>
-        </div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AvatarGlow extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('avatar-glow', [
+            'avatar_placeholder' => SSC_PLUGIN_URL . 'assets/images/placeholder-avatar.png',
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/ClipPathEditor.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/ClipPathEditor.php
@@ -1,55 +1,19 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class ClipPathEditor {
-    public function render(){ ?>
-     <style>
-        #ssc-clip-preview-wrapper {
-            display: grid;
-            place-items: center;
-            padding: 24px;
-            background: var(--ssc-bg);
-            border-radius: 8px;
-        }
-        #ssc-clip-preview { 
-            background-image: url('<?php echo esc_url(SSC_PLUGIN_URL . 'assets/images/preview-bg.jpg'); ?>'); 
-            background-size: cover; 
-            background-position: center;
-            height: 300px; 
-            width: 300px; 
-            transition: all 0.3s ease;
-        }
-    </style>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>✂️ Générateur de Formes (Clip-Path)</h2>
-        <p>Découpez vos conteneurs et images dans des formes géométriques pour des designs plus dynamiques.</p>
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Formes Prédéfinies</h3>
-                <select id="ssc-clip-preset">
-                    <option value="none">Aucune (Rectangle)</option>
-                    <option value="circle(50% at 50% 50%)">Cercle</option>
-                    <option value="ellipse(50% 30% at 50% 50%)">Ellipse</option>
-                    <option value="polygon(50% 0%, 0% 100%, 100% 100%)">Triangle</option>
-                    <option value="polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)">Hexagone</option>
-                    <option value="polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)">Étoile</option>
-                    <option value="polygon(0 15%, 15% 15%, 15% 0, 85% 0, 85% 15%, 100% 15%, 100% 85%, 85% 85%, 85% 100%, 15% 100%, 15% 85%, 0 85%)">Croix</option>
-                </select>
-                <label style="margin-top:16px; display:block;"><strong>Taille de l'aperçu: <span id="ssc-clip-size-val">300px</span></strong></label>
-                <input type="range" id="ssc-clip-preview-size" min="100" max="500" value="300" step="10" style="width:100%;">
-                <h3 style="margin-top:16px;">Code CSS Généré</h3>
-                <pre id="ssc-clip-css" class="ssc-code"></pre>
-                <div class="ssc-actions"><button id="ssc-clip-copy" class="button">Copier le CSS</button></div>
-            </div>
-            <div class="ssc-pane">
-                 <h3>Aperçu</h3>
-                 <div id="ssc-clip-preview-wrapper">
-                    <div id="ssc-clip-preview"></div>
-                 </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ClipPathEditor extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('clip-path-editor', [
+            'preview_background' => SSC_PLUGIN_URL . 'assets/images/preview-bg.jpg',
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/CssViewer.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/CssViewer.php
@@ -1,29 +1,22 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class CssViewer {
-    public function render(){ 
-        // Récupérer le contenu des options CSS
-        $active_css = get_option('ssc_active_css', '/* Cette option est vide. */');
-        $tokens_css = get_option('ssc_tokens_css', '/* Cette option est vide. */');
-        ?>
-        <div class="ssc-app ssc-fullwidth">
-            <h2>🔍 Visualiseur de CSS Actif</h2>
-            <p>Ce module affiche le contenu brut des options CSS de Supersede telles qu'elles sont enregistrées dans votre base de données. C'est un outil de débogage utile pour voir le code final appliqué à votre site.</p>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-            <div class="ssc-panel" style="margin-top: 16px;">
-                <h3>Contenu de : <code>ssc_active_css</code></h3>
-                <p class="description">C'est la feuille de style principale où la plupart des modules (Utilities, effets visuels, etc.) enregistrent leur code.</p>
-                <textarea readonly class="large-text code" rows="15" style="background: #f0f0f0; color: #333; font-family: monospace; width: 100%;"><?php echo esc_textarea($active_css); ?></textarea>
-            </div>
-            
-            <div class="ssc-panel" style="margin-top: 16px;">
-                <h3>Contenu de : <code>ssc_tokens_css</code></h3>
-                <p class="description">Cette option contient les variables CSS (Tokens) que vous avez définies dans le "Tokens Manager".</p>
-                <textarea readonly class="large-text code" rows="10" style="background: #f0f0f0; color: #333; font-family: monospace; width: 100%;"><?php echo esc_textarea($tokens_css); ?></textarea>
-            </div>
-        </div>
-    <?php }
+class CssViewer extends AbstractPage
+{
+    private const EMPTY_MESSAGE = '/* Cette option est vide. */';
+
+    public function render(): void
+    {
+        $this->render_view('css-viewer', [
+            'active_css' => get_option('ssc_active_css', self::EMPTY_MESSAGE),
+            'tokens_css' => get_option('ssc_tokens_css', self::EMPTY_MESSAGE),
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/Dashboard.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/Dashboard.php
@@ -1,46 +1,24 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-final class Dashboard {
-    public function render() : void { ?>
-    <div class="ssc-wrap wrap">
-        <h1><?php echo esc_html__('Supersede CSS — Dashboard', 'supersede-css-jlg'); ?></h1>
-        <p class="description"><?php echo esc_html__('Bienvenue ! Utilisez le menu ou la palette de commande (⌘/Ctrl + K) pour naviguer.', 'supersede-css-jlg'); ?></p>
-        
-        <div class="ssc-panel" style="margin-top: 24px;">
-            <h2><?php echo esc_html__('Accès Rapide', 'supersede-css-jlg'); ?></h2>
-            <p>
-                <a class="button button-primary" href="<?php echo esc_url(admin_url('admin.php?page=supersede-css-jlg-utilities')); ?>">Éditeur CSS</a>
-                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=supersede-css-jlg-tokens')); ?>">Tokens Manager</a>
-                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=supersede-css-jlg-avatar')); ?>">Avatar Glow</a>
-                <a class="button" href="<?php echo esc_url(admin_url('admin.php?page=supersede-css-jlg-debug-center')); ?>">Centre de Débogage</a>
-            </p>
-        </div>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div class="ssc-panel" style="margin-top: 24px;">
-            <h2>💡 Comprendre le Workflow (Créer et Activer un Style)</h2>
-            <p>Pour utiliser efficacement les modules créatifs comme <strong>Avatar Glow</strong> ou <strong>Preset Designer</strong>, suivez ces 3 étapes logiques :</p>
-            <ol style="list-style-type: decimal; margin-left: 20px;">
-                <li style="margin-bottom: 15px;">
-                    <strong>ÉTAPE 1 : CRÉER ET ENREGISTRER</strong><br>
-                    Allez dans un module (ex: Avatar Glow). Personnalisez votre effet (couleurs, vitesse...). Donnez-lui un nom et une classe CSS unique (ex: <code>.aura-speciale</code>), puis cliquez sur <strong>"Enregistrer le Preset"</strong>.<br>
-                    <em>➡️ <strong>Résultat :</strong> La "recette" de votre effet est sauvegardée dans la bibliothèque du plugin. Elle n'est pas encore visible sur le site.</em>
-                </li>
-                <li style="margin-bottom: 15px;">
-                    <strong>ÉTAPE 2 : APPLIQUER (Activer)</strong><br>
-                    Avec votre preset fraîchement enregistré toujours sélectionné, cliquez sur <strong>"Appliquer sur le site"</strong>.<br>
-                    <em>➡️ <strong>Résultat :</strong> Le code CSS de votre effet est ajouté à la feuille de style globale de votre site. L'effet est maintenant "disponible" et prêt à être utilisé.</em>
-                </li>
-                <li style="margin-bottom: 15px;">
-                    <strong>ÉTAPE 3 : UTILISER</strong><br>
-                    Vos rédacteurs peuvent maintenant aller dans l'éditeur de page ou d'article, sélectionner le conteneur d'une image et lui ajouter la classe CSS que vous avez définie (<code>aura-speciale</code>) dans les réglages avancés du bloc.<br>
-                    <em>➡️ <strong>Résultat :</strong> L'effet d'aura apparaît sur l'image sur le site public !</em>
-                </li>
-            </ol>
-            <p>En résumé : <strong>On enregistre</strong> un preset pour le sauvegarder pour le futur, et <strong>on l'applique</strong> pour le rendre utilisable dès maintenant.</p>
-        </div>
-    </div>
-<?php }
+final class Dashboard extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('dashboard', [
+            'quick_links' => [
+                'utilities'    => admin_url('admin.php?page=supersede-css-jlg-utilities'),
+                'tokens'       => admin_url('admin.php?page=supersede-css-jlg-tokens'),
+                'avatar'       => admin_url('admin.php?page=supersede-css-jlg-avatar'),
+                'debug_center' => admin_url('admin.php?page=supersede-css-jlg-debug-center'),
+            ],
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/DebugCenter.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/DebugCenter.php
@@ -1,58 +1,26 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class DebugCenter {
-    public function render(): void { 
-        ?>
-        <div class="ssc-wrap ssc-debug-center">
-            <h1><?php echo esc_html__('Supersede CSS — Debug Center', 'supersede-css-jlg'); ?></h1>
-            <p><?php echo esc_html__('Un hub centralisé pour la santé du système, la gestion des modules et le journal d\'activité.', 'supersede-css-jlg'); ?></p>
-            
-            <div class="ssc-two" style="align-items: flex-start; margin-top: 16px;">
-                <div class="ssc-pane">
-                    <h2><?php echo esc_html__('Informations Système', 'supersede-css-jlg'); ?></h2>
-                    <table class="widefat striped" style="margin: 0;"><tbody>
-                        <tr><td><strong>Version du Plugin</strong></td><td><?php echo esc_html(defined('SSC_VERSION') ? SSC_VERSION : 'N/A'); ?></td></tr>
-                        <tr><td><strong>Version WordPress</strong></td><td><?php echo esc_html(get_bloginfo('version')); ?></td></tr>
-                        <tr><td><strong>Version PHP</strong></td><td><?php echo esc_html(phpversion()); ?></td></tr>
-                    </tbody></table>
-                </div>
-                <div class="ssc-pane">
-                    <h2><?php echo esc_html__('Actions Globales', 'supersede-css-jlg'); ?></h2>
-                    <div class="ssc-actions">
-                        <button class="button button-primary" id="ssc-health-run">Lancer Health Check</button>
-                    </div>
-                    <pre id="ssc-health-json" class="ssc-code" style="max-height:120px; margin-top:10px;"></pre>
-                </div>
-            </div>
-            
-            <div class="ssc-panel ssc-danger-zone" style="margin-top: 16px;">
-                 <h2>🛑 Zone de Danger</h2>
-                 <p id="ssc-danger-intro">Les actions ci-dessous sont irréversibles. Soyez certain de vouloir continuer.</p>
-                 <button id="ssc-reset-all-css" class="button" style="background: #dc2626; border-color: #991b1b; color: white;">Réinitialiser tout le CSS</button>
-                 <p id="ssc-danger-desc" class="description">Cette action videra les options <code>ssc_active_css</code> et <code>ssc_tokens_css</code> de votre base de données, désactivant tous les styles ajoutés par Supersede.</p>
-            </div>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-            <div class="ssc-panel" style="margin-top: 16px;">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-                    <h2><?php echo esc_html__('Journal d\'Activité Récent', 'supersede-css-jlg'); ?></h2>
-                    <button id="ssc-clear-log" class="button button-link-delete">Vider le journal</button>
-                </div>
-                <?php $log = class_exists('\SSC\Infra\Logger') ? \SSC\Infra\Logger::all() : []; if(!empty($log)): ?>
-                  <table class="widefat striped"><thead><tr><th>Date (UTC)</th><th>Utilisateur</th><th>Action</th><th>Données</th></tr></thead><tbody>
-                    <?php foreach ($log as $row): ?>
-                        <tr>
-                            <td><?php echo esc_html($row['t'] ?? ''); ?></td>
-                            <td><?php echo esc_html($row['user'] ?? ''); ?></td>
-                            <td><strong><?php echo esc_html($row['action'] ?? ''); ?></strong></td>
-                            <td><code><?php echo esc_html(json_encode($row['data'] ?? [])); ?></code></td>
-                        </tr>
-                    <?php endforeach; ?>
-                  </tbody></table>
-                <?php else: ?><p>Aucune entrée dans le journal.</p><?php endif; ?>
-            </div>
-        </div>
-    <?php }
+class DebugCenter extends AbstractPage
+{
+    public function render(): void
+    {
+        $log_entries = class_exists('\\SSC\\Infra\\Logger') ? \SSC\Infra\Logger::all() : [];
+
+        $this->render_view('debug-center', [
+            'system_info' => [
+                'plugin_version'    => defined('SSC_VERSION') ? SSC_VERSION : 'N/A',
+                'wordpress_version' => get_bloginfo('version'),
+                'php_version'       => phpversion(),
+            ],
+            'log_entries' => $log_entries,
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/FilterEditor.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/FilterEditor.php
@@ -1,69 +1,19 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class FilterEditor {
-    public function render(){ ?>
-    <style>
-        #ssc-filter-preview-bg { 
-            background-image: url('<?php echo esc_url(SSC_PLUGIN_URL . 'assets/images/preview-bg.jpg'); ?>'); 
-            background-size: cover; 
-            border-radius: 12px; 
-            padding: 24px; 
-            display: grid;
-            place-items: center;
-        }
-        #ssc-filter-preview-box { 
-            transition: all 0.2s ease-in-out;
-            width: 80%;
-            height: 250px;
-            color: white; 
-            font-size: 24px; 
-            font-weight: bold; 
-            text-shadow: 0 2px 4px rgba(0,0,0,0.5);
-            display: grid;
-            place-items: center;
-            border-radius: 16px;
-        }
-        .ssc-glassmorphism-preview { 
-            background: rgba(255, 255, 255, 0.2); 
-            box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1); 
-            backdrop-filter: blur(5px); 
-            -webkit-backdrop-filter: blur(5px); 
-            border: 1px solid rgba(255, 255, 255, 0.3); 
-        }
-    </style>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>🎨 Éditeur de Filtres & Effets de Verre</h2>
-        <p>Appliquez des filtres visuels à vos images et conteneurs, ou créez un effet "Glassmorphism" tendance.</p>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Filtres CSS (<code>filter</code>)</h3>
-                <div class="ssc-two">
-                    <div><label>Flou (Blur)</label><input type="range" class="ssc-filter-prop" data-prop="blur" min="0" max="20" value="0" step="1"> <span id="val-blur">0px</span></div>
-                    <div><label>Luminosité</label><input type="range" class="ssc-filter-prop" data-prop="brightness" min="0" max="200" value="100" step="5"> <span id="val-brightness">100%</span></div>
-                    <div><label>Contraste</label><input type="range" class="ssc-filter-prop" data-prop="contrast" min="0" max="200" value="100" step="5"> <span id="val-contrast">100%</span></div>
-                    <div><label>Niveaux de gris</label><input type="range" class="ssc-filter-prop" data-prop="grayscale" min="0" max="100" value="0" step="5"> <span id="val-grayscale">0%</span></div>
-                    <div><label>Rotation de teinte</label><input type="range" class="ssc-filter-prop" data-prop="hue-rotate" min="0" max="360" value="0" step="15"> <span id="val-hue-rotate">0deg</span></div>
-                    <div><label>Saturation</label><input type="range" class="ssc-filter-prop" data-prop="saturate" min="0" max="200" value="100" step="5"> <span id="val-saturate">100%</span></div>
-                </div>
-                <hr>
-                <h3>Effet Verre (<code>backdrop-filter</code>)</h3>
-                <label><input type="checkbox" id="ssc-glass-enable"> <strong>Activer le Glassmorphism</strong></label>
-                <pre id="ssc-filter-css" class="ssc-code" style="margin-top:16px;"></pre>
-                <div class="ssc-actions"><button id="ssc-filter-copy" class="button">Copier le CSS</button></div>
-            </div>
-            <div class="ssc-pane">
-                <h3>Aperçu en Direct</h3>
-                <div id="ssc-filter-preview-bg">
-                    <div id="ssc-filter-preview-box">
-                        Votre Contenu Ici
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+class FilterEditor extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('filter-editor', [
+            'preview_background' => SSC_PLUGIN_URL . 'assets/images/preview-bg.jpg',
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/GradientEditor.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/GradientEditor.php
@@ -1,21 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class GradientEditor {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth"><h2>Visual Gradient Editor</h2><div class="ssc-two" style="align-items: flex-start;">
-        <div class="ssc-pane">
-            <div class="ssc-grad-controls">
-                <div class="ssc-control-group"><label>Type</label><select id="ssc-grad-type"><option value="linear-gradient">Linéaire</option><option value="radial-gradient">Radial</option><option value="conic-gradient">Conique</option></select></div>
-                <div id="ssc-grad-angle-control" class="ssc-control-group"><label>Angle</label><input type="range" id="ssc-grad-angle" min="0" max="360" value="90" step="1"><input type="number" id="ssc-grad-angle-num" min="0" max="360" value="90" class="small-text"> deg</div>
-            </div>
-            <div class="ssc-control-group"><label>Color Stops</label><div id="ssc-grad-stops-preview" class="ssc-grad-preview-bar"></div><div id="ssc-grad-stops-ui"></div></div>
-            <div class="ssc-actions"><button id="ssc-grad-apply" class="button button-primary">Appliquer</button><button id="ssc-grad-copy" class="button">Copier CSS</button></div>
-            <pre id="ssc-grad-css" class="ssc-code"></pre>
-        </div>
-        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-grad-preview" style="height:200px;border-radius:12px;border:1px solid var(--ssc-border);"></div></div>
-    </div></div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class GradientEditor extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('gradient-editor');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/GridEditor.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/GridEditor.php
@@ -1,39 +1,17 @@
 <?php declare(strict_types=1);
-namespace SSC\Admin\Pages; if (!defined('ABSPATH')) { exit; }
-class GridEditor {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>📏 Visual Grid Editor</h2>
-        <p>Construisez des mises en page CSS Grid de manière intuitive, sans écrire de code.</p>
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Paramètres de la Grille</h3>
 
-                <label><strong>Nombre de colonnes</strong></label>
-                <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
-                <span id="ssc-grid-cols-val">3</span>
+namespace SSC\Admin\Pages;
 
-                <label style="margin-top:16px; display:block;"><strong>Espacement (gap) en pixels</strong></label>
-                <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
-                <span id="ssc-grid-gap-val">16px</span>
-                
-                <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                    <button id="ssc-grid-apply" class="button button-primary">Appliquer</button>
-                    <button id="ssc-grid-copy" class="button">Copier CSS</button>
-                </div>
-                
-                <h3 style="margin-top:24px;">Code CSS Généré</h3>
-                <p class="description">Appliquez la classe <code>.ssc-grid-container</code> à votre conteneur.</p>
-                <pre id="ssc-grid-css" class="ssc-code"></pre>
-            </div>
-            <div class="ssc-pane">
-                <h3>Aperçu en Direct</h3>
-                <div id="ssc-grid-preview" style="display:grid; border:1px dashed var(--ssc-border); padding:10px; border-radius:8px;">
-                    <!-- Les éléments de la grille seront générés par JS -->
-                </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+use SSC\Admin\AbstractPage;
+
+if (!defined('ABSPATH')) {
+    exit;
 }
-?>
+
+class GridEditor extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('grid-editor');
+    }
+}

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/ImportExport.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/ImportExport.php
@@ -1,35 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class ImportExport {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>Import / Export</h2>
-        <div class="ssc-panel" style="margin-bottom: 16px;">
-            <h3>Sauvegardez et restaurez votre configuration</h3>
-            <ul>
-                <li><strong>Exporter Config (.json) :</strong> Télécharge un fichier JSON contenant <strong>toutes</strong> vos configurations Supersede CSS (presets, tokens, etc.). Idéal pour sauvegarder votre travail ou le migrer vers un autre site.</li>
-                <li><strong>Exporter CSS (.css) :</strong> Télécharge uniquement le code CSS final qui est appliqué sur votre site. Utile pour une utilisation externe ou une simple sauvegarde du style.</li>
-                <li><strong>Importer (.json) :</strong> Restaure une configuration complète depuis un fichier JSON que vous avez précédemment exporté. <strong>Attention :</strong> cela remplacera vos configurations actuelles.</li>
-            </ul>
-        </div>
-        <div class="ssc-two">
-            <div class="ssc-pane">
-                <h3>Exporter</h3><p>Téléchargez vos configurations ou uniquement le CSS actif.</p>
-                <div class="ssc-actions">
-                    <button id="ssc-export-config" class="button button-primary">Exporter Config (.json)</button>
-                    <button id="ssc-export-css" class="button">Exporter CSS (.css)</button>
-                </div>
-            </div>
-            <div class="ssc-pane">
-                <h3>Importer</h3><p>Importez un fichier de configuration (.json).</p>
-                <input type="file" id="ssc-import-file" accept=".json">
-                <button id="ssc-import-btn" class="button">Importer</button>
-                <div id="ssc-import-msg" class="ssc-muted"></div>
-            </div>
-        </div>
-    </div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ImportExport extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('import-export');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/PageLayoutBuilder.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/PageLayoutBuilder.php
@@ -1,100 +1,19 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class PageLayoutBuilder {
-    public function render(){ ?>
-    <style>
-        .ssc-layout-grid { display: grid; height: 400px; border: 2px dashed var(--ssc-accent); padding: 10px; border-radius: 8px; background: var(--ssc-bg); }
-        .ssc-layout-block { background: var(--ssc-card); border: 1px solid var(--ssc-border); border-radius: 4px; display: grid; place-items: center; font-weight: bold; }
-        .ssc-layout-preview-mobile { width: 375px; margin-left: auto; margin-right: auto; }
-        .ssc-tutorial-panel h4 { margin-top: 1.2em; margin-bottom: 0.5em; }
-        .ssc-tutorial-panel ul, .ssc-tutorial-panel ol { margin-left: 20px; }
-    </style>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>📐 Maquettage de Page (CSS Grid)</h2>
-        <p>Préparez des mises en page complexes pour vos thèmes ou des sections spécifiques de vos pages.</p>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div class="ssc-panel ssc-tutorial-panel" style="margin-bottom:16px;">
-            <h3>💡 Tutoriel : Comment Utiliser le Maquettage de Page dans WordPress</h3>
-            <p>Cet outil génère le "plan" CSS de votre mise en page. Pour l'utiliser, vous devez ensuite construire la structure HTML correspondante dans votre page WordPress.</p>
-            
-            <h4>Étape 1 : Générer et Appliquer le CSS</h4>
-            <ol>
-                <li>Choisissez un "Modèle de layout" dans le menu déroulant ci-dessous. Le code CSS est généré instantanément.</li>
-                <li>Copiez l'intégralité de ce code.</li>
-                <li>Allez dans le menu <strong>Supersede CSS → Utilities</strong>, collez le code dans l'éditeur (onglet Desktop) et cliquez sur <strong>"Save CSS"</strong>.</li>
-            </ol>
-
-            <h4>Étape 2 : Créer la Structure HTML avec l'Éditeur de Blocs</h4>
-            <ol>
-                <li>Modifiez la page ou l'article où vous souhaitez appliquer cette mise en page.</li>
-                <li>Ajoutez un bloc <strong>Groupe</strong>. Ce sera votre conteneur principal.</li>
-                <li>Sélectionnez ce bloc Groupe, allez dans le panneau des réglages à droite, section <strong>"Avancé"</strong>.</li>
-                <li>Dans le champ "Classe(s) CSS additionnelle(s)", collez la classe principale du layout (par exemple, <code>ssc-layout-holy-grail</code>).</li>
-                <li>À l'intérieur de ce groupe principal, ajoutez un bloc (un "Groupe" est idéal) pour chaque zone définie dans le CSS (par exemple, 5 blocs pour le "Saint Graal").</li>
-                <li>Pour chaque bloc intérieur, assignez la classe CSS de sa zone dans ses réglages "Avancé" (<code>header</code>, <code>content</code>, <code>footer</code>, etc.).</li>
-                <li>Vous pouvez maintenant remplir ces blocs de zone avec votre contenu (textes, images, titres...).</li>
-            </ol>
-            <p>Votre mise en page est prête ! Elle s'adaptera automatiquement sur les écrans plus petits.</p>
-        </div>
-
-
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Paramètres & Code</h3>
-                <label><strong>Modèle de layout</strong></label>
-                <select id="layout-preset">
-                    <option value="holy-grail">Saint Graal (Header, 3 colonnes, Footer)</option>
-                    <option value="sidebar-right">Contenu + Sidebar à Droite</option>
-                    <option value="hero-features">Section Héro + 3 Cartes</option>
-                    <option value="dashboard">Tableau de Bord Asymétrique</option>
-                </select>
-                <hr>
-                <label><strong>Vue :</strong></label>
-                <div class="ssc-actions">
-                    <button class="button button-primary" id="view-desktop">Desktop</button>
-                    <button class="button" id="view-mobile">Mobile</button>
-                </div>
-                <h3 style="margin-top:24px;">Code CSS Généré</h3>
-                <pre id="layout-css" class="ssc-code"></pre>
-            </div>
-            <div class="ssc-pane">
-                <h3>Aperçu Visuel</h3>
-                <div id="layout-preview-container">
-                    <div id="layout-grid-desktop" class="ssc-layout-grid"></div>
-                    <div id="layout-grid-mobile" class="ssc-layout-grid ssc-layout-preview-mobile" style="display:none;"></div>
-                </div>
-            </div>
-        </div>
-
-        <div class="ssc-panel ssc-tutorial-panel" style="margin-top:16px;">
-            <h3>🚀 Idées d'Amélioration & Inspiration</h3>
-            <h4>Ajouter de l'Espacement (Gap)</h4>
-            <p>Par défaut, les blocs sont collés. Pour ajouter un espacement uniforme entre toutes les zones, modifiez la classe principale dans votre CSS et ajoutez la propriété <code>gap</code> :</p>
-            <pre class="ssc-code">.ssc-layout-holy-grail {
-  display: grid;
-  gap: 1rem; /* ou 16px, 2em, etc. */
-  /* ... autres propriétés ... */
-}</pre>
-            
-            <h4>Layouts pour des Sections de Page</h4>
-            <p>N'hésitez pas à utiliser ces layouts non pas pour une page entière, mais pour une section spécifique. Le modèle "Héro + 3 Cartes" est parfait pour une section "Nos services" sur votre page d'accueil.</p>
-
-            <h4>Combiner avec les Tokens</h4>
-            <p>Pour une maintenance facile, définissez vos espacements ou tailles de colonnes avec des <a href="<?php echo esc_url(admin_url('admin.php?page=supersede-css-jlg-tokens')); ?>">Tokens</a>. Par exemple :</p>
-            <pre class="ssc-code">:root { --spacing-medium: 1.5rem; }
-
-.ssc-layout-sidebar-right {
-  display: grid;
-  grid-template-columns: 3fr 1fr;
-  gap: var(--spacing-medium);
-}</pre>
-
-            <h4>Créer vos propres modèles</h4>
-            <p>Utilisez les modèles générés comme base. En modifiant les valeurs de <code>grid-template-areas</code> et <code>grid-template-columns</code>, vous pouvez inventer n'importe quelle mise en page imaginable !</p>
-        </div>
-    </div>
-    <?php }
+class PageLayoutBuilder extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('page-layout-builder', [
+            'tokens_page_url' => admin_url('admin.php?page=supersede-css-jlg-tokens'),
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/PresetDesigner.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/PresetDesigner.php
@@ -1,41 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class PresetDesigner {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>Preset Designer</h2>
-        <div class="ssc-panel" style="margin-bottom: 16px;">
-            <h3>Comment utiliser les Presets ?</h3>
-            <p>Les presets sont des ensembles de styles réutilisables que vous pouvez créer une fois et appliquer à n'importe quel élément de votre site.</p>
-            <ol style="margin-left: 20px;">
-                <li><strong>Créer un Preset :</strong> Dans l'éditeur ci-dessous, donnez un nom (ex: "Bouton Principal Rouge"), un sélecteur CSS (<code>.btn-red</code>) et ajoutez les propriétés CSS (<code>background-color</code>, <code>color</code>, etc.).</li>
-                <li><strong>Enregistrer :</strong> Cliquez sur "Enregistrer". Votre preset apparaît maintenant dans la liste des "Presets Existants".</li>
-                <li><strong>Appliquer un Preset :</strong> Utilisez la section "Quick Apply" en haut. Cherchez votre preset, sélectionnez-le et cliquez sur "Appliquer". Le CSS du preset sera ajouté à votre feuille de style globale.</li>
-            </ol>
-        </div>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane" style="flex: 1.5;"><h3>Quick Apply</h3><div class="ssc-actions"><input type="search" id="ssc-qa-search" class="regular-text" placeholder="Rechercher..."><select id="ssc-qa-select" class="regular-text"></select><button id="ssc-qa-apply" class="button button-primary">Appliquer</button></div></div>
-            <div class="ssc-pane" style="flex: 1;"><h3>Presets Existants</h3><ul id="ssc-presets-list" class="ssc-list"></ul></div>
-        </div>
-        <div class="ssc-panel" style="margin-top: 16px;">
-            <h3>Créer / Modifier un Preset</h3>
-            <div class="ssc-two">
-                <div><label><strong>Nom</strong></label><input type="text" id="ssc-preset-name" class="regular-text" placeholder="ex: Bouton arrondi"></div>
-                <div><label><strong>Sélecteur CSS</strong></label><input type="text" id="ssc-preset-scope" class="regular-text" placeholder=".btn:hover"></div>
-            </div>
-            <label style="margin-top: 12px; display: block;"><strong>Propriétés CSS</strong></label>
-            <div id="ssc-preset-props-builder" class="ssc-kv-builder"></div>
-            <button type="button" id="ssc-preset-add-prop" class="button" style="margin-top:8px;">+ Ajouter</button>
-            <div class="ssc-actions" style="margin-top:16px; border-top: 1px solid #eee; padding-top: 16px;">
-                <button id="ssc-save-preset" class="button button-primary">Enregistrer</button>
-                <button id="ssc-delete-preset" class="button button-link-delete" style="display:none;">Supprimer</button>
-            </div>
-            <div id="ssc-preset-msg" class="ssc-muted"></div>
-        </div>
-    </div>
-    <?php }
+class PresetDesigner extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('preset-designer');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/ScopeBuilder.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/ScopeBuilder.php
@@ -1,34 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class ScopeBuilder {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>Scope Builder</h2>
-        
-        <div class="ssc-panel" style="margin-bottom: 16px;">
-            <h3>Comment utiliser le Scope Builder ?</h3>
-            <p>Cet outil vous permet d'appliquer rapidement des styles CSS à des éléments très spécifiques de votre site sans avoir à naviguer dans l'éditeur principal.</p>
-            <ol style="margin-left: 20px;">
-                <li><strong>Sélecteur(s) :</strong> C'est la cible de votre style. Entrez une classe (<code>.mon-bouton</code>), un ID (<code>#logo</code>) ou une combinaison plus complexe (<code>.card > a</code>).</li>
-                <li><strong>Pseudo-classe :</strong> (Optionnel) Choisissez un état pour appliquer le style, comme lorsque l'utilisateur survole l'élément (<code>:hover</code>) ou clique dessus (<code>:focus</code>).</li>
-                <li><strong>Propriétés CSS :</strong> Écrivez le code CSS à appliquer dans la zone de texte. Par exemple : <code>background-color: #e73c7e;<br>color: white;<br>border-radius: 50px;</code></li>
-                <li><strong>Aperçu :</strong> Le résultat est visible en direct sur les éléments de démo à droite.</li>
-                <li><strong>Appliquer :</strong> Ajoute le CSS généré à la feuille de style globale de votre site.</li>
-            </ol>
-        </div>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <label>Sélecteur(s)</label><input type="text" id="ssc-sel" class="large-text" placeholder=".btn, .card > a">
-                <label>Pseudo-classe</label><select id="ssc-pseudo"><option value="">(aucune)</option><option value=":hover">:hover</option><option value=":focus">:focus</option></select>
-                <label>Propriétés CSS</label><textarea id="ssc-css" rows="12" class="code"></textarea>
-                <div class="ssc-actions"><button id="ssc-apply" class="button button-primary">Appliquer</button><button id="ssc-copy" class="button">Copier</button></div>
-            </div>
-            <div class="ssc-pane"><h3>Preview</h3><div id="ssc-scope-preview-container" style="border: 1px dashed #ccc; padding: 1em; border-radius: 8px;"><style id="ssc-scope-preview-style"></style><button class="btn demo">Bouton</button><a href="#" class="link demo">Lien</a></div></div>
-        </div>
-    </div>
-    <?php }
+class ScopeBuilder extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('scope-builder');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/ShadowEditor.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/ShadowEditor.php
@@ -1,18 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class ShadowEditor {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth"><h2>Visual Shadow Editor</h2><div class="ssc-two" style="align-items: flex-start;">
-        <div class="ssc-pane">
-            <div id="ssc-shadow-layers-container"></div>
-            <div class="ssc-actions" style="margin-top: 16px;"><button id="ssc-shadow-add-layer" class="button">Ajouter un calque</button></div><hr>
-            <div class="ssc-actions"><button id="ssc-shadow-apply" class="button button-primary">Appliquer</button><button id="ssc-shadow-copy" class="button">Copier CSS</button></div>
-            <pre id="ssc-shadow-css" class="ssc-code"></pre>
-        </div>
-        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-shadow-preview" style="width: 200px; height: 120px; background: #fff; border-radius: 12px; margin: 2em auto; display: grid; place-items: center; border: 1px solid #e5e7eb; transition: all 0.2s ease;">Aperçu</div></div>
-    </div></div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class ShadowEditor extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('shadow-editor');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
@@ -1,72 +1,21 @@
 <?php declare(strict_types=1);
-namespace SSC\Admin\Pages; if (!defined('ABSPATH')) { exit; }
-class Tokens {
-    public function render() { ?>
-    <div class="ssc-app ssc-fullwidth">
-        <div class="ssc-panel">
-            <h2>🚀 Bienvenue dans le Gestionnaire de Tokens</h2>
-            <p>Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, etc.) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.</p>
-        </div>
 
-        <div class="ssc-two" style="margin-top:16px; align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>👨‍🏫 Qu'est-ce qu'un Token (ou Variable CSS) ?</h3>
-                <p>Imaginez que vous décidiez d'utiliser une couleur bleue spécifique (`#3498db`) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C'est long et risqué !</p>
-                <p>Un <strong>token</strong> est un "raccourci". Vous donnez un nom facile à retenir à votre couleur, comme <code>--couleur-principale</code>. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.</p>
-                <p><strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s'applique partout !</strong></p>
-                <hr>
-                <h4>Exemple Concret</h4>
-                <p><strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l'élément <code>:root</code> (la racine de votre page).</p>
-                <pre class="ssc-code">:root {
-   --couleur-principale: #3498db;
-   --radius-arrondi: 8px;
-}</pre>
-                <p><strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction <code>var()</code> pour appeler la valeur du token.</p>
-                <pre class="ssc-code">.mon-bouton {
-   background-color: var(--couleur-principale);
-   border-radius: var(--radius-arrondi);
-   color: white;
+namespace SSC\Admin\Pages;
+
+use SSC\Admin\AbstractPage;
+
+if (!defined('ABSPATH')) {
+    exit;
 }
 
-.mon-titre {
-   color: var(--couleur-principale);
-}</pre>
-            </div>
-            <div class="ssc-pane">
-                <h3>🎨 Éditeur Visuel de Tokens</h3>
-                <p>Utilisez cet éditeur pour créer et gérer vos tokens sans écrire de code. Les modifications apparaîtront dans la zone de texte ci-dessous.</p>
-                
-                <div id="ssc-token-builder">
-                    <!-- Les tokens seront ajoutés ici par JavaScript -->
-                </div>
-                
-                <div class="ssc-actions" style="margin-top:12px;">
-                    <button id="ssc-token-add" class="button">+ Ajouter un Token</button>
-                </div>
+class Tokens extends AbstractPage
+{
+    private const DEFAULT_CSS = ":root {\n  --couleur-principale: #4f46e5;\n  --radius-moyen: 8px;\n}";
 
-                <hr>
-                
-                <h3>📜 Code CSS des Tokens (`:root`)</h3>
-                <p>C'est ici que le code généré par l'éditeur visuel apparaît. Vous pouvez aussi y coller directement votre propre code.</p>
-                <textarea id="ssc-tokens" rows="10" class="large-text"><?php echo esc_textarea(get_option('ssc_tokens_css', ":root {\n  --couleur-principale: #4f46e5;\n  --radius-moyen: 8px;\n}")); ?></textarea>
-                <div class="ssc-actions" style="margin-top:8px;">
-                    <button id="ssc-tokens-apply" class="button button-primary">Appliquer les Tokens sur le site</button>
-                    <button id="ssc-tokens-copy" class="button">Copier le Code</button>
-                </div>
-            </div>
-        </div>
-
-        <div class="ssc-panel" style="margin-top:16px;">
-            <h3>👁️ Aperçu en Direct</h3>
-            <p>Voyez comment vos tokens affectent les éléments. Le style de cet aperçu est directement contrôlé par le code CSS ci-dessus.</p>
-            <style id="ssc-tokens-preview-style"></style>
-            <div id="ssc-tokens-preview" style="padding: 24px; border: 2px dashed var(--couleur-principale, #ccc); border-radius: var(--radius-moyen, 8px); background: #fff;">
-                <button class="button button-primary" style="background-color: var(--couleur-principale); border-radius: var(--radius-moyen);">Bouton Principal</button>
-                <a href="#" style="color: var(--couleur-principale); margin-left: 16px;">Lien Principal</a>
-            </div>
-        </div>
-    </div>
-    <?php }
+    public function render(): void
+    {
+        $this->render_view('tokens', [
+            'tokens_css' => get_option('ssc_tokens_css', self::DEFAULT_CSS),
+        ]);
+    }
 }
-?>
-

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/TronGrid.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/TronGrid.php
@@ -1,67 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class TronGrid {
-    public function render(){ ?>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>🌐 Tron Grid Animator</h2>
-        <p>Générez un fond de grille animé et personnalisable. Idéal pour des bannières ou des fonds de section futuristes.</p>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Paramètres de la Grille</h3>
-
-                <label><strong>Couleur des lignes</strong></label>
-                <input type="color" id="ssc-tron-line-color" value="#00ffff">
-
-                <label style="margin-top:16px; display:block;"><strong>Couleur de fond (Dégradé)</strong></label>
-                <div class="ssc-actions">
-                    <span>Haut :</span> <input type="color" id="ssc-tron-bg1" value="#0a0a23">
-                    <span>Bas :</span> <input type="color" id="ssc-tron-bg2" value="#000000">
-                </div>
-
-                <label style="margin-top:16px; display:block;"><strong>Taille de la grille (pixels)</strong></label>
-                <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5">
-                <span id="ssc-tron-size-val">50px</span>
-
-                <label style="margin-top:16px; display:block;"><strong>Épaisseur des lignes (pixels)</strong></label>
-                <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1">
-                <span id="ssc-tron-thickness-val">1px</span>
-
-                <label style="margin-top:16px; display:block;"><strong>Vitesse de l'animation (secondes)</strong></label>
-                <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1">
-                <span id="ssc-tron-speed-val">10s</span>
-                
-                <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                    <button id="ssc-tron-apply" class="button button-primary">Appliquer sur le site</button>
-                    <button id="ssc-tron-copy" class="button">Copier le CSS</button>
-                </div>
-
-                <h3 style="margin-top:24px;">Comment utiliser cet effet ?</h3>
-                <p class="description">
-                    Le bouton <strong>"Appliquer sur le site"</strong> ajoute le code CSS généré à la feuille de style globale de votre site. Vous pouvez ensuite utiliser la classe <code>.ssc-tron-grid-bg</code> sur n'importe quel élément (div, section, etc.) pour lui appliquer ce fond.
-                </p>
-                <p class="description">
-                    <strong>Pour créer plusieurs grilles différentes :</strong>
-                </p>
-                <ol style="padding-left: 20px;" class="description">
-                    <li>Personnalisez votre première grille ici.</li>
-                    <li>Cliquez sur <strong>"Copier CSS"</strong>.</li>
-                    <li>Allez dans le module <strong>"Utilities"</strong> (l'éditeur CSS principal).</li>
-                    <li>Collez le code et renommez la classe principale, par exemple en <code>.ma-grille-bleue</code>.</li>
-                    <li>Revenez ici, créez une autre variation, et répétez l'opération avec un nouveau nom de classe (ex: <code>.ma-grille-rouge</code>).</li>
-                </ol>
-                
-                <pre id="ssc-tron-css" class="ssc-code"></pre>
-            </div>
-            <div class="ssc-pane">
-                <h3>Aperçu en Direct</h3>
-                <div id="ssc-tron-preview" style="height: 300px; border-radius: 12px; border: 1px solid var(--ssc-border); overflow: hidden;">
-                    </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+class TronGrid extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('tron-grid');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/TypographyEditor.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/TypographyEditor.php
@@ -1,39 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class TypographyEditor {
-    public function render(){ ?>
-    <style>
-        #ssc-typo-preview { transition: font-size 0.1s linear; }
-        .ssc-typo-vp-slider-container { width: 100%; background: var(--ssc-bg); padding: 10px; border-radius: 8px; margin-top: 10px; }
-    </style>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>📏 Typographie Fluide (Clamp)</h2>
-        <p>Générez du texte qui s'adapte parfaitement à toutes les tailles d'écran, sans "sauts" disgracieux.</p>
-        <div class="ssc-two" style="align-items: flex-start;">
-            <div class="ssc-pane">
-                <h3>Paramètres de la Police (en pixels)</h3>
-                <div class="ssc-two">
-                    <div><label>Taille min. police</label><input type="number" id="ssc-typo-min-fs" value="16" class="small-text"></div>
-                    <div><label>Taille max. police</label><input type="number" id="ssc-typo-max-fs" value="48" class="small-text"></div>
-                    <div><label>Largeur min. écran</label><input type="number" id="ssc-typo-min-vp" value="375" class="small-text"></div>
-                    <div><label>Largeur max. écran</label><input type="number" id="ssc-typo-max-vp" value="1280" class="small-text"></div>
-                </div>
-                <h3 style="margin-top:16px;">Code CSS Généré</h3>
-                <pre id="ssc-typo-css" class="ssc-code"></pre>
-                <div class="ssc-actions"><button id="ssc-typo-copy" class="button">Copier le CSS</button></div>
-            </div>
-            <div class="ssc-pane">
-                 <h3>Aperçu en Direct</h3>
-                 <p id="ssc-typo-preview">Ce texte grandit et rétrécit de manière fluide.</p>
-                 <div class="ssc-typo-vp-slider-container">
-                    <label>Simuler la largeur de l'écran : <span id="ssc-typo-vp-val">375px</span></label>
-                    <input type="range" id="ssc-typo-vp-slider" min="320" max="1600" value="375" style="width: 100%;">
-                 </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class TypographyEditor extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('typography-editor');
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/Utilities.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/Utilities.php
@@ -1,92 +1,22 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class Utilities {
-    public function render(){ ?>
-    <style>
-        .ssc-editor-tabs { display: flex; border-bottom: 1px solid var(--ssc-border); }
-        .ssc-editor-tab { padding: 8px 16px; cursor: pointer; border-bottom: 2px solid transparent; }
-        .ssc-editor-tab.active { color: var(--ssc-accent); border-bottom-color: var(--ssc-accent); font-weight: 600; }
-        .ssc-editor-panel { display: none; height: 100%; }
-        .ssc-editor-panel.active { display: block; }
-        .ssc-tutorial-content { padding: 16px; }
-        .ssc-tutorial-content code { background: var(--ssc-bg); padding: 2px 6px; border-radius: 4px; }
-        #ssc-picker-overlay { position: absolute; inset: 0; background: rgba(79, 70, 229, 0.2); z-index: 9998; display: none; cursor: crosshair; }
-        #ssc-picker-tooltip { position: fixed; background: #0f172a; color: white; padding: 4px 8px; border-radius: 4px; font-size: 12px; z-index: 9999; white-space: nowrap; display: none; }
-    </style>
-    <div class="ssc-wrap ssc-utilities-wrap">
-        <div class="ssc-editor-layout">
-            <div class="ssc-editor-column">
-                <div class="ssc-editor-header">
-                    <h2><?php echo esc_html__('Éditeur CSS', 'supersede-css-jlg'); ?></h2>
-                    <div class="ssc-actions">
-                        <button id="ssc-save-css" class="button button-primary"><?php echo esc_html__('Enregistrer le CSS', 'supersede-css-jlg'); ?></button>
-                    </div>
-                </div>
-                <div class="ssc-editor-tabs">
-                    <div class="ssc-editor-tab active" data-tab="desktop">🖥️ Desktop</div>
-                    <div class="ssc-editor-tab" data-tab="tablet">📲 Tablette</div>
-                    <div class="ssc-editor-tab" data-tab="mobile">📱 Mobile</div>
-                    <div class="ssc-editor-tab" data-tab="tutorial">💡 Tutoriel @media queries</div>
-                </div>
-                <div class="ssc-editor-container">
-                    <div id="ssc-editor-panel-desktop" class="ssc-editor-panel active"><textarea id="ssc-css-editor-desktop"><?php echo esc_textarea(get_option('ssc_css_desktop', '')); ?></textarea></div>
-                    <div id="ssc-editor-panel-tablet" class="ssc-editor-panel"><textarea id="ssc-css-editor-tablet"><?php echo esc_textarea(get_option('ssc_css_tablet', '')); ?></textarea></div>
-                    <div id="ssc-editor-panel-mobile" class="ssc-editor-panel"><textarea id="ssc-css-editor-mobile"><?php echo esc_textarea(get_option('ssc_css_mobile', '')); ?></textarea></div>
-                    <div id="ssc-editor-panel-tutorial" class="ssc-editor-panel ssc-tutorial-content">
-                        <h3>Le Principe : "Desktop First" Simplifié</h3>
-                        <p>Pensez à votre design comme à la construction d'une maison :</p>
-                        <ol>
-                            <li><strong>L'onglet <code>Desktop</code> est le plan de base de la maison.</strong> C'est ici que vous définissez tous les styles fondamentaux (couleurs, polices, espacements). Ces styles s'appliquent par défaut à <strong>toutes les tailles d'écran</strong>.</li>
-                            <li><strong>L'onglet <code>Tablette</code> est l'aménagement pour les pièces moyennes.</strong> Vous ne redessinez pas tout, vous spécifiez uniquement les changements. Par exemple, réduire la taille d'un titre.</li>
-                            <li><strong>L'onglet <code>Mobile</code> est pour les plus petites pièces.</strong> Vous faites les derniers ajustements pour que tout soit parfait sur un petit écran.</li>
-                        </ol>
-                        <p>En coulisses, le plugin enveloppe automatiquement le code des onglets Tablette et Mobile dans des <strong>@media queries</strong>, vous faisant gagner du temps.</p>
-                        <hr>
-                        <h4>Exemple Concret : Un Titre Adaptatif</h4>
-                        <p><strong>Objectif :</strong> Un titre <code>.mon-titre</code> qui change de taille et d'alignement.</p>
-                        <p><strong>1. Onglet <code>Desktop</code> (la base) :</strong></p>
-                        <pre class="ssc-code">.mon-titre {
-  font-size: 48px;
-  color: blue;
-  font-weight: bold;
-}</pre>
-                        <p><strong>2. Onglet <code>Tablette</code> (premier ajustement) :</strong></p>
-                        <pre class="ssc-code">.mon-titre {
-  font-size: 36px;
-}</pre>
-                        <p><strong>3. Onglet <code>Mobile</code> (ajustement final) :</strong></p>
-                        <pre class="ssc-code">.mon-titre {
-  font-size: 24px;
-  text-align: center;
-}</pre>
-                    </div>
-                </div>
-            </div>
-            <div class="ssc-preview-column">
-                <div class="ssc-preview-header">
-                    <div class="ssc-url-bar">
-                        <input type="url" id="ssc-preview-url" value="<?php echo esc_url(get_home_url()); ?>">
-                        <button class="button" id="ssc-preview-load"><?php echo esc_html__('Load', 'supersede-css-jlg'); ?></button>
-                        <button class="button" id="ssc-element-picker-toggle" title="Cibler un élément">🎯</button>
-                    </div>
-                    <div class="ssc-responsive-toggles">
-                        <button class="button button-primary" data-vp="desktop" title="Desktop">🖥️</button><button class="button" data-vp="tablet" title="Tablet">📲</button><button class="button" data-vp="mobile" title="Mobile">📱</button>
-                    </div>
-                </div>
-                <div class="ssc-preview-frame-container">
-                    <div id="ssc-picker-overlay"></div>
-                    <div id="ssc-picker-tooltip"></div>
-                    <iframe id="ssc-preview-frame" sandbox="allow-same-origin allow-forms allow-scripts"></iframe>
-                </div>
-                <div style="padding-top: 8px;">
-                    <label>Sélecteur Ciblé :</label>
-                    <input type="text" id="ssc-picked-selector" readonly class="large-text" placeholder="Cliquez sur 🎯 puis sur un élément dans l'aperçu.">
-                </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Utilities extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('utilities', [
+            'css_desktop' => get_option('ssc_css_desktop', ''),
+            'css_tablet'  => get_option('ssc_css_tablet', ''),
+            'css_mobile'  => get_option('ssc_css_mobile', ''),
+            'preview_url' => get_home_url(),
+        ]);
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/VisualEffects.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/VisualEffects.php
@@ -1,100 +1,17 @@
 <?php declare(strict_types=1);
+
 namespace SSC\Admin\Pages;
 
-if (!defined('ABSPATH')) { exit; }
+use SSC\Admin\AbstractPage;
 
-class VisualEffects {
-    public function render(){ ?>
-    <style>
-        .ssc-ve-tabs { display: flex; border-bottom: 1px solid var(--ssc-border); margin-bottom: 16px; }
-        .ssc-ve-tab { padding: 10px 16px; cursor: pointer; border-bottom: 2px solid transparent; }
-        .ssc-ve-tab.active { color: var(--ssc-accent); border-bottom-color: var(--ssc-accent); font-weight: 600; }
-        .ssc-ve-panel { display: none; }
-        .ssc-ve-panel.active { display: block; }
-        .ssc-ve-preview-box { height: 300px; border-radius: 12px; border: 1px solid var(--ssc-border); overflow: hidden; position: relative; background: #000; }
-        #ssc-crt-canvas { width: 100%; height: 100%; }
-        .ssc-ecg-path { fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; transition: all 0.3s; }
-        #ssc-ecg-preview-container { position: relative; background: #0b1020; display: grid; place-items: center; }
-        #ssc-ecg-preview-svg { position: absolute; width: 100%; height: auto; }
-        #ssc-ecg-logo-preview { max-width: 100px; max-height: 100px; z-index: 5; }
-        .ssc-grid-three { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; }
-    </style>
-    <div class="ssc-app ssc-fullwidth">
-        <h2>🎬 Générateur d'Effets Visuels</h2>
-        <p>Une collection d'effets visuels avancés pour animer vos fonds, images et conteneurs.</p>
-        <div class="ssc-ve-tabs">
-            <div class="ssc-ve-tab active" data-tab="backgrounds">🌌 Fonds Animés</div>
-            <div class="ssc-ve-tab" data-tab="ecg">❤️ ECG / Battement de Cœur</div>
-            <div class="ssc-ve-tab" data-tab="crt">📺 Effet CRT (Scanline)</div>
-        </div>
+if (!defined('ABSPATH')) {
+    exit;
+}
 
-        <div id="ssc-ve-panel-crt" class="ssc-ve-panel">
-            <div class="ssc-two" style="align-items: flex-start;">
-                <div class="ssc-pane">
-                    <h3>Paramètres de l'effet CRT</h3>
-                    <p class="description">Cet effet est purement décoratif et ne génère pas de CSS à exporter.</p>
-                    <div class="ssc-grid-three">
-                        <div><label>Couleur Scanline</label><input type="color" class="ssc-crt-control" id="scanlineColor" value="#00ff00"></div>
-                        <div><label>Opacité Scanline</label><input type="range" class="ssc-crt-control" id="scanlineOpacity" min="0" max="1" value="0.4" step="0.05"></div>
-                        <div><label>Vitesse Scanline</label><input type="range" class="ssc-crt-control" id="scanlineSpeed" min="0.1" max="2" value="0.5" step="0.1"></div>
-                        <div><label>Intensité Bruit</label><input type="range" class="ssc-crt-control" id="noiseIntensity" min="0" max="0.5" value="0.1" step="0.02"></div>
-                        <div><label>Aberration Chromatique</label><input type="range" class="ssc-crt-control" id="chromaticAberration" min="0" max="5" value="1" step="0.5"></div>
-                    </div>
-                </div>
-                <div class="ssc-pane">
-                    <h3>Aperçu</h3>
-                    <div class="ssc-ve-preview-box"><canvas id="ssc-crt-canvas"></canvas></div>
-                </div>
-            </div>
-        </div>
-
-        <div id="ssc-ve-panel-ecg" class="ssc-ve-panel">
-             <div class="ssc-two" style="align-items: flex-start;">
-                <div class="ssc-pane">
-                    <h3>Paramètres de l'ECG</h3>
-                    <label><strong>Preset de Rythme</strong></label>
-                    <select id="ssc-ecg-preset" class="regular-text"><option value="stable">Stable</option><option value="fast">Rapide</option><option value="critical">Critique</option></select>
-                    <label style="margin-top:16px;"><strong>Couleur de la ligne</strong></label>
-                    <input type="color" id="ssc-ecg-color" value="#00ff00">
-                    <label style="margin-top:16px;"><strong>Positionnement (top)</strong></label>
-                    <input type="range" id="ssc-ecg-top" min="0" max="100" value="50" step="1"><span id="ssc-ecg-top-val">50%</span>
-                    <label style="margin-top:16px;"><strong>Superposition (z-index)</strong></label>
-                    <input type="range" id="ssc-ecg-z-index" min="-10" max="10" value="1" step="1"><span id="ssc-ecg-z-index-val">1</span>
-                    <hr>
-                    <label><strong>Logo/Image au centre</strong></label>
-                    <button id="ssc-ecg-upload-btn" class="button">Choisir une image</button>
-                    <label style="margin-top:16px;"><strong>Taille du logo</strong></label>
-                    <input type="range" id="ssc-ecg-logo-size" min="20" max="200" value="100" step="1"><span id="ssc-ecg-logo-size-val">100px</span>
-                    <hr>
-                    <pre id="ssc-ecg-css" class="ssc-code ssc-code-small" style="margin-top:16px;"></pre>
-                    <button id="ssc-ecg-apply" class="button button-primary" style="margin-top:8px;">Appliquer l'Effet</button>
-                </div>
-                <div class="ssc-pane">
-                    <h3>Aperçu</h3>
-                    <div id="ssc-ecg-preview-container" class="ssc-ve-preview-box">
-                        <img id="ssc-ecg-logo-preview" src="" alt="Logo Preview" style="display:none;">
-                        <svg id="ssc-ecg-preview-svg" viewBox="0 0 400 60" preserveAspectRatio="none"><path id="ssc-ecg-preview-path" class="ssc-ecg-path" d="M0,30 L100,30 L110,18 L120,42 L130,26 L140,30 L240,30 L250,20 L260,40 L270,28 L280,30 L400,30"/></svg>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div id="ssc-ve-panel-backgrounds" class="ssc-ve-panel">
-             <div class="ssc-two" style="align-items: flex-start;">
-                <div class="ssc-pane">
-                    <h3>Paramètres du Fond</h3>
-                    <select id="ssc-bg-type" class="regular-text"><option value="stars">Étoiles</option><option value="gradient">Dégradé</option></select>
-                    <div id="ssc-bg-controls-stars"><label>Couleur</label><input type="color" id="starColor" value="#FFFFFF"><label>Nombre</label><input type="range" id="starCount" min="50" max="500" value="200" step="10"></div>
-                    <div id="ssc-bg-controls-gradient" style="display:none;"><label>Vitesse</label><input type="range" id="gradientSpeed" min="2" max="20" value="10" step="1"></div>
-                     <pre id="ssc-bg-css" class="ssc-code"></pre>
-                    <button id="ssc-bg-apply" class="button button-primary">Appliquer</button>
-                </div>
-                <div class="ssc-pane">
-                    <h3>Aperçu</h3>
-                    <div id="ssc-bg-preview" class="ssc-ve-preview-box"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <?php }
+class VisualEffects extends AbstractPage
+{
+    public function render(): void
+    {
+        $this->render_view('visual-effects');
+    }
 }

--- a/supersede-css-jlg-enhanced/views/animation-studio.php
+++ b/supersede-css-jlg-enhanced/views/animation-studio.php
@@ -1,0 +1,37 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>🎬 Animation Studio</h2>
+    <p>Choisissez un preset d'animation, personnalisez-le et appliquez-le à vos éléments.</p>
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Paramètres de l'Animation</h3>
+            <label><strong>Preset d'animation</strong></label>
+            <select id="ssc-anim-preset" class="regular-text">
+                <option value="bounce">Bounce (Rebond)</option>
+                <option value="pulse">Pulse (Pulsation)</option>
+                <option value="fade-in">Fade In (Apparition)</option>
+                <option value="slide-in-left">Slide In Left (Glisse depuis la gauche)</option>
+            </select>
+            <label style="margin-top:16px; display:block;"><strong>Durée (secondes)</strong></label>
+            <input type="range" id="ssc-anim-duration" min="0.1" max="5" value="1.5" step="0.1">
+            <span id="ssc-anim-duration-val">1.5s</span>
+            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+                <button id="ssc-anim-apply" class="button button-primary">Appliquer</button>
+                <button id="ssc-anim-copy" class="button">Copier CSS</button>
+            </div>
+            <h3 style="margin-top:24px;">Code CSS Généré</h3>
+            <p class="description">Appliquez la classe <code>.ssc-animated</code> et la classe du preset (ex: <code>.ssc-bounce</code>) à votre élément.</p>
+            <pre id="ssc-anim-css" class="ssc-code"></pre>
+        </div>
+        <div class="ssc-pane">
+            <h3>Aperçu en Direct</h3>
+            <div id="ssc-anim-preview-container" style="display:grid; place-items:center; height:200px;">
+                <div id="ssc-anim-preview-box" style="width: 100px; height: 100px; background: var(--ssc-accent); border-radius: 12px;"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/avatar-glow.php
+++ b/supersede-css-jlg-enhanced/views/avatar-glow.php
@@ -1,0 +1,64 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $avatar_placeholder */
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>✨ Gestionnaire de Presets Avatar Glow</h2>
+    <p>Créez et gérez des effets d'aura réutilisables pour vos rédacteurs. Chaque preset aura son propre nom de classe.</p>
+
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Éditeur de Presets</h3>
+            <label><strong>Preset Actif</strong></label>
+            <div class="ssc-actions">
+                <select id="ssc-glow-preset-select" class="regular-text" style="flex: 1;"></select>
+                <button id="ssc-glow-new-preset" class="button">Nouveau</button>
+            </div>
+
+            <div id="ssc-glow-editor-fields">
+                <hr>
+                <div class="ssc-two">
+                    <div><label><strong>Nom du Preset</strong></label><input type="text" id="ssc-glow-preset-name" class="regular-text" placeholder="Aura Bleue Rapide"></div>
+                    <div><label><strong>Nom de la Classe CSS</strong></label><input type="text" id="ssc-glow-preset-class" class="regular-text" placeholder=".avatar-glow-blue"></div>
+                </div>
+                <p class="description">Le nom de la classe doit être unique et commencer par un point (ex: <code>.glow-team-1</code>).</p>
+                <hr>
+
+                <h4>Paramètres de l'Effet</h4>
+                <label><strong>Couleur du dégradé</strong></label>
+                <div class="ssc-actions">
+                    <span>Début :</span> <input type="color" id="ssc-glow-color1" value="#8b5cf6">
+                    <span>Fin :</span> <input type="color" id="ssc-glow-color2" value="#ec4899">
+                </div>
+                <label style="margin-top:16px;"><strong>Vitesse (secondes)</strong></label>
+                <input type="range" id="ssc-glow-speed" min="1" max="20" value="5" step="0.5">
+                <span id="ssc-glow-speed-val">5s</span>
+                <label style="margin-top:16px;"><strong>Épaisseur (pixels)</strong></label>
+                <input type="range" id="ssc-glow-thickness" min="2" max="12" value="4" step="1">
+                <span id="ssc-glow-thickness-val">4px</span>
+            </div>
+
+            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+                <button id="ssc-glow-save-preset" class="button button-primary">Enregistrer ce Preset</button>
+                <button id="ssc-glow-apply" class="button">Appliquer sur le site</button>
+                <button id="ssc-glow-delete-preset" class="button button-link-delete" style="display: none;">Supprimer ce Preset</button>
+            </div>
+        </div>
+
+        <div class="ssc-pane">
+            <h3>Aperçu en Direct</h3>
+            <div id="ssc-glow-preview-bg" style="display:grid; place-items:center; height:250px; background: #0b1020; border-radius: 12px; transition: background 0.3s; border: 1px solid var(--ssc-border);">
+                <div id="ssc-glow-preview-container" style="width: 128px; height: 128px;">
+                    <img id="ssc-glow-preview-img" src="<?php echo esc_url($avatar_placeholder); ?>" alt="avatar" style="width:100%; height:100%; border-radius:50%; object-fit:cover;">
+                </div>
+            </div>
+            <button id="ssc-glow-upload-btn" class="button" style="margin-top:16px;">Changer l'image d'avatar</button>
+
+             <h4 style="margin-top:16px;">Comment l'utiliser ?</h4>
+             <p class="description">Une fois le preset enregistré et appliqué, demandez à vos rédacteurs d'ajouter la classe <code id="ssc-glow-how-to-use-class">.avatar-glow-blue</code> au conteneur (la `div`) de leur image.</p>
+             <pre id="ssc-glow-css-output" class="ssc-code"></pre>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/clip-path-editor.php
+++ b/supersede-css-jlg-enhanced/views/clip-path-editor.php
@@ -1,0 +1,52 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $preview_background */
+?>
+<style>
+    #ssc-clip-preview-wrapper {
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        background: var(--ssc-bg);
+        border-radius: 8px;
+    }
+    #ssc-clip-preview {
+        background-image: url('<?php echo esc_url($preview_background); ?>');
+        background-size: cover;
+        background-position: center;
+        height: 300px;
+        width: 300px;
+        transition: all 0.3s ease;
+    }
+</style>
+<div class="ssc-app ssc-fullwidth">
+    <h2>✂️ Générateur de Formes (Clip-Path)</h2>
+    <p>Découpez vos conteneurs et images dans des formes géométriques pour des designs plus dynamiques.</p>
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Formes Prédéfinies</h3>
+            <select id="ssc-clip-preset">
+                <option value="none">Aucune (Rectangle)</option>
+                <option value="circle(50% at 50% 50%)">Cercle</option>
+                <option value="ellipse(50% 30% at 50% 50%)">Ellipse</option>
+                <option value="polygon(50% 0%, 0% 100%, 100% 100%)">Triangle</option>
+                <option value="polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)">Hexagone</option>
+                <option value="polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)">Étoile</option>
+                <option value="polygon(0 15%, 15% 15%, 15% 0, 85% 0, 85% 15%, 100% 15%, 100% 85%, 85% 85%, 85% 100%, 15% 100%, 15% 85%, 0 85%)">Croix</option>
+            </select>
+            <label style="margin-top:16px; display:block;"><strong>Taille de l'aperçu: <span id="ssc-clip-size-val">300px</span></strong></label>
+            <input type="range" id="ssc-clip-preview-size" min="100" max="500" value="300" step="10" style="width:100%;">
+            <h3 style="margin-top:16px;">Code CSS Généré</h3>
+            <pre id="ssc-clip-css" class="ssc-code"></pre>
+            <div class="ssc-actions"><button id="ssc-clip-copy" class="button">Copier le CSS</button></div>
+        </div>
+        <div class="ssc-pane">
+             <h3>Aperçu</h3>
+             <div id="ssc-clip-preview-wrapper">
+                <div id="ssc-clip-preview"></div>
+             </div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/css-viewer.php
+++ b/supersede-css-jlg-enhanced/views/css-viewer.php
@@ -1,0 +1,23 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $active_css */
+/** @var string $tokens_css */
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>🔍 Visualiseur de CSS Actif</h2>
+    <p>Ce module affiche le contenu brut des options CSS de Supersede telles qu'elles sont enregistrées dans votre base de données. C'est un outil de débogage utile pour voir le code final appliqué à votre site.</p>
+
+    <div class="ssc-panel" style="margin-top: 16px;">
+        <h3>Contenu de : <code>ssc_active_css</code></h3>
+        <p class="description">C'est la feuille de style principale où la plupart des modules (Utilities, effets visuels, etc.) enregistrent leur code.</p>
+        <textarea readonly class="large-text code" rows="15" style="background: #f0f0f0; color: #333; font-family: monospace; width: 100%;"><?php echo esc_textarea($active_css); ?></textarea>
+    </div>
+
+    <div class="ssc-panel" style="margin-top: 16px;">
+        <h3>Contenu de : <code>ssc_tokens_css</code></h3>
+        <p class="description">Cette option contient les variables CSS (Tokens) que vous avez définies dans le "Tokens Manager".</p>
+        <textarea readonly class="large-text code" rows="10" style="background: #f0f0f0; color: #333; font-family: monospace; width: 100%;"><?php echo esc_textarea($tokens_css); ?></textarea>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/dashboard.php
+++ b/supersede-css-jlg-enhanced/views/dashboard.php
@@ -1,0 +1,43 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var array{utilities?:string,tokens?:string,avatar?:string,debug_center?:string} $quick_links */
+?>
+<div class="ssc-wrap wrap">
+    <h1><?php echo esc_html__('Supersede CSS — Dashboard', 'supersede-css-jlg'); ?></h1>
+    <p class="description"><?php echo esc_html__('Bienvenue ! Utilisez le menu ou la palette de commande (⌘/Ctrl + K) pour naviguer.', 'supersede-css-jlg'); ?></p>
+
+    <div class="ssc-panel" style="margin-top: 24px;">
+        <h2><?php echo esc_html__('Accès Rapide', 'supersede-css-jlg'); ?></h2>
+        <p>
+            <a class="button button-primary" href="<?php echo esc_url($quick_links['utilities'] ?? '#'); ?>">Éditeur CSS</a>
+            <a class="button" href="<?php echo esc_url($quick_links['tokens'] ?? '#'); ?>">Tokens Manager</a>
+            <a class="button" href="<?php echo esc_url($quick_links['avatar'] ?? '#'); ?>">Avatar Glow</a>
+            <a class="button" href="<?php echo esc_url($quick_links['debug_center'] ?? '#'); ?>">Centre de Débogage</a>
+        </p>
+    </div>
+
+    <div class="ssc-panel" style="margin-top: 24px;">
+        <h2>💡 Comprendre le Workflow (Créer et Activer un Style)</h2>
+        <p>Pour utiliser efficacement les modules créatifs comme <strong>Avatar Glow</strong> ou <strong>Preset Designer</strong>, suivez ces 3 étapes logiques :</p>
+        <ol style="list-style-type: decimal; margin-left: 20px;">
+            <li style="margin-bottom: 15px;">
+                <strong>ÉTAPE 1 : CRÉER ET ENREGISTRER</strong><br>
+                Allez dans un module (ex: Avatar Glow). Personnalisez votre effet (couleurs, vitesse...). Donnez-lui un nom et une classe CSS unique (ex: <code>.aura-speciale</code>), puis cliquez sur <strong>"Enregistrer le Preset"</strong>.<br>
+                <em>➡️ <strong>Résultat :</strong> La "recette" de votre effet est sauvegardée dans la bibliothèque du plugin. Elle n'est pas encore visible sur le site.</em>
+            </li>
+            <li style="margin-bottom: 15px;">
+                <strong>ÉTAPE 2 : APPLIQUER (Activer)</strong><br>
+                Avec votre preset fraîchement enregistré toujours sélectionné, cliquez sur <strong>"Appliquer sur le site"</strong>.<br>
+                <em>➡️ <strong>Résultat :</strong> Le code CSS de votre effet est ajouté à la feuille de style globale de votre site. L'effet est maintenant "disponible" et prêt à être utilisé.</em>
+            </li>
+            <li style="margin-bottom: 15px;">
+                <strong>ÉTAPE 3 : UTILISER</strong><br>
+                Vos rédacteurs peuvent maintenant aller dans l'éditeur de page ou d'article, sélectionner le conteneur d'une image et lui ajouter la classe CSS que vous avez définie (<code>aura-speciale</code>) dans les réglages avancés du bloc.<br>
+                <em>➡️ <strong>Résultat :</strong> L'effet d'aura apparaît sur l'image sur le site public !</em>
+            </li>
+        </ol>
+        <p>En résumé : <strong>On enregistre</strong> un preset pour le sauvegarder pour le futur, et <strong>on l'applique</strong> pour le rendre utilisable dès maintenant.</p>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/debug-center.php
+++ b/supersede-css-jlg-enhanced/views/debug-center.php
@@ -1,0 +1,60 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var array{plugin_version?:string,wordpress_version?:string,php_version?:string} $system_info */
+/** @var array<int,array<string,mixed>> $log_entries */
+$plugin_version    = $system_info['plugin_version'] ?? 'N/A';
+$wordpress_version = $system_info['wordpress_version'] ?? '';
+$php_version       = $system_info['php_version'] ?? '';
+?>
+<div class="ssc-wrap ssc-debug-center">
+    <h1><?php echo esc_html__('Supersede CSS — Debug Center', 'supersede-css-jlg'); ?></h1>
+    <p><?php echo esc_html__('Un hub centralisé pour la santé du système, la gestion des modules et le journal d\'activité.', 'supersede-css-jlg'); ?></p>
+
+    <div class="ssc-two" style="align-items: flex-start; margin-top: 16px;">
+        <div class="ssc-pane">
+            <h2><?php echo esc_html__('Informations Système', 'supersede-css-jlg'); ?></h2>
+            <table class="widefat striped" style="margin: 0;"><tbody>
+                <tr><td><strong>Version du Plugin</strong></td><td><?php echo esc_html($plugin_version); ?></td></tr>
+                <tr><td><strong>Version WordPress</strong></td><td><?php echo esc_html($wordpress_version); ?></td></tr>
+                <tr><td><strong>Version PHP</strong></td><td><?php echo esc_html($php_version); ?></td></tr>
+            </tbody></table>
+        </div>
+        <div class="ssc-pane">
+            <h2><?php echo esc_html__('Actions Globales', 'supersede-css-jlg'); ?></h2>
+            <div class="ssc-actions">
+                <button class="button button-primary" id="ssc-health-run">Lancer Health Check</button>
+            </div>
+            <pre id="ssc-health-json" class="ssc-code" style="max-height:120px; margin-top:10px;"></pre>
+        </div>
+    </div>
+
+    <div class="ssc-panel ssc-danger-zone" style="margin-top: 16px;">
+         <h2>🛑 Zone de Danger</h2>
+         <p id="ssc-danger-intro">Les actions ci-dessous sont irréversibles. Soyez certain de vouloir continuer.</p>
+         <button id="ssc-reset-all-css" class="button" style="background: #dc2626; border-color: #991b1b; color: white;">Réinitialiser tout le CSS</button>
+         <p id="ssc-danger-desc" class="description">Cette action videra les options <code>ssc_active_css</code> et <code>ssc_tokens_css</code> de votre base de données, désactivant tous les styles ajoutés par Supersede.</p>
+    </div>
+
+    <div class="ssc-panel" style="margin-top: 16px;">
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+            <h2><?php echo esc_html__('Journal d\'Activité Récent', 'supersede-css-jlg'); ?></h2>
+            <button id="ssc-clear-log" class="button button-link-delete">Vider le journal</button>
+        </div>
+        <?php if (!empty($log_entries)) : ?>
+            <table class="widefat striped"><thead><tr><th>Date (UTC)</th><th>Utilisateur</th><th>Action</th><th>Données</th></tr></thead><tbody>
+                <?php foreach ($log_entries as $row) : ?>
+                    <tr>
+                        <td><?php echo esc_html($row['t'] ?? ''); ?></td>
+                        <td><?php echo esc_html($row['user'] ?? ''); ?></td>
+                        <td><strong><?php echo esc_html($row['action'] ?? ''); ?></strong></td>
+                        <td><code><?php echo esc_html(json_encode($row['data'] ?? [])); ?></code></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody></table>
+        <?php else : ?>
+            <p>Aucune entrée dans le journal.</p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/filter-editor.php
+++ b/supersede-css-jlg-enhanced/views/filter-editor.php
@@ -1,0 +1,66 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $preview_background */
+?>
+<style>
+    #ssc-filter-preview-bg {
+        background-image: url('<?php echo esc_url($preview_background); ?>');
+        background-size: cover;
+        border-radius: 12px;
+        padding: 24px;
+        display: grid;
+        place-items: center;
+    }
+    #ssc-filter-preview-box {
+        transition: all 0.2s ease-in-out;
+        width: 80%;
+        height: 250px;
+        color: white;
+        font-size: 24px;
+        font-weight: bold;
+        text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+        display: grid;
+        place-items: center;
+        border-radius: 16px;
+    }
+    .ssc-glassmorphism-preview {
+        background: rgba(255, 255, 255, 0.2);
+        box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+        backdrop-filter: blur(5px);
+        -webkit-backdrop-filter: blur(5px);
+        border: 1px solid rgba(255, 255, 255, 0.3);
+    }
+</style>
+<div class="ssc-app ssc-fullwidth">
+    <h2>🎨 Éditeur de Filtres & Effets de Verre</h2>
+    <p>Appliquez des filtres visuels à vos images et conteneurs, ou créez un effet "Glassmorphism" tendance.</p>
+
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Filtres CSS (<code>filter</code>)</h3>
+            <div class="ssc-two">
+                <div><label>Flou (Blur)</label><input type="range" class="ssc-filter-prop" data-prop="blur" min="0" max="20" value="0" step="1"> <span id="val-blur">0px</span></div>
+                <div><label>Luminosité</label><input type="range" class="ssc-filter-prop" data-prop="brightness" min="0" max="200" value="100" step="5"> <span id="val-brightness">100%</span></div>
+                <div><label>Contraste</label><input type="range" class="ssc-filter-prop" data-prop="contrast" min="0" max="200" value="100" step="5"> <span id="val-contrast">100%</span></div>
+                <div><label>Niveaux de gris</label><input type="range" class="ssc-filter-prop" data-prop="grayscale" min="0" max="100" value="0" step="5"> <span id="val-grayscale">0%</span></div>
+                <div><label>Rotation de teinte</label><input type="range" class="ssc-filter-prop" data-prop="hue-rotate" min="0" max="360" value="0" step="15"> <span id="val-hue-rotate">0deg</span></div>
+                <div><label>Saturation</label><input type="range" class="ssc-filter-prop" data-prop="saturate" min="0" max="200" value="100" step="5"> <span id="val-saturate">100%</span></div>
+            </div>
+            <hr>
+            <h3>Effet Verre (<code>backdrop-filter</code>)</h3>
+            <label><input type="checkbox" id="ssc-glass-enable"> <strong>Activer le Glassmorphism</strong></label>
+            <pre id="ssc-filter-css" class="ssc-code" style="margin-top:16px;"></pre>
+            <div class="ssc-actions"><button id="ssc-filter-copy" class="button">Copier le CSS</button></div>
+        </div>
+        <div class="ssc-pane">
+            <h3>Aperçu en Direct</h3>
+            <div id="ssc-filter-preview-bg">
+                <div id="ssc-filter-preview-box">
+                    Votre Contenu Ici
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/gradient-editor.php
+++ b/supersede-css-jlg-enhanced/views/gradient-editor.php
@@ -1,0 +1,17 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth"><h2>Visual Gradient Editor</h2><div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <div class="ssc-grad-controls">
+                <div class="ssc-control-group"><label>Type</label><select id="ssc-grad-type"><option value="linear-gradient">Linéaire</option><option value="radial-gradient">Radial</option><option value="conic-gradient">Conique</option></select></div>
+                <div id="ssc-grad-angle-control" class="ssc-control-group"><label>Angle</label><input type="range" id="ssc-grad-angle" min="0" max="360" value="90" step="1"><input type="number" id="ssc-grad-angle-num" min="0" max="360" value="90" class="small-text"> deg</div>
+            </div>
+            <div class="ssc-control-group"><label>Color Stops</label><div id="ssc-grad-stops-preview" class="ssc-grad-preview-bar"></div><div id="ssc-grad-stops-ui"></div></div>
+            <div class="ssc-actions"><button id="ssc-grad-apply" class="button button-primary">Appliquer</button><button id="ssc-grad-copy" class="button">Copier CSS</button></div>
+            <pre id="ssc-grad-css" class="ssc-code"></pre>
+        </div>
+        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-grad-preview" style="height:200px;border-radius:12px;border:1px solid var(--ssc-border);"></div></div>
+    </div></div>

--- a/supersede-css-jlg-enhanced/views/grid-editor.php
+++ b/supersede-css-jlg-enhanced/views/grid-editor.php
@@ -1,0 +1,37 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>📏 Visual Grid Editor</h2>
+    <p>Construisez des mises en page CSS Grid de manière intuitive, sans écrire de code.</p>
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Paramètres de la Grille</h3>
+
+            <label><strong>Nombre de colonnes</strong></label>
+            <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
+            <span id="ssc-grid-cols-val">3</span>
+
+            <label style="margin-top:16px; display:block;"><strong>Espacement (gap) en pixels</strong></label>
+            <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
+            <span id="ssc-grid-gap-val">16px</span>
+
+            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+                <button id="ssc-grid-apply" class="button button-primary">Appliquer</button>
+                <button id="ssc-grid-copy" class="button">Copier CSS</button>
+            </div>
+
+            <h3 style="margin-top:24px;">Code CSS Généré</h3>
+            <p class="description">Appliquez la classe <code>.ssc-grid-container</code> à votre conteneur.</p>
+            <pre id="ssc-grid-css" class="ssc-code"></pre>
+        </div>
+        <div class="ssc-pane">
+            <h3>Aperçu en Direct</h3>
+            <div id="ssc-grid-preview" style="display:grid; border:1px dashed var(--ssc-border); padding:10px; border-radius:8px;">
+                <!-- Les éléments de la grille seront générés par JS -->
+            </div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/import-export.php
+++ b/supersede-css-jlg-enhanced/views/import-export.php
@@ -1,0 +1,31 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>Import / Export</h2>
+    <div class="ssc-panel" style="margin-bottom: 16px;">
+        <h3>Sauvegardez et restaurez votre configuration</h3>
+        <ul>
+            <li><strong>Exporter Config (.json) :</strong> Télécharge un fichier JSON contenant <strong>toutes</strong> vos configurations Supersede CSS (presets, tokens, etc.). Idéal pour sauvegarder votre travail ou le migrer vers un autre site.</li>
+            <li><strong>Exporter CSS (.css) :</strong> Télécharge uniquement le code CSS final qui est appliqué sur votre site. Utile pour une utilisation externe ou une simple sauvegarde du style.</li>
+            <li><strong>Importer (.json) :</strong> Restaure une configuration complète depuis un fichier JSON que vous avez précédemment exporté. <strong>Attention :</strong> cela remplacera vos configurations actuelles.</li>
+        </ul>
+    </div>
+    <div class="ssc-two">
+        <div class="ssc-pane">
+            <h3>Exporter</h3><p>Téléchargez vos configurations ou uniquement le CSS actif.</p>
+            <div class="ssc-actions">
+                <button id="ssc-export-config" class="button button-primary">Exporter Config (.json)</button>
+                <button id="ssc-export-css" class="button">Exporter CSS (.css)</button>
+            </div>
+        </div>
+        <div class="ssc-pane">
+            <h3>Importer</h3><p>Importez un fichier de configuration (.json).</p>
+            <input type="file" id="ssc-import-file" accept=".json">
+            <button id="ssc-import-btn" class="button">Importer</button>
+            <div id="ssc-import-msg" class="ssc-muted"></div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/page-layout-builder.php
+++ b/supersede-css-jlg-enhanced/views/page-layout-builder.php
@@ -1,0 +1,97 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $tokens_page_url */
+?>
+<style>
+    .ssc-layout-grid { display: grid; height: 400px; border: 2px dashed var(--ssc-accent); padding: 10px; border-radius: 8px; background: var(--ssc-bg); }
+    .ssc-layout-block { background: var(--ssc-card); border: 1px solid var(--ssc-border); border-radius: 4px; display: grid; place-items: center; font-weight: bold; }
+    .ssc-layout-preview-mobile { width: 375px; margin-left: auto; margin-right: auto; }
+    .ssc-tutorial-panel h4 { margin-top: 1.2em; margin-bottom: 0.5em; }
+    .ssc-tutorial-panel ul, .ssc-tutorial-panel ol { margin-left: 20px; }
+</style>
+<div class="ssc-app ssc-fullwidth">
+    <h2>📐 Maquettage de Page (CSS Grid)</h2>
+    <p>Préparez des mises en page complexes pour vos thèmes ou des sections spécifiques de vos pages.</p>
+
+    <div class="ssc-panel ssc-tutorial-panel" style="margin-bottom:16px;">
+        <h3>💡 Tutoriel : Comment Utiliser le Maquettage de Page dans WordPress</h3>
+        <p>Cet outil génère le "plan" CSS de votre mise en page. Pour l'utiliser, vous devez ensuite construire la structure HTML correspondante dans votre page WordPress.</p>
+
+        <h4>Étape 1 : Générer et Appliquer le CSS</h4>
+        <ol>
+            <li>Choisissez un "Modèle de layout" dans le menu déroulant ci-dessous. Le code CSS est généré instantanément.</li>
+            <li>Copiez l'intégralité de ce code.</li>
+            <li>Allez dans le menu <strong>Supersede CSS → Utilities</strong>, collez le code dans l'éditeur (onglet Desktop) et cliquez sur <strong>"Save CSS"</strong>.</li>
+        </ol>
+
+        <h4>Étape 2 : Créer la Structure HTML avec l'Éditeur de Blocs</h4>
+        <ol>
+            <li>Modifiez la page ou l'article où vous souhaitez appliquer cette mise en page.</li>
+            <li>Ajoutez un bloc <strong>Groupe</strong>. Ce sera votre conteneur principal.</li>
+            <li>Sélectionnez ce bloc Groupe, allez dans le panneau des réglages à droite, section <strong>"Avancé"</strong>.</li>
+            <li>Dans le champ "Classe(s) CSS additionnelle(s)", collez la classe principale du layout (par exemple, <code>ssc-layout-holy-grail</code>).</li>
+            <li>À l'intérieur de ce groupe principal, ajoutez un bloc (un "Groupe" est idéal) pour chaque zone définie dans le CSS (par exemple, 5 blocs pour le "Saint Graal").</li>
+            <li>Pour chaque bloc intérieur, assignez la classe CSS de sa zone dans ses réglages "Avancé" (<code>header</code>, <code>content</code>, <code>footer</code>, etc.).</li>
+            <li>Vous pouvez maintenant remplir ces blocs de zone avec votre contenu (textes, images, titres...).</li>
+        </ol>
+        <p>Votre mise en page est prête ! Elle s'adaptera automatiquement sur les écrans plus petits.</p>
+    </div>
+
+
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Paramètres & Code</h3>
+            <label><strong>Modèle de layout</strong></label>
+            <select id="layout-preset">
+                <option value="holy-grail">Saint Graal (Header, 3 colonnes, Footer)</option>
+                <option value="sidebar-right">Contenu + Sidebar à Droite</option>
+                <option value="hero-features">Section Héro + 3 Cartes</option>
+                <option value="dashboard">Tableau de Bord Asymétrique</option>
+            </select>
+            <hr>
+            <label><strong>Vue :</strong></label>
+            <div class="ssc-actions">
+                <button class="button button-primary" id="view-desktop">Desktop</button>
+                <button class="button" id="view-mobile">Mobile</button>
+            </div>
+            <h3 style="margin-top:24px;">Code CSS Généré</h3>
+            <pre id="layout-css" class="ssc-code"></pre>
+        </div>
+        <div class="ssc-pane">
+            <h3>Aperçu Visuel</h3>
+            <div id="layout-preview-container">
+                <div id="layout-grid-desktop" class="ssc-layout-grid"></div>
+                <div id="layout-grid-mobile" class="ssc-layout-grid ssc-layout-preview-mobile" style="display:none;"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="ssc-panel ssc-tutorial-panel" style="margin-top:16px;">
+        <h3>🚀 Idées d'Amélioration & Inspiration</h3>
+        <h4>Ajouter de l'Espacement (Gap)</h4>
+        <p>Par défaut, les blocs sont collés. Pour ajouter un espacement uniforme entre toutes les zones, modifiez la classe principale dans votre CSS et ajoutez la propriété <code>gap</code> :</p>
+        <pre class="ssc-code">.ssc-layout-holy-grail {
+  display: grid;
+  gap: 1rem; /* ou 16px, 2em, etc. */
+  /* ... autres propriétés ... */
+}</pre>
+
+        <h4>Layouts pour des Sections de Page</h4>
+        <p>N'hésitez pas à utiliser ces layouts non pas pour une page entière, mais pour une section spécifique. Le modèle "Héro + 3 Cartes" est parfait pour une section "Nos services" sur votre page d'accueil.</p>
+
+        <h4>Combiner avec les Tokens</h4>
+        <p>Pour une maintenance facile, définissez vos espacements ou tailles de colonnes avec des <a href="<?php echo esc_url($tokens_page_url); ?>">Tokens</a>. Par exemple :</p>
+        <pre class="ssc-code">:root { --spacing-medium: 1.5rem; }
+
+.ssc-layout-sidebar-right {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: var(--spacing-medium);
+}</pre>
+
+        <h4>Créer vos propres modèles</h4>
+        <p>Utilisez les modèles générés comme base. En modifiant les valeurs de <code>grid-template-areas</code> et <code>grid-template-columns</code>, vous pouvez inventer n'importe quelle mise en page imaginable !</p>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/preset-designer.php
+++ b/supersede-css-jlg-enhanced/views/preset-designer.php
@@ -1,0 +1,37 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>Preset Designer</h2>
+    <div class="ssc-panel" style="margin-bottom: 16px;">
+        <h3>Comment utiliser les Presets ?</h3>
+        <p>Les presets sont des ensembles de styles réutilisables que vous pouvez créer une fois et appliquer à n'importe quel élément de votre site.</p>
+        <ol style="margin-left: 20px;">
+            <li><strong>Créer un Preset :</strong> Dans l'éditeur ci-dessous, donnez un nom (ex: "Bouton Principal Rouge"), un sélecteur CSS (<code>.btn-red</code>) et ajoutez les propriétés CSS (<code>background-color</code>, <code>color</code>, etc.).</li>
+            <li><strong>Enregistrer :</strong> Cliquez sur "Enregistrer". Votre preset apparaît maintenant dans la liste des "Presets Existants".</li>
+            <li><strong>Appliquer un Preset :</strong> Utilisez la section "Quick Apply" en haut. Cherchez votre preset, sélectionnez-le et cliquez sur "Appliquer". Le CSS du preset sera ajouté à votre feuille de style globale.</li>
+        </ol>
+    </div>
+
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane" style="flex: 1.5;"><h3>Quick Apply</h3><div class="ssc-actions"><input type="search" id="ssc-qa-search" class="regular-text" placeholder="Rechercher..."><select id="ssc-qa-select" class="regular-text"></select><button id="ssc-qa-apply" class="button button-primary">Appliquer</button></div></div>
+        <div class="ssc-pane" style="flex: 1;"><h3>Presets Existants</h3><ul id="ssc-presets-list" class="ssc-list"></ul></div>
+    </div>
+    <div class="ssc-panel" style="margin-top: 16px;">
+        <h3>Créer / Modifier un Preset</h3>
+        <div class="ssc-two">
+            <div><label><strong>Nom</strong></label><input type="text" id="ssc-preset-name" class="regular-text" placeholder="ex: Bouton arrondi"></div>
+            <div><label><strong>Sélecteur CSS</strong></label><input type="text" id="ssc-preset-scope" class="regular-text" placeholder=".btn:hover"></div>
+        </div>
+        <label style="margin-top: 12px; display: block;"><strong>Propriétés CSS</strong></label>
+        <div id="ssc-preset-props-builder" class="ssc-kv-builder"></div>
+        <button type="button" id="ssc-preset-add-prop" class="button" style="margin-top:8px;">+ Ajouter</button>
+        <div class="ssc-actions" style="margin-top:16px; border-top: 1px solid #eee; padding-top: 16px;">
+            <button id="ssc-save-preset" class="button button-primary">Enregistrer</button>
+            <button id="ssc-delete-preset" class="button button-link-delete" style="display:none;">Supprimer</button>
+        </div>
+        <div id="ssc-preset-msg" class="ssc-muted"></div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/scope-builder.php
+++ b/supersede-css-jlg-enhanced/views/scope-builder.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>Scope Builder</h2>
+
+    <div class="ssc-panel" style="margin-bottom: 16px;">
+        <h3>Comment utiliser le Scope Builder ?</h3>
+        <p>Cet outil vous permet d'appliquer rapidement des styles CSS à des éléments très spécifiques de votre site sans avoir à naviguer dans l'éditeur principal.</p>
+        <ol style="margin-left: 20px;">
+            <li><strong>Sélecteur(s) :</strong> C'est la cible de votre style. Entrez une classe (<code>.mon-bouton</code>), un ID (<code>#logo</code>) ou une combinaison plus complexe (<code>.card > a</code>).</li>
+            <li><strong>Pseudo-classe :</strong> (Optionnel) Choisissez un état pour appliquer le style, comme lorsque l'utilisateur survole l'élément (<code>:hover</code>) ou clique dessus (<code>:focus</code>).</li>
+            <li><strong>Propriétés CSS :</strong> Écrivez le code CSS à appliquer dans la zone de texte. Par exemple : <code>background-color: #e73c7e;<br>color: white;<br>border-radius: 50px;</code></li>
+            <li><strong>Aperçu :</strong> Le résultat est visible en direct sur les éléments de démo à droite.</li>
+            <li><strong>Appliquer :</strong> Ajoute le CSS généré à la feuille de style globale de votre site.</li>
+        </ol>
+    </div>
+
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <label>Sélecteur(s)</label><input type="text" id="ssc-sel" class="large-text" placeholder=".btn, .card > a">
+            <label>Pseudo-classe</label><select id="ssc-pseudo"><option value="">(aucune)</option><option value=":hover">:hover</option><option value=":focus">:focus</option></select>
+            <label>Propriétés CSS</label><textarea id="ssc-css" rows="12" class="code"></textarea>
+            <div class="ssc-actions"><button id="ssc-apply" class="button button-primary">Appliquer</button><button id="ssc-copy" class="button">Copier</button></div>
+        </div>
+        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-scope-preview-container" style="border: 1px dashed #ccc; padding: 1em; border-radius: 8px;"><style id="ssc-scope-preview-style"></style><button class="btn demo">Bouton</button><a href="#" class="link demo">Lien</a></div></div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/shadow-editor.php
+++ b/supersede-css-jlg-enhanced/views/shadow-editor.php
@@ -1,0 +1,14 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth"><h2>Visual Shadow Editor</h2><div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <div id="ssc-shadow-layers-container"></div>
+            <div class="ssc-actions" style="margin-top: 16px;"><button id="ssc-shadow-add-layer" class="button">Ajouter un calque</button></div><hr>
+            <div class="ssc-actions"><button id="ssc-shadow-apply" class="button button-primary">Appliquer</button><button id="ssc-shadow-copy" class="button">Copier CSS</button></div>
+            <pre id="ssc-shadow-css" class="ssc-code"></pre>
+        </div>
+        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-shadow-preview" style="width: 200px; height: 120px; background: #fff; border-radius: 12px; margin: 2em auto; display: grid; place-items: center; border: 1px solid #e5e7eb; transition: all 0.2s ease;">Aperçu</div></div>
+    </div></div>

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -1,0 +1,70 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $tokens_css */
+?>
+<div class="ssc-app ssc-fullwidth">
+    <div class="ssc-panel">
+        <h2>🚀 Bienvenue dans le Gestionnaire de Tokens</h2>
+        <p>Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, etc.) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.</p>
+    </div>
+
+    <div class="ssc-two" style="margin-top:16px; align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>👨‍🏫 Qu'est-ce qu'un Token (ou Variable CSS) ?</h3>
+            <p>Imaginez que vous décidiez d'utiliser une couleur bleue spécifique (`#3498db`) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C'est long et risqué !</p>
+            <p>Un <strong>token</strong> est un "raccourci". Vous donnez un nom facile à retenir à votre couleur, comme <code>--couleur-principale</code>. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.</p>
+            <p><strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s'applique partout !</strong></p>
+            <hr>
+            <h4>Exemple Concret</h4>
+            <p><strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l'élément <code>:root</code> (la racine de votre page).</p>
+            <pre class="ssc-code">:root {
+   --couleur-principale: #3498db;
+   --radius-arrondi: 8px;
+}</pre>
+            <p><strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction <code>var()</code> pour appeler la valeur du token.</p>
+            <pre class="ssc-code">.mon-bouton {
+   background-color: var(--couleur-principale);
+   border-radius: var(--radius-arrondi);
+   color: white;
+}
+
+.mon-titre {
+   color: var(--couleur-principale);
+}</pre>
+        </div>
+        <div class="ssc-pane">
+            <h3>🎨 Éditeur Visuel de Tokens</h3>
+            <p>Utilisez cet éditeur pour créer et gérer vos tokens sans écrire de code. Les modifications apparaîtront dans la zone de texte ci-dessous.</p>
+
+            <div id="ssc-token-builder">
+                <!-- Les tokens seront ajoutés ici par JavaScript -->
+            </div>
+
+            <div class="ssc-actions" style="margin-top:12px;">
+                <button id="ssc-token-add" class="button">+ Ajouter un Token</button>
+            </div>
+
+            <hr>
+
+            <h3>📜 Code CSS des Tokens (`:root`)</h3>
+            <p>C'est ici que le code généré par l'éditeur visuel apparaît. Vous pouvez aussi y coller directement votre propre code.</p>
+            <textarea id="ssc-tokens" rows="10" class="large-text"><?php echo esc_textarea($tokens_css); ?></textarea>
+            <div class="ssc-actions" style="margin-top:8px;">
+                <button id="ssc-tokens-apply" class="button button-primary">Appliquer les Tokens sur le site</button>
+                <button id="ssc-tokens-copy" class="button">Copier le Code</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="ssc-panel" style="margin-top:16px;">
+        <h3>👁️ Aperçu en Direct</h3>
+        <p>Voyez comment vos tokens affectent les éléments. Le style de cet aperçu est directement contrôlé par le code CSS ci-dessus.</p>
+        <style id="ssc-tokens-preview-style"></style>
+        <div id="ssc-tokens-preview" style="padding: 24px; border: 2px dashed var(--couleur-principale, #ccc); border-radius: var(--radius-moyen, 8px); background: #fff;">
+            <button class="button button-primary" style="background-color: var(--couleur-principale); border-radius: var(--radius-moyen);">Bouton Principal</button>
+            <a href="#" style="color: var(--couleur-principale); margin-left: 16px;">Lien Principal</a>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/tron-grid.php
+++ b/supersede-css-jlg-enhanced/views/tron-grid.php
@@ -1,0 +1,62 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="ssc-app ssc-fullwidth">
+    <h2>🌐 Tron Grid Animator</h2>
+    <p>Générez un fond de grille animé et personnalisable. Idéal pour des bannières ou des fonds de section futuristes.</p>
+
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Paramètres de la Grille</h3>
+
+            <label><strong>Couleur des lignes</strong></label>
+            <input type="color" id="ssc-tron-line-color" value="#00ffff">
+
+            <label style="margin-top:16px; display:block;"><strong>Couleur de fond (Dégradé)</strong></label>
+            <div class="ssc-actions">
+                <span>Haut :</span> <input type="color" id="ssc-tron-bg1" value="#0a0a23">
+                <span>Bas :</span> <input type="color" id="ssc-tron-bg2" value="#000000">
+            </div>
+
+            <label style="margin-top:16px; display:block;"><strong>Taille de la grille (pixels)</strong></label>
+            <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5">
+            <span id="ssc-tron-size-val">50px</span>
+
+            <label style="margin-top:16px; display:block;"><strong>Épaisseur des lignes (pixels)</strong></label>
+            <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1">
+            <span id="ssc-tron-thickness-val">1px</span>
+
+            <label style="margin-top:16px; display:block;"><strong>Vitesse de l'animation (secondes)</strong></label>
+            <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1">
+            <span id="ssc-tron-speed-val">10s</span>
+
+            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+                <button id="ssc-tron-apply" class="button button-primary">Appliquer sur le site</button>
+                <button id="ssc-tron-copy" class="button">Copier le CSS</button>
+            </div>
+
+            <h3 style="margin-top:24px;">Comment utiliser cet effet ?</h3>
+            <p class="description">
+                Le bouton <strong>"Appliquer sur le site"</strong> ajoute le code CSS généré à la feuille de style globale de votre site. Vous pouvez ensuite utiliser la classe <code>.ssc-tron-grid-bg</code> sur n'importe quel élément (div, section, etc.) pour lui appliquer ce fond.
+            </p>
+            <p class="description">
+                <strong>Pour créer plusieurs grilles différentes :</strong>
+            </p>
+            <ol style="padding-left: 20px;" class="description">
+                <li>Personnalisez votre première grille ici.</li>
+                <li>Cliquez sur <strong>"Copier CSS"</strong>.</li>
+                <li>Allez dans le module <strong>"Utilities"</strong> (l'éditeur CSS principal).</li>
+                <li>Collez le code et renommez la classe principale, par exemple en <code>.ma-grille-bleue</code>.</li>
+                <li>Revenez ici, créez une autre variation, et répétez l'opération avec un nouveau nom de classe (ex: <code>.ma-grille-rouge</code>).</li>
+            </ol>
+
+            <pre id="ssc-tron-css" class="ssc-code"></pre>
+        </div>
+        <div class="ssc-pane">
+            <h3>Aperçu en Direct</h3>
+            <div id="ssc-tron-preview" style="height: 300px; border-radius: 12px; border: 1px solid var(--ssc-border); overflow: hidden;"></div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/typography-editor.php
+++ b/supersede-css-jlg-enhanced/views/typography-editor.php
@@ -1,0 +1,42 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<style>
+    #ssc-typo-preview { transition: font-size 0.1s linear; }
+    .ssc-typo-vp-slider-container { width: 100%; background: var(--ssc-bg); padding: 10px; border-radius: 8px; margin-top: 10px; }
+</style>
+<div class="ssc-app ssc-fullwidth">
+    <h2>📏 Typographie Fluide (Clamp)</h2>
+    <p>Générez du texte qui s'adapte parfaitement à toutes les tailles d'écran, sans "sauts" disgracieux.</p>
+    <div class="ssc-two" style="align-items: flex-start;">
+        <div class="ssc-pane">
+            <h3>Paramètres de la Police (en pixels)</h3>
+            <div class="ssc-two">
+                <div><label>Taille min. police</label><input type="number" id="ssc-typo-min-fs" value="16" class="small-text"></div>
+                <div><label>Taille max. police</label><input type="number" id="ssc-typo-max-fs" value="48" class="small-text"></div>
+            </div>
+            <div class="ssc-two" style="margin-top: 12px;">
+                <div><label>Taille min. viewport (px)</label><input type="number" id="ssc-typo-min-vp" value="320" class="small-text"></div>
+                <div><label>Taille max. viewport (px)</label><input type="number" id="ssc-typo-max-vp" value="1280" class="small-text"></div>
+            </div>
+            <label style="margin-top: 16px;">Texte à prévisualiser</label>
+            <input type="text" id="ssc-typo-text" class="large-text" value="Design fluide, lecture parfaite.">
+            <div class="ssc-actions" style="margin-top: 16px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+                <button id="ssc-typo-generate" class="button button-primary">Générer</button>
+                <button id="ssc-typo-copy" class="button">Copier le CSS</button>
+            </div>
+            <pre id="ssc-typo-css" class="ssc-code" style="margin-top: 16px;"></pre>
+        </div>
+        <div class="ssc-pane">
+            <h3>Aperçu</h3>
+            <div class="ssc-typo-vp-slider-container">
+                <label>Largeur du viewport (px)</label>
+                <input type="range" id="ssc-typo-vp-slider" min="320" max="1280" value="960">
+                <span id="ssc-typo-vp-value">960px</span>
+            </div>
+            <div id="ssc-typo-preview" style="margin-top: 16px; font-size: clamp(16px, 3vw, 48px);">Design fluide, lecture parfaite.</div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/utilities.php
+++ b/supersede-css-jlg-enhanced/views/utilities.php
@@ -1,0 +1,92 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+/** @var string $css_desktop */
+/** @var string $css_tablet */
+/** @var string $css_mobile */
+/** @var string $preview_url */
+?>
+<style>
+    .ssc-editor-tabs { display: flex; border-bottom: 1px solid var(--ssc-border); }
+    .ssc-editor-tab { padding: 8px 16px; cursor: pointer; border-bottom: 2px solid transparent; }
+    .ssc-editor-tab.active { color: var(--ssc-accent); border-bottom-color: var(--ssc-accent); font-weight: 600; }
+    .ssc-editor-panel { display: none; height: 100%; }
+    .ssc-editor-panel.active { display: block; }
+    .ssc-tutorial-content { padding: 16px; }
+    .ssc-tutorial-content code { background: var(--ssc-bg); padding: 2px 6px; border-radius: 4px; }
+    #ssc-picker-overlay { position: absolute; inset: 0; background: rgba(79, 70, 229, 0.2); z-index: 9998; display: none; cursor: crosshair; }
+    #ssc-picker-tooltip { position: fixed; background: #0f172a; color: white; padding: 4px 8px; border-radius: 4px; font-size: 12px; z-index: 9999; white-space: nowrap; display: none; }
+</style>
+<div class="ssc-wrap ssc-utilities-wrap">
+    <div class="ssc-editor-layout">
+        <div class="ssc-editor-column">
+            <div class="ssc-editor-header">
+                <h2><?php echo esc_html__('Éditeur CSS', 'supersede-css-jlg'); ?></h2>
+                <div class="ssc-actions">
+                    <button id="ssc-save-css" class="button button-primary"><?php echo esc_html__('Enregistrer le CSS', 'supersede-css-jlg'); ?></button>
+                </div>
+            </div>
+            <div class="ssc-editor-tabs">
+                <div class="ssc-editor-tab active" data-tab="desktop">🖥️ Desktop</div>
+                <div class="ssc-editor-tab" data-tab="tablet">📲 Tablette</div>
+                <div class="ssc-editor-tab" data-tab="mobile">📱 Mobile</div>
+                <div class="ssc-editor-tab" data-tab="tutorial">💡 Tutoriel @media queries</div>
+            </div>
+            <div class="ssc-editor-container">
+                <div id="ssc-editor-panel-desktop" class="ssc-editor-panel active"><textarea id="ssc-css-editor-desktop"><?php echo esc_textarea($css_desktop); ?></textarea></div>
+                <div id="ssc-editor-panel-tablet" class="ssc-editor-panel"><textarea id="ssc-css-editor-tablet"><?php echo esc_textarea($css_tablet); ?></textarea></div>
+                <div id="ssc-editor-panel-mobile" class="ssc-editor-panel"><textarea id="ssc-css-editor-mobile"><?php echo esc_textarea($css_mobile); ?></textarea></div>
+                <div id="ssc-editor-panel-tutorial" class="ssc-editor-panel ssc-tutorial-content">
+                    <h3>Le Principe : "Desktop First" Simplifié</h3>
+                    <p>Pensez à votre design comme à la construction d'une maison :</p>
+                    <ol>
+                        <li><strong>L'onglet <code>Desktop</code> est le plan de base de la maison.</strong> C'est ici que vous définissez tous les styles fondamentaux (couleurs, polices, espacements). Ces styles s'appliquent par défaut à <strong>toutes les tailles d'écran</strong>.</li>
+                        <li><strong>L'onglet <code>Tablette</code> est l'aménagement pour les pièces moyennes.</strong> Vous ne redessinez pas tout, vous spécifiez uniquement les changements. Par exemple, réduire la taille d'un titre.</li>
+                        <li><strong>L'onglet <code>Mobile</code> est pour les plus petites pièces.</strong> Vous faites les derniers ajustements pour que tout soit parfait sur un petit écran.</li>
+                    </ol>
+                    <p>En coulisses, le plugin enveloppe automatiquement le code des onglets Tablette et Mobile dans des <strong>@media queries</strong>, vous faisant gagner du temps.</p>
+                    <hr>
+                    <h4>Exemple Concret : Un Titre Adaptatif</h4>
+                    <p><strong>Objectif :</strong> Un titre <code>.mon-titre</code> qui change de taille et d'alignement.</p>
+                    <p><strong>1. Onglet <code>Desktop</code> (la base) :</strong></p>
+                    <pre class="ssc-code">.mon-titre {
+  font-size: 48px;
+  color: blue;
+  font-weight: bold;
+}</pre>
+                    <p><strong>2. Onglet <code>Tablette</code> (premier ajustement) :</strong></p>
+                    <pre class="ssc-code">.mon-titre {
+  font-size: 36px;
+}</pre>
+                    <p><strong>3. Onglet <code>Mobile</code> (ajustement final) :</strong></p>
+                    <pre class="ssc-code">.mon-titre {
+  font-size: 24px;
+  text-align: center;
+}</pre>
+                </div>
+            </div>
+        </div>
+        <div class="ssc-preview-column">
+            <div class="ssc-preview-header">
+                <div class="ssc-url-bar">
+                    <input type="url" id="ssc-preview-url" value="<?php echo esc_url($preview_url); ?>">
+                    <button class="button" id="ssc-preview-load"><?php echo esc_html__('Load', 'supersede-css-jlg'); ?></button>
+                    <button class="button" id="ssc-element-picker-toggle" title="Cibler un élément">🎯</button>
+                </div>
+                <div class="ssc-responsive-toggles">
+                    <button class="button button-primary" data-vp="desktop" title="Desktop">🖥️</button><button class="button" data-vp="tablet" title="Tablet">📲</button><button class="button" data-vp="mobile" title="Mobile">📱</button>
+                </div>
+            </div>
+            <div class="ssc-preview-frame-container">
+                <div id="ssc-picker-overlay"></div>
+                <div id="ssc-picker-tooltip"></div>
+                <iframe id="ssc-preview-frame" sandbox="allow-same-origin allow-forms allow-scripts"></iframe>
+            </div>
+            <div style="padding-top: 8px;">
+                <label>Sélecteur Ciblé :</label>
+                <input type="text" id="ssc-picked-selector" readonly class="large-text" placeholder="Cliquez sur 🎯 puis sur un élément dans l'aperçu.">
+            </div>
+        </div>
+    </div>
+</div>

--- a/supersede-css-jlg-enhanced/views/visual-effects.php
+++ b/supersede-css-jlg-enhanced/views/visual-effects.php
@@ -1,0 +1,96 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<style>
+    .ssc-ve-tabs { display: flex; border-bottom: 1px solid var(--ssc-border); margin-bottom: 16px; }
+    .ssc-ve-tab { padding: 10px 16px; cursor: pointer; border-bottom: 2px solid transparent; }
+    .ssc-ve-tab.active { color: var(--ssc-accent); border-bottom-color: var(--ssc-accent); font-weight: 600; }
+    .ssc-ve-panel { display: none; }
+    .ssc-ve-panel.active { display: block; }
+    .ssc-ve-preview-box { height: 300px; border-radius: 12px; border: 1px solid var(--ssc-border); overflow: hidden; position: relative; background: #000; }
+    #ssc-crt-canvas { width: 100%; height: 100%; }
+    .ssc-ecg-path { fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; transition: all 0.3s; }
+    #ssc-ecg-preview-container { position: relative; background: #0b1020; display: grid; place-items: center; }
+    #ssc-ecg-preview-svg { position: absolute; width: 100%; height: auto; }
+    #ssc-ecg-logo-preview { max-width: 100px; max-height: 100px; z-index: 5; }
+    .ssc-grid-three { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; }
+</style>
+<div class="ssc-app ssc-fullwidth">
+    <h2>🎬 Générateur d'Effets Visuels</h2>
+    <p>Une collection d'effets visuels avancés pour animer vos fonds, images et conteneurs.</p>
+    <div class="ssc-ve-tabs">
+        <div class="ssc-ve-tab active" data-tab="backgrounds">🌌 Fonds Animés</div>
+        <div class="ssc-ve-tab" data-tab="ecg">❤️ ECG / Battement de Cœur</div>
+        <div class="ssc-ve-tab" data-tab="crt">📺 Effet CRT (Scanline)</div>
+    </div>
+
+    <div id="ssc-ve-panel-crt" class="ssc-ve-panel">
+        <div class="ssc-two" style="align-items: flex-start;">
+            <div class="ssc-pane">
+                <h3>Paramètres de l'effet CRT</h3>
+                <p class="description">Cet effet est purement décoratif et ne génère pas de CSS à exporter.</p>
+                <div class="ssc-grid-three">
+                    <div><label>Couleur Scanline</label><input type="color" class="ssc-crt-control" id="scanlineColor" value="#00ff00"></div>
+                    <div><label>Opacité Scanline</label><input type="range" class="ssc-crt-control" id="scanlineOpacity" min="0" max="1" value="0.4" step="0.05"></div>
+                    <div><label>Vitesse Scanline</label><input type="range" class="ssc-crt-control" id="scanlineSpeed" min="0.1" max="2" value="0.5" step="0.1"></div>
+                    <div><label>Intensité Bruit</label><input type="range" class="ssc-crt-control" id="noiseIntensity" min="0" max="0.5" value="0.1" step="0.02"></div>
+                    <div><label>Aberration Chromatique</label><input type="range" class="ssc-crt-control" id="chromaticAberration" min="0" max="5" value="1" step="0.5"></div>
+                </div>
+            </div>
+            <div class="ssc-pane">
+                <h3>Aperçu</h3>
+                <div class="ssc-ve-preview-box"><canvas id="ssc-crt-canvas"></canvas></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="ssc-ve-panel-ecg" class="ssc-ve-panel">
+         <div class="ssc-two" style="align-items: flex-start;">
+            <div class="ssc-pane">
+                <h3>Paramètres de l'ECG</h3>
+                <label><strong>Preset de Rythme</strong></label>
+                <select id="ssc-ecg-preset" class="regular-text"><option value="stable">Stable</option><option value="fast">Rapide</option><option value="critical">Critique</option></select>
+                <label style="margin-top:16px;"><strong>Couleur de la ligne</strong></label>
+                <input type="color" id="ssc-ecg-color" value="#00ff00">
+                <label style="margin-top:16px;"><strong>Positionnement (top)</strong></label>
+                <input type="range" id="ssc-ecg-top" min="0" max="100" value="50" step="1"><span id="ssc-ecg-top-val">50%</span>
+                <label style="margin-top:16px;"><strong>Superposition (z-index)</strong></label>
+                <input type="range" id="ssc-ecg-z-index" min="-10" max="10" value="1" step="1"><span id="ssc-ecg-z-index-val">1</span>
+                <hr>
+                <label><strong>Logo/Image au centre</strong></label>
+                <button id="ssc-ecg-upload-btn" class="button">Choisir une image</button>
+                <label style="margin-top:16px;"><strong>Taille du logo</strong></label>
+                <input type="range" id="ssc-ecg-logo-size" min="20" max="200" value="100" step="1"><span id="ssc-ecg-logo-size-val">100px</span>
+                <hr>
+                <pre id="ssc-ecg-css" class="ssc-code ssc-code-small" style="margin-top:16px;"></pre>
+                <button id="ssc-ecg-apply" class="button button-primary" style="margin-top:8px;">Appliquer l'Effet</button>
+            </div>
+            <div class="ssc-pane">
+                <h3>Aperçu</h3>
+                <div id="ssc-ecg-preview-container" class="ssc-ve-preview-box">
+                    <img id="ssc-ecg-logo-preview" src="" alt="Logo Preview" style="display:none;">
+                    <svg id="ssc-ecg-preview-svg" viewBox="0 0 400 60" preserveAspectRatio="none"><path id="ssc-ecg-preview-path" class="ssc-ecg-path" d="M0,30 L100,30 L110,18 L120,42 L130,26 L140,30 L240,30 L250,20 L260,40 L270,28 L280,30 L400,30"/></svg>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="ssc-ve-panel-backgrounds" class="ssc-ve-panel">
+         <div class="ssc-two" style="align-items: flex-start;">
+            <div class="ssc-pane">
+                <h3>Paramètres du Fond</h3>
+                <select id="ssc-bg-type" class="regular-text"><option value="stars">Étoiles</option><option value="gradient">Dégradé</option></select>
+                <div id="ssc-bg-controls-stars"><label>Couleur</label><input type="color" id="starColor" value="#FFFFFF"><label>Nombre</label><input type="range" id="starCount" min="50" max="500" value="200" step="10"></div>
+                <div id="ssc-bg-controls-gradient" style="display:none;"><label>Vitesse</label><input type="range" id="gradientSpeed" min="2" max="20" value="10" step="1"></div>
+                 <pre id="ssc-bg-css" class="ssc-code"></pre>
+                <button id="ssc-bg-apply" class="button button-primary">Appliquer</button>
+            </div>
+            <div class="ssc-pane">
+                <h3>Aperçu</h3>
+                <div id="ssc-bg-preview" class="ssc-ve-preview-box"></div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add an `AbstractPage` helper that loads PHP view templates from the plugin
- update every admin page class to prepare data and render the matching view file
- move each page's HTML markup into new files under `views/`

## Testing
- php -l


------
https://chatgpt.com/codex/tasks/task_e_68c9672c3be4832e8252e3d8b421fabe