### PR TITLE
Persist responsive CSS segments

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -13,10 +13,14 @@
         });
     }
 
+    function getEditorValue(view) {
+        return editors[view] ? editors[view].getValue() : '';
+    }
+
     function getFullCss() {
-        const desktopCss = editors.desktop ? editors.desktop.getValue() : '';
-        const tabletCss = editors.tablet ? editors.tablet.getValue() : '';
-        const mobileCss = editors.mobile ? editors.mobile.getValue() : '';
+        const desktopCss = getEditorValue('desktop');
+        const tabletCss = getEditorValue('tablet');
+        const mobileCss = getEditorValue('mobile');
 
         const tabletWrapped = tabletCss.trim() ? `@media (max-width: 782px) {\n${tabletCss}\n}` : '';
         const mobileWrapped = mobileCss.trim() ? `@media (max-width: 480px) {\n${mobileCss}\n}` : '';
@@ -69,10 +73,20 @@
         });
 
         $('#ssc-save-css').on('click', function() {
+            const desktopCss = getEditorValue('desktop');
+            const tabletCss = getEditorValue('tablet');
+            const mobileCss = getEditorValue('mobile');
             const fullCss = getFullCss();
             $.ajax({
                 url: SSC.rest.root + 'save-css', method: 'POST',
-                data: { css: fullCss, option_name: 'ssc_active_css', _wpnonce: SSC.rest.nonce },
+                data: {
+                    css: fullCss,
+                    css_desktop: desktopCss,
+                    css_tablet: tabletCss,
+                    css_mobile: mobileCss,
+                    option_name: 'ssc_active_css',
+                    _wpnonce: SSC.rest.nonce
+                },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('CSS enregistré !'));
         });


### PR DESCRIPTION
## Summary
- send individual desktop, tablet, and mobile editor contents when saving CSS
- extend the REST save-css handler to persist the breakpoint-specific CSS with CssSanitizer and rebuild the combined stylesheet
- add helpers to sanitize incoming segments and recompute the responsive CSS before updating ssc_active_css

## Testing
- php -l src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfb148bc832e91006a5e21d133e9