### PR TITLE
Adjust export normalization to preserve CSS formatting

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -280,11 +280,6 @@ final class Routes {
         }
 
         foreach ($options as $name => $value) {
-            if (is_string($value)) {
-                $options[$name] = sanitize_text_field($value);
-                continue;
-            }
-
             if (is_array($value)) {
                 array_walk_recursive($value, static function (&$item): void {
                     if (is_string($item)) {
@@ -293,11 +288,6 @@ final class Routes {
                 });
 
                 $options[$name] = $value;
-                continue;
-            }
-
-            if (is_scalar($value)) {
-                $options[$name] = sanitize_text_field((string) $value);
             }
         }
         return new \WP_REST_Response($options, 200);


### PR DESCRIPTION
## Summary
- keep scalar configuration exports untouched after maybe_unserialize so CSS strings retain formatting
- preserve recursive HTML sanitization for array values only

## Testing
- php /tmp/test_export.php

------
https://chatgpt.com/codex/tasks/task_e_68cac50e45b4832e8dd9dd29b1a7de73