### PR TITLE
Allow safe data URIs in CSS sanitizer

### DIFF
--- a/supersede-css-jlg-enhanced/readme.txt
+++ b/supersede-css-jlg-enhanced/readme.txt
@@ -13,6 +13,7 @@ Cette version a été entièrement refactorisée pour améliorer la stabilité, 
 * Les fonctions identifient et neutralisent les protocoles dangereux (`javascript:`, `vbscript:`) à l'aide de `wp_kses_bad_protocol()` tout en conservant les URL légitimes et les valeurs attendues.
 * Les propriétés personnalisées (`--var`) et autres déclarations modernes sont sauvegardées après un nettoyage ciblé afin d'éviter de casser des styles valides.
 * Les jeux de presets (scope, propriétés) et les effets Avatar Glow sont normalisés (textes, sélecteurs, couleurs, URLs) avant persistance afin d'éviter les injections sans perdre la configuration enregistrée.
+* Scénario manuel : ajouter un bloc CSS contenant `background-image: url("data:image/svg+xml;base64,PHN2Zy4uLg==");` puis un autre avec `background-image: url("javascript:alert(1)");`. Après sauvegarde, vérifier que la première propriété est intacte tandis que la seconde est supprimée du CSS généré dans l'interface.
 
 == Changelog ==
 = 10.0.0 =


### PR DESCRIPTION
## Summary
- allow CssSanitizer to preserve safe data: URLs for images and fonts while still filtering disallowed protocols
- document a manual scenario covering data: image URLs and blocked javascript: URLs in the plugin readme

## Testing
- php -l supersede-css-jlg-enhanced/src/Support/CssSanitizer.php

------
https://chatgpt.com/codex/tasks/task_e_68cadcac412c832e9f8c4e3cbd77ea0d