### PR TITLE
Avoid resanitizing exported option scalars

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -279,17 +279,18 @@ final class Routes {
             $options[$result->option_name] = maybe_unserialize($result->option_value);
         }
 
-        foreach ($options as $name => $value) {
-            if (is_array($value)) {
-                array_walk_recursive($value, static function (&$item): void {
-                    if (is_string($item)) {
-                        $item = wp_kses_post($item);
-                    }
-                });
-
-                $options[$name] = $value;
+        foreach ($options as $name => &$value) {
+            if (!is_array($value)) {
+                continue;
             }
+
+            array_walk_recursive($value, static function (&$item): void {
+                if (is_string($item)) {
+                    $item = wp_kses_post($item);
+                }
+            });
         }
+        unset($value);
         return new \WP_REST_Response($options, 200);
     }
 


### PR DESCRIPTION
## Summary
- skip resanitizing scalar values when exporting options so maybe_unserialize output is preserved
- continue sanitizing array payloads recursively while iterating by reference

## Testing
- php /tmp/test_export_config.php

------
https://chatgpt.com/codex/tasks/task_e_68caf622ae44832ea922a30e49f3ac3a