### PR TITLE
Preserve quoted CSS tokens when stripping HTML tags

### DIFF
--- a/supersede-css-jlg-enhanced/manual-tests/property-syntax.php
+++ b/supersede-css-jlg-enhanced/manual-tests/property-syntax.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+define('ABSPATH', __DIR__);
+
+if (!function_exists('wp_kses')) {
+    function wp_kses(string $string, array $allowed_html): string
+    {
+        return strip_tags($string);
+    }
+}
+
+if (!function_exists('wp_allowed_protocols')) {
+    function wp_allowed_protocols(): array
+    {
+        return ['http', 'https'];
+    }
+}
+
+if (!function_exists('wp_kses_bad_protocol')) {
+    function wp_kses_bad_protocol(string $string, array $allowed_protocols)
+    {
+        $string = trim($string);
+
+        $colonPosition = strpos($string, ':');
+        if ($colonPosition === false) {
+            return $string;
+        }
+
+        $protocol = strtolower(substr($string, 0, $colonPosition));
+        if (!in_array($protocol, $allowed_protocols, true)) {
+            return '';
+        }
+
+        return $string;
+    }
+}
+
+if (!function_exists('safecss_filter_attr')) {
+    function safecss_filter_attr(string $css): string
+    {
+        return $css;
+    }
+}
+
+require dirname(__DIR__) . '/src/Support/CssSanitizer.php';
+
+use SSC\Support\CssSanitizer;
+
+$css = <<<'CSS'
+@property --angle {
+    syntax: '<angle>';
+    inherits: false;
+    initial-value: 0deg;
+}
+
+.foo {
+    background-image: url('javascript:alert(1)');
+}
+
+@import url("javascript:alert(2)");
+CSS;
+
+echo "Original CSS:\n" . $css . "\n\n";
+
+$sanitized = CssSanitizer::sanitize($css);
+
+echo "Sanitized CSS:\n" . $sanitized . "\n";


### PR DESCRIPTION
## Summary
- ensure quoted CSS values are protected when stripping HTML tags before sanitization
- reuse the protection for custom property values so tokens like `<angle>` survive
- add a manual regression script covering the `@property` syntax and existing URL/import defenses

## Testing
- php supersede-css-jlg-enhanced/manual-tests/property-syntax.php
- php supersede-css-jlg-enhanced/manual-tests/sanitize-imports.php

------
https://chatgpt.com/codex/tasks/task_e_68cb019c5510832ea3a41f745d64dafc