### PR TITLE
Fix viewport value selector in typography editor

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/typography-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/typography-editor.js
@@ -22,7 +22,7 @@
 
     function updatePreview() {
         const vpWidth = $('#ssc-typo-vp-slider').val();
-        $('#ssc-typo-vp-val').text(vpWidth + 'px');
+        $('#ssc-typo-vp-value').text(vpWidth + 'px');
 
         const minFS = parseFloat($('#ssc-typo-min-fs').val());
         const maxFS = parseFloat($('#ssc-typo-max-fs').val());


### PR DESCRIPTION
## Summary
- update the viewport value selector in the typography editor preview to match the markup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0d6d5ab4832ea32e211e70ef5039