### PR TITLE
Fix typography editor viewport label selector

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/typography-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/typography-editor.js
@@ -22,7 +22,7 @@
 
     function updatePreview() {
         const vpWidth = $('#ssc-typo-vp-slider').val();
-        $('#ssc-typo-vp-val').text(vpWidth + 'px');
+        $('#ssc-typo-vp-value').text(vpWidth + 'px');
 
         const minFS = parseFloat($('#ssc-typo-min-fs').val());
         const maxFS = parseFloat($('#ssc-typo-max-fs').val());


### PR DESCRIPTION
## Summary
- target the viewport value label using the correct DOM id in the typography editor preview update

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb0cfa5240832e853b1f3efd9d2b55