### PR TITLE
Refine animation preview refresh logic

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/animation-studio.js
+++ b/supersede-css-jlg-enhanced/assets/js/animation-studio.js
@@ -53,12 +53,19 @@
         }
         styleTag.text(css);
         
-        const previewBox = $('#ssc-anim-preview-box');
-        // Relancer l'animation en clonant l'élément
-        const newBox = previewBox.clone(true);
-        previewBox.before(newBox);
-        $("." + previewBox.attr("class") + ":last").remove();
-        newBox.addClass('ssc-animated ' + preset.name);
+        let previewBox = $('#ssc-anim-preview-box');
+        const animationClasses = Object.values(presets).map(preset => preset.name);
+        const preservedClasses = (previewBox.attr('class') || '')
+            .split(/\s+/)
+            .filter(cls => cls && cls !== 'ssc-animated' && !animationClasses.includes(cls));
+
+        const newBox = previewBox.clone(false);
+        newBox.attr('id', 'ssc-anim-preview-box');
+        newBox.attr('class', preservedClasses.join(' '));
+
+        previewBox.replaceWith(newBox);
+        previewBox = $('#ssc-anim-preview-box');
+        previewBox.addClass('ssc-animated ' + preset.name);
     }
 
     $(document).ready(function() {


### PR DESCRIPTION
## Summary
- replace the animation preview reset logic with a replaceWith flow that preserves the preview element's id
- filter out prior animation classes so the refreshed preview receives only the active animation classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb16466354832e8534d4136b08742c