### PR TITLE
Enable configuration import via REST endpoint

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -16,6 +16,14 @@
     color: var(--ssc-muted);
 }
 
+#ssc-import-msg.ssc-success {
+    color: #15803d;
+}
+
+#ssc-import-msg.ssc-error {
+    color: #b91c1c;
+}
+
 .ssc-two { display:grid; grid-template-columns: 1fr 1fr; gap:16px; }
 @media (max-width: 782px) { .ssc-two { grid-template-columns: 1fr; } }
 .ssc-pane, .ssc-panel { background:var(--ssc-card); border:1px solid var(--ssc-border); border-radius:12px; padding:16px; }

--- a/supersede-css-jlg-enhanced/manual-tests/import-config.md
+++ b/supersede-css-jlg-enhanced/manual-tests/import-config.md
@@ -1,0 +1,31 @@
+# Test manuel : restauration d'une configuration exportée
+
+Objectif : vérifier que le flux « Exporter → Importer » permet de restaurer une configuration complète sans erreur.
+
+## Pré-requis
+
+- Un site WordPress avec le plugin Supersede CSS activé.
+- Un compte disposant du droit `manage_options`.
+
+## Étapes
+
+1. **Préparer une configuration d'exemple**
+   1. Ouvrir l'écran Supersede CSS et saisir un CSS simple (ex. `body { background: #f5f5f5; }`).
+   2. Créer au moins un preset et un token pour disposer de données visibles dans l'export.
+2. **Exporter la configuration**
+   1. Aller dans l’onglet « Import / Export ».
+   2. Cliquer sur **Exporter Config (.json)** et enregistrer le fichier généré.
+3. **Modifier les options existantes**
+   1. Supprimer manuellement le CSS/preset ajouté lors de l’étape 1 (ex. via l’interface Supersede ou en réinitialisant les sections concernées).
+   2. Vérifier que le site ne contient plus les éléments personnalisés.
+4. **Importer le fichier exporté**
+   1. Toujours dans l’onglet « Import / Export », sélectionner le fichier JSON précédemment exporté.
+   2. Cliquer sur **Importer** et s’assurer que le toast « Configuration importée ! » et le message récapitulatif apparaissent.
+5. **Valider la restauration**
+   1. Revenir sur l’éditeur principal et vérifier que le CSS, les presets et les autres réglages sont de nouveau présents.
+   2. En cas d’échec, relever le message affiché dans `#ssc-import-msg` ainsi que la réponse REST (onglet Réseau du navigateur) pour faciliter le diagnostic.
+
+## Résultat attendu
+
+- Le message de succès indique le nombre d’options restaurées et, le cas échéant, celles ignorées.
+- Les styles et presets supprimés à l’étape 3 sont de nouveau disponibles après l’import.


### PR DESCRIPTION
## Summary
- implement the import UI workflow to read JSON files, call the REST API and surface success/error feedback
- add the `ssc/v1/import-config` endpoint that sanitizes incoming options and applies them safely
- document the manual import/export verification procedure for QA

## Testing
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6e4cbe7c832e96e0b5136dd520f1