### PR TITLE
Enable configuration import workflow

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -16,6 +16,16 @@
     color: var(--ssc-muted);
 }
 
+.ssc-notice-success {
+    color: var(--ssc-accent);
+    font-weight: 600;
+}
+
+.ssc-notice-error {
+    color: #b91c1c;
+    font-weight: 600;
+}
+
 .ssc-two { display:grid; grid-template-columns: 1fr 1fr; gap:16px; }
 @media (max-width: 782px) { .ssc-two { grid-template-columns: 1fr; } }
 .ssc-pane, .ssc-panel { background:var(--ssc-card); border:1px solid var(--ssc-border); border-radius:12px; padding:16px; }

--- a/supersede-css-jlg-enhanced/assets/js/import-export.js
+++ b/supersede-css-jlg-enhanced/assets/js/import-export.js
@@ -56,9 +56,114 @@
             });
         });
         
-        // --- IMPORTATION (Logique de base) ---
-        $('#ssc-import-btn').on('click', function() {
-            alert("La fonctionnalité d'importation est en cours de développement.");
+        // --- IMPORTATION ---
+        const importBtn = $('#ssc-import-btn');
+        const importInput = $('#ssc-import-file');
+        const importMsg = $('#ssc-import-msg');
+
+        const showImportMessage = (type, text) => {
+            if (!importMsg.length) {
+                if (typeof window.sscToast === 'function') {
+                    window.sscToast(text);
+                }
+                return;
+            }
+
+            importMsg
+                .removeClass('ssc-muted ssc-notice-success ssc-notice-error')
+                .text(text);
+
+            if (type === 'success') {
+                importMsg.addClass('ssc-notice-success');
+                if (typeof window.sscToast === 'function') {
+                    window.sscToast(text);
+                }
+            } else if (type === 'error') {
+                importMsg.addClass('ssc-notice-error');
+                if (typeof window.sscToast === 'function') {
+                    window.sscToast(text);
+                }
+            } else {
+                importMsg.addClass('ssc-muted');
+            }
+        };
+
+        importBtn.on('click', function() {
+            const btn = $(this);
+
+            if (!importInput.length) {
+                showImportMessage('error', 'Champ de fichier introuvable.');
+                return;
+            }
+
+            const files = importInput[0].files;
+
+            if (!files || !files.length) {
+                showImportMessage('error', 'Sélectionnez un fichier JSON exporté depuis Supersede CSS.');
+                return;
+            }
+
+            const file = files[0];
+            const reader = new FileReader();
+
+            btn.text('Importation...').prop('disabled', true);
+            showImportMessage('info', 'Lecture du fichier...');
+
+            reader.onerror = () => {
+                btn.text('Importer').prop('disabled', false);
+                showImportMessage('error', "Impossible de lire le fichier sélectionné.");
+            };
+
+            reader.onload = event => {
+                let parsed;
+                try {
+                    parsed = JSON.parse(event.target.result);
+                } catch (error) {
+                    btn.text('Importer').prop('disabled', false);
+                    showImportMessage('error', 'Le fichier ne contient pas un JSON valide.');
+                    return;
+                }
+
+                if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    btn.text('Importer').prop('disabled', false);
+                    showImportMessage('error', "Le JSON doit représenter un objet d'options Supersede CSS.");
+                    return;
+                }
+
+                $.ajax({
+                    url: SSC.rest.root + 'import-config',
+                    method: 'POST',
+                    data: {
+                        payload: JSON.stringify(parsed),
+                        _wpnonce: SSC.rest.nonce
+                    },
+                    beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
+                }).done(response => {
+                    if (response && response.ok) {
+                        const updated = Array.isArray(response.updated) ? response.updated.length : 0;
+                        const message = updated > 0
+                            ? `Configuration importée (${updated} option${updated > 1 ? 's' : ''} mise${updated > 1 ? 's' : ''} à jour).`
+                            : 'Configuration importée.';
+                        showImportMessage('success', message);
+                        importInput.val('');
+                    } else {
+                        const message = response && response.message
+                            ? response.message
+                            : "Une erreur est survenue lors de l'import.";
+                        showImportMessage('error', message);
+                    }
+                }).fail(xhr => {
+                    const response = xhr.responseJSON;
+                    const message = response && response.message
+                        ? response.message
+                        : "Une erreur est survenue lors de l'import.";
+                    showImportMessage('error', message);
+                }).always(() => {
+                    btn.text('Importer').prop('disabled', false);
+                });
+            };
+
+            reader.readAsText(file);
         });
     });
 })(jQuery);

--- a/supersede-css-jlg-enhanced/manual-tests/import-config.md
+++ b/supersede-css-jlg-enhanced/manual-tests/import-config.md
@@ -1,0 +1,19 @@
+# Test manuel – Import d'une configuration Supersede CSS
+
+Ce test permet de vérifier que l'import d'un export JSON restaure correctement les options principales du plugin.
+
+## Pré-requis
+- Un site WordPress avec le plugin Supersede CSS activé.
+- Un fichier d'export valide obtenu via **Exporter Config (.json)** dans l'interface du plugin.
+
+## Étapes
+1. Accédez à l'écran **Supersede CSS → Import / Export** dans l'administration WordPress.
+2. Vérifiez que les options (presets, CSS actifs, etc.) sont actuellement différentes de celles contenues dans votre export (facultatif mais recommandé).
+3. Dans le bloc **Importer**, sélectionnez votre fichier d'export via le champ « Importer (.json) ».
+4. Cliquez sur le bouton **Importer**.
+5. Attendez la notification de succès indiquant le nombre d'options mises à jour.
+
+## Résultats attendus
+- Un toast et un message sous le bouton confirment l'import réussi avec le nombre d'options restaurées.
+- Les options suivantes sont mises à jour d'après l'export : `ssc_active_css`, `ssc_css_desktop`, `ssc_css_tablet`, `ssc_css_mobile`, `ssc_tokens_css`, `ssc_presets`, `ssc_avatar_glow_presets` (si présentes dans le fichier).
+- En cas de fichier invalide, un message d'erreur clair est affiché et aucune option n'est modifiée.


### PR DESCRIPTION
## Summary
- implement the client-side import flow with JSON validation, REST submission, and user notifications
- add the REST endpoint that sanitizes and stores imported Supersede CSS options
- document the manual verification steps and add styles for the new import status messages

## Testing
- php -l src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6d9ba990832ead3b46c9cacc46b8