### PR TITLE
Improve CSS sanitizer whitelist and add modern property tests

### DIFF
--- a/supersede-css-jlg-enhanced/manual-tests/sanitize-modern-properties.php
+++ b/supersede-css-jlg-enhanced/manual-tests/sanitize-modern-properties.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+\define('ABSPATH', __DIR__);
+
+if (!\function_exists('wp_kses')) {
+    function wp_kses(string $string, array $allowed_html): string
+    {
+        return $string;
+    }
+}
+
+if (!\function_exists('wp_allowed_protocols')) {
+    function wp_allowed_protocols(): array
+    {
+        return ['http', 'https'];
+    }
+}
+
+if (!\function_exists('wp_kses_bad_protocol')) {
+    function wp_kses_bad_protocol(string $string, array $allowed_protocols)
+    {
+        return $string;
+    }
+}
+
+require \dirname(__DIR__) . '/src/Support/CssSanitizer.php';
+
+use SSC\Support\CssSanitizer;
+
+$tests = [
+    'grid declarations are preserved' => [
+        'input' => '.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }',
+        'expected' => '.grid {display:grid; grid-template-columns:repeat(3, 1fr); gap:1rem}',
+    ],
+    'animation transform and filter survive' => [
+        'input' => '.box { animation: spin 3s linear infinite; transform: rotate(0deg); filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.5)); }',
+        'expected' => '.box {animation:spin 3s linear infinite; transform:rotate(0deg); filter:drop-shadow(0 0 10px rgba(0, 0, 0, 0.5))}',
+    ],
+    'unsafe protocols in URLs are stripped' => [
+        'input' => '.img { filter: url("javascript:alert(1)"); }',
+        'expected' => '.img',
+    ],
+];
+
+foreach ($tests as $label => $test) {
+    $sanitized = CssSanitizer::sanitize($test['input']);
+    $status = $sanitized === $test['expected'] ? 'OK' : 'FAIL';
+
+    echo $label . ':' . PHP_EOL;
+    echo '  Input:     ' . $test['input'] . PHP_EOL;
+    echo '  Sanitized: ' . $sanitized . PHP_EOL;
+    echo '  Expected:  ' . $test['expected'] . PHP_EOL;
+    echo '  Result:    ' . $status . PHP_EOL;
+    echo str_repeat('-', 40) . PHP_EOL;
+
+    if ($status === 'FAIL') {
+        exit(1);
+    }
+}

--- a/supersede-css-jlg-enhanced/readme.txt
+++ b/supersede-css-jlg-enhanced/readme.txt
@@ -9,7 +9,7 @@ Description: Boîte à outils visuelle pour CSS avec presets, éditeurs live, to
 Cette version a été entièrement refactorisée pour améliorer la stabilité, l'expérience utilisateur et les performances. Elle intègre de nouveaux modules créatifs et simplifie les interfaces complexes.
 
 == Sécurité ==
-* Toutes les écritures de CSS passent désormais par `SSC\Support\CssSanitizer` qui retire les balises HTML avec `wp_kses()` avant d'analyser chaque déclaration avec `safe_style_css()` via `safecss_filter_attr()`.
+* Toutes les écritures de CSS passent désormais par `SSC\Support\CssSanitizer` qui retire les balises HTML avec `wp_kses()`, contrôle les URL via `wp_kses_bad_protocol()` et valide les déclarations au moyen d'une liste blanche couvrant les modules modernes (grid, animation, transform, filter, etc.).
 * Les fonctions identifient et neutralisent les protocoles dangereux (`javascript:`, `vbscript:`) à l'aide de `wp_kses_bad_protocol()` tout en conservant les URL légitimes et les valeurs attendues.
 * Les propriétés personnalisées (`--var`) et autres déclarations modernes sont sauvegardées après un nettoyage ciblé afin d'éviter de casser des styles valides.
 * Les jeux de presets (scope, propriétés) et les effets Avatar Glow sont normalisés (textes, sélecteurs, couleurs, URLs) avant persistance afin d'éviter les injections sans perdre la configuration enregistrée.

--- a/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
@@ -6,6 +6,369 @@ if (!defined('ABSPATH')) { exit; }
 
 final class CssSanitizer
 {
+    private const ALLOWED_PROPERTIES = [
+        'accent-color' => true,
+        'align-content' => true,
+        'align-items' => true,
+        'align-self' => true,
+        'all' => true,
+        'animation' => true,
+        'animation-composition' => true,
+        'animation-delay' => true,
+        'animation-direction' => true,
+        'animation-duration' => true,
+        'animation-fill-mode' => true,
+        'animation-iteration-count' => true,
+        'animation-name' => true,
+        'animation-play-state' => true,
+        'animation-timing-function' => true,
+        'appearance' => true,
+        'aspect-ratio' => true,
+        'backdrop-filter' => true,
+        'backface-visibility' => true,
+        'background' => true,
+        'background-attachment' => true,
+        'background-blend-mode' => true,
+        'background-clip' => true,
+        'background-color' => true,
+        'background-image' => true,
+        'background-origin' => true,
+        'background-position' => true,
+        'background-position-x' => true,
+        'background-position-y' => true,
+        'background-repeat' => true,
+        'background-size' => true,
+        'block-size' => true,
+        'border' => true,
+        'border-block' => true,
+        'border-block-color' => true,
+        'border-block-end' => true,
+        'border-block-start' => true,
+        'border-block-style' => true,
+        'border-block-width' => true,
+        'border-bottom' => true,
+        'border-bottom-color' => true,
+        'border-bottom-left-radius' => true,
+        'border-bottom-right-radius' => true,
+        'border-bottom-style' => true,
+        'border-bottom-width' => true,
+        'border-collapse' => true,
+        'border-color' => true,
+        'border-end-end-radius' => true,
+        'border-end-start-radius' => true,
+        'border-image' => true,
+        'border-image-outset' => true,
+        'border-image-repeat' => true,
+        'border-image-slice' => true,
+        'border-image-source' => true,
+        'border-image-width' => true,
+        'border-inline' => true,
+        'border-inline-color' => true,
+        'border-inline-end' => true,
+        'border-inline-start' => true,
+        'border-inline-style' => true,
+        'border-inline-width' => true,
+        'border-left' => true,
+        'border-left-color' => true,
+        'border-left-style' => true,
+        'border-left-width' => true,
+        'border-radius' => true,
+        'border-right' => true,
+        'border-right-color' => true,
+        'border-right-style' => true,
+        'border-right-width' => true,
+        'border-spacing' => true,
+        'border-start-end-radius' => true,
+        'border-start-start-radius' => true,
+        'border-style' => true,
+        'border-top' => true,
+        'border-top-color' => true,
+        'border-top-left-radius' => true,
+        'border-top-right-radius' => true,
+        'border-top-style' => true,
+        'border-top-width' => true,
+        'border-width' => true,
+        'bottom' => true,
+        'box-shadow' => true,
+        'box-sizing' => true,
+        'break-after' => true,
+        'break-before' => true,
+        'break-inside' => true,
+        'caption-side' => true,
+        'caret-color' => true,
+        'clear' => true,
+        'clip' => true,
+        'clip-path' => true,
+        'color' => true,
+        'color-scheme' => true,
+        'column-count' => true,
+        'column-fill' => true,
+        'column-gap' => true,
+        'column-rule' => true,
+        'column-rule-color' => true,
+        'column-rule-style' => true,
+        'column-rule-width' => true,
+        'column-span' => true,
+        'column-width' => true,
+        'columns' => true,
+        'contain' => true,
+        'contain-intrinsic-block-size' => true,
+        'contain-intrinsic-height' => true,
+        'contain-intrinsic-inline-size' => true,
+        'contain-intrinsic-size' => true,
+        'contain-intrinsic-width' => true,
+        'container' => true,
+        'container-name' => true,
+        'container-type' => true,
+        'content' => true,
+        'counter-increment' => true,
+        'counter-reset' => true,
+        'cursor' => true,
+        'direction' => true,
+        'display' => true,
+        'filter' => true,
+        'flex' => true,
+        'flex-basis' => true,
+        'flex-direction' => true,
+        'flex-flow' => true,
+        'flex-grow' => true,
+        'flex-shrink' => true,
+        'flex-wrap' => true,
+        'float' => true,
+        'font' => true,
+        'font-family' => true,
+        'font-feature-settings' => true,
+        'font-kerning' => true,
+        'font-language-override' => true,
+        'font-optical-sizing' => true,
+        'font-palette' => true,
+        'font-size' => true,
+        'font-size-adjust' => true,
+        'font-stretch' => true,
+        'font-style' => true,
+        'font-synthesis' => true,
+        'font-smooth' => true,
+        'font-variant' => true,
+        'font-variant-alternates' => true,
+        'font-variant-caps' => true,
+        'font-variant-east-asian' => true,
+        'font-variant-ligatures' => true,
+        'font-variant-numeric' => true,
+        'font-variant-position' => true,
+        'font-variation-settings' => true,
+        'font-weight' => true,
+        'gap' => true,
+        'grid' => true,
+        'grid-area' => true,
+        'grid-auto-columns' => true,
+        'grid-auto-flow' => true,
+        'grid-auto-rows' => true,
+        'grid-column' => true,
+        'grid-column-end' => true,
+        'grid-column-gap' => true,
+        'grid-column-start' => true,
+        'grid-gap' => true,
+        'grid-row' => true,
+        'grid-row-end' => true,
+        'grid-row-gap' => true,
+        'grid-row-start' => true,
+        'grid-template' => true,
+        'grid-template-areas' => true,
+        'grid-template-columns' => true,
+        'grid-template-rows' => true,
+        'height' => true,
+        'hyphens' => true,
+        'image-rendering' => true,
+        'inset' => true,
+        'inset-block' => true,
+        'inset-block-end' => true,
+        'inset-block-start' => true,
+        'inset-inline' => true,
+        'inset-inline-end' => true,
+        'inset-inline-start' => true,
+        'isolation' => true,
+        'justify-content' => true,
+        'justify-items' => true,
+        'justify-self' => true,
+        'left' => true,
+        'letter-spacing' => true,
+        'line-height' => true,
+        'list-style' => true,
+        'list-style-image' => true,
+        'list-style-position' => true,
+        'list-style-type' => true,
+        'margin' => true,
+        'margin-block' => true,
+        'margin-block-end' => true,
+        'margin-block-start' => true,
+        'margin-bottom' => true,
+        'margin-inline' => true,
+        'margin-inline-end' => true,
+        'margin-inline-start' => true,
+        'margin-left' => true,
+        'margin-right' => true,
+        'margin-top' => true,
+        'mask' => true,
+        'mask-border' => true,
+        'mask-border-mode' => true,
+        'mask-border-outset' => true,
+        'mask-border-repeat' => true,
+        'mask-border-slice' => true,
+        'mask-border-source' => true,
+        'mask-border-width' => true,
+        'mask-clip' => true,
+        'mask-composite' => true,
+        'mask-image' => true,
+        'mask-mode' => true,
+        'mask-origin' => true,
+        'mask-position' => true,
+        'mask-repeat' => true,
+        'mask-size' => true,
+        'mask-type' => true,
+        'max-block-size' => true,
+        'max-height' => true,
+        'max-inline-size' => true,
+        'max-width' => true,
+        'min-block-size' => true,
+        'min-height' => true,
+        'min-inline-size' => true,
+        'min-width' => true,
+        'mix-blend-mode' => true,
+        'object-fit' => true,
+        'object-position' => true,
+        'opacity' => true,
+        'order' => true,
+        'outline' => true,
+        'outline-color' => true,
+        'outline-offset' => true,
+        'outline-style' => true,
+        'outline-width' => true,
+        'overflow-clip-margin' => true,
+        'overflow' => true,
+        'overflow-anchor' => true,
+        'overflow-wrap' => true,
+        'overflow-x' => true,
+        'overflow-y' => true,
+        'overscroll-behavior' => true,
+        'overscroll-behavior-block' => true,
+        'overscroll-behavior-inline' => true,
+        'overscroll-behavior-x' => true,
+        'overscroll-behavior-y' => true,
+        'padding' => true,
+        'padding-block' => true,
+        'padding-block-end' => true,
+        'padding-block-start' => true,
+        'padding-bottom' => true,
+        'padding-inline' => true,
+        'padding-inline-end' => true,
+        'padding-inline-start' => true,
+        'padding-left' => true,
+        'padding-right' => true,
+        'padding-top' => true,
+        'perspective' => true,
+        'perspective-origin' => true,
+        'place-content' => true,
+        'place-items' => true,
+        'place-self' => true,
+        'pointer-events' => true,
+        'position' => true,
+        'resize' => true,
+        'right' => true,
+        'row-gap' => true,
+        'scroll-behavior' => true,
+        'scroll-margin' => true,
+        'scroll-margin-block' => true,
+        'scroll-margin-block-end' => true,
+        'scroll-margin-block-start' => true,
+        'scroll-margin-bottom' => true,
+        'scroll-margin-inline' => true,
+        'scroll-margin-inline-end' => true,
+        'scroll-margin-inline-start' => true,
+        'scroll-margin-left' => true,
+        'scroll-margin-right' => true,
+        'scroll-margin-top' => true,
+        'scroll-padding' => true,
+        'scroll-padding-block' => true,
+        'scroll-padding-block-end' => true,
+        'scroll-padding-block-start' => true,
+        'scroll-padding-bottom' => true,
+        'scroll-padding-inline' => true,
+        'scroll-padding-inline-end' => true,
+        'scroll-padding-inline-start' => true,
+        'scroll-padding-left' => true,
+        'scroll-padding-right' => true,
+        'scroll-padding-top' => true,
+        'scrollbar-color' => true,
+        'scrollbar-width' => true,
+        'scroll-snap-align' => true,
+        'scroll-snap-stop' => true,
+        'scroll-snap-type' => true,
+        'shape-margin' => true,
+        'shape-outside' => true,
+        'table-layout' => true,
+        'text-align' => true,
+        'text-align-last' => true,
+        'text-decoration' => true,
+        'text-decoration-color' => true,
+        'text-decoration-line' => true,
+        'text-decoration-style' => true,
+        'text-decoration-thickness' => true,
+        'text-indent' => true,
+        'text-rendering' => true,
+        'text-overflow' => true,
+        'text-shadow' => true,
+        'text-transform' => true,
+        'text-wrap' => true,
+        'text-underline-offset' => true,
+        'text-underline-position' => true,
+        'top' => true,
+        'transform' => true,
+        'transform-box' => true,
+        'transform-origin' => true,
+        'transform-style' => true,
+        'translate' => true,
+        'rotate' => true,
+        'scale' => true,
+        'transition' => true,
+        'transition-delay' => true,
+        'transition-duration' => true,
+        'transition-property' => true,
+        'transition-timing-function' => true,
+        'view-transition-name' => true,
+        'user-select' => true,
+        'vertical-align' => true,
+        'visibility' => true,
+        'white-space' => true,
+        'will-change' => true,
+        'width' => true,
+        'word-break' => true,
+        'word-spacing' => true,
+        'word-wrap' => true,
+        'writing-mode' => true,
+        'z-index' => true,
+    ];
+
+    private const ALLOWED_PROPERTY_PREFIXES = [
+        'background-',
+        'border-',
+        'font-',
+        'grid-',
+        'animation-',
+        'transition-',
+        'transform-',
+        'flex-',
+        'mask-',
+        'margin-',
+        'padding-',
+        'scroll-',
+        'text-',
+        'column-',
+        'row-',
+        'place-',
+        'justify-',
+        'align-',
+        'inset-',
+    ];
     public static function sanitize(string $css): string
     {
         $css = trim($css);
@@ -73,22 +436,26 @@ final class CssSanitizer
                 continue;
             }
 
-            $declaration = $property . ':' . $value . ';';
-            $sanitized = trim(\safecss_filter_attr($declaration));
-            if ($sanitized === '') {
-                if (strpos($property, '--') === 0) {
-                    $customValue = self::sanitizeCustomPropertyValue($value);
-                    if ($customValue === '') {
-                        continue;
-                    }
-                    $sanitizedParts[] = $property . ':' . $customValue;
+            if (str_starts_with($property, '--')) {
+                $customValue = self::sanitizeCustomPropertyValue($value);
+                if ($customValue === '') {
+                    continue;
                 }
+
+                $sanitizedParts[] = $property . ':' . $customValue;
                 continue;
             }
 
-            $sanitized = rtrim($sanitized, ';');
-            $sanitized = self::sanitizeUrls($sanitized);
-            $sanitizedParts[] = $sanitized;
+            if (!self::isAllowedProperty($property)) {
+                continue;
+            }
+
+            $sanitizedValue = self::sanitizePropertyValue($property, $value);
+            if ($sanitizedValue === '') {
+                continue;
+            }
+
+            $sanitizedParts[] = $property . ':' . $sanitizedValue;
         }
 
         return implode('; ', $sanitizedParts);
@@ -221,6 +588,58 @@ final class CssSanitizer
     private static function isSafePropertyName(string $property): bool
     {
         return (bool) \preg_match('/^(--[A-Za-z0-9_-]+|[A-Za-z-][A-Za-z0-9_-]*)$/', $property);
+    }
+
+    private static function isAllowedProperty(string $property): bool
+    {
+        if (isset(self::ALLOWED_PROPERTIES[$property])) {
+            return true;
+        }
+
+        foreach (self::ALLOWED_PROPERTY_PREFIXES as $prefix) {
+            if (str_starts_with($property, $prefix)) {
+                return true;
+            }
+        }
+
+        if (str_starts_with($property, '-')) {
+            $normalized = (string) \preg_replace('/^-(webkit|moz|ms|o)-/i', '', $property);
+            if ($normalized !== $property) {
+                return self::isAllowedProperty($normalized);
+            }
+        }
+
+        return false;
+    }
+
+    private static function sanitizePropertyValue(string $property, string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return '';
+        }
+
+        $value = self::stripHtmlTags($value);
+        $value = (string) \preg_replace('#/\*.*?\*/#s', '', $value);
+        $value = (string) \preg_replace('/expression\s*\([^)]*\)/i', '', $value);
+        $value = (string) \preg_replace('/behaviou?r\s*:[^;]+;?/i', '', $value);
+        $value = (string) \preg_replace('/@import\b[^;]*/i', '', $value);
+        $placeholders = [];
+        $masked = self::maskQuotedSegments($value, $placeholders);
+        $masked = str_replace(['{', '}'], '', $masked);
+        if (!empty($placeholders)) {
+            $masked = strtr($masked, $placeholders);
+        }
+        $value = $masked;
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $value = self::sanitizeUrls($value);
+
+        return $value;
     }
 
     private static function sanitizeCustomPropertyValue(string $value): string
@@ -585,33 +1004,25 @@ final class CssSanitizer
             return null;
         }
 
-        $sanitized = trim(\safecss_filter_attr($property . ':' . $value . ';'));
-        if ($sanitized === '') {
-            if (strpos($property, '--') === 0) {
-                $customValue = self::sanitizeCustomPropertyValue($value);
-                if ($customValue === '') {
-                    return null;
-                }
-
-                return [$property, $customValue];
+        if (str_starts_with($property, '--')) {
+            $customValue = self::sanitizeCustomPropertyValue($value);
+            if ($customValue === '') {
+                return null;
             }
 
+            return [$property, $customValue];
+        }
+
+        if (!self::isAllowedProperty($property)) {
             return null;
         }
 
-        $sanitized = rtrim($sanitized, ';');
-        $parts = explode(':', $sanitized, 2);
-        if (count($parts) !== 2) {
+        $sanitizedValue = self::sanitizePropertyValue($property, $value);
+        if ($sanitizedValue === '') {
             return null;
         }
 
-        $propName = trim($parts[0]);
-        $propValue = trim($parts[1]);
-        if ($propName === '' || $propValue === '') {
-            return null;
-        }
-
-        return [$propName, $propValue];
+        return [$property, $sanitizedValue];
     }
 
     public static function sanitizeAvatarGlowPresets(array $presets): array

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -46,7 +46,7 @@ add_action('plugins_loaded', function(){
         $css_main = is_string($css_main) ? $css_main : '';
         $css_tokens = is_string($css_tokens) ? $css_tokens : '';
         $css_combined = $css_tokens . "\n" . $css_main;
-        // Filtre le CSS en s'appuyant sur wp_kses() et safe_style_css() pour neutraliser les injections.
+        // Filtre le CSS via CssSanitizer qui combine wp_kses(), validation des URLs et une liste blanche de propriétés modernes.
         $css_filtered = CssSanitizer::sanitize($css_combined);
 
         if ($css_filtered !== '') {


### PR DESCRIPTION
## Summary
- replace the safecss_filter_attr usage with a curated whitelist and URL validation so modern CSS properties such as grid, animation, transform, and filter survive sanitization
- add a manual test script that exercises grid, animation, transform, and filter declarations while asserting that unsafe URL protocols are removed
- update inline documentation to reference the new whitelist-based strategy

## Testing
- php manual-tests/sanitize-declarations.php
- php manual-tests/sanitize-modern-properties.php
- php manual-tests/sanitize-imports.php
- php manual-tests/sanitize-urls.php
- php manual-tests/property-syntax.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6d9b5fbc832e9d36d52c386450b9