### PR TITLE
Restrict CSS sanitizer data URI handling

### DIFF
--- a/supersede-css-jlg-enhanced/manual-tests/sanitize-urls.php
+++ b/supersede-css-jlg-enhanced/manual-tests/sanitize-urls.php
@@ -43,6 +43,14 @@ $tests = [
         'input' => 'div { background: url("javascript:alert(1)"); }',
         'expected' => '',
     ],
+    'safe image data URI is preserved' => [
+        'input' => 'div { background-image: url("data:image/png;base64,AAAA"); }',
+        'expected' => 'div {background-image:url("data:image/png;base64,AAAA")}',
+    ],
+    'svg data URI is stripped' => [
+        'input' => 'div { background-image: url("data:image/svg+xml,<svg></svg>"); }',
+        'expected' => '',
+    ],
 ];
 
 foreach ($tests as $label => $test) {

--- a/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
@@ -427,6 +427,10 @@ final class CssSanitizer
             if ($sanitized === '' || \preg_match('/^(?:javascript|vbscript)/i', $sanitized)) {
                 return '';
             }
+
+            if (str_starts_with(strtolower($sanitized), 'data:')) {
+                return '';
+            }
         }
 
         if ($quote === '') {
@@ -447,7 +451,15 @@ final class CssSanitizer
         }
 
         $mime = strtolower($matches[1]);
-        if (str_starts_with($mime, 'image/')) {
+
+        $allowedImageTypes = [
+            'image/png',
+            'image/jpeg',
+            'image/gif',
+            'image/webp',
+        ];
+
+        if (in_array($mime, $allowedImageTypes, true)) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- restrict the data URI whitelist to specific safe image types while preserving existing font allowances
- reject non-whitelisted data URIs when sanitizing url() tokens
- extend the manual URL sanitization test to cover safe PNG and disallowed SVG data URIs

## Testing
- php supersede-css-jlg-enhanced/manual-tests/sanitize-urls.php

------
https://chatgpt.com/codex/tasks/task_e_68cd75cd1d50832eb01427724d68c739