### PR TITLE
Harden preset selector sanitation

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/preset-designer.js
+++ b/supersede-css-jlg-enhanced/assets/js/preset-designer.js
@@ -111,10 +111,15 @@
 
         // Enregistrer un preset (nouveau ou modifié)
         $('#ssc-save-preset').on('click', function() {
-            const name = $('#ssc-preset-name').val();
-            const scope = $('#ssc-preset-scope').val();
+            const name = $('#ssc-preset-name').val().trim();
+            const scope = $('#ssc-preset-scope').val().trim();
             if (!name || !scope) {
                 alert('Le nom et le sélecteur sont obligatoires.');
+                return;
+            }
+
+            if (/[{};@]/.test(scope)) {
+                alert('Le sélecteur est invalide.');
                 return;
             }
 

--- a/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
@@ -889,8 +889,17 @@ final class CssSanitizer
     {
         $selector = \wp_kses($selector, []);
         $selector = (string) \preg_replace('/[\x00-\x1F\x7F]+/u', ' ', $selector);
+        $selector = trim($selector);
 
-        return trim($selector);
+        if ($selector === '') {
+            return '';
+        }
+
+        if (\preg_match('/[{};@]/u', $selector)) {
+            return '';
+        }
+
+        return $selector;
     }
 
     private static function sanitizeDeclarationPair(string $property, string $value): ?array


### PR DESCRIPTION
## Summary
- reject CSS preset selectors containing braces, directives, or other illegal characters during sanitation
- cover selector sanitation with dedicated tests and lightweight WordPress helper stubs
- prevent the preset designer UI from sending selectors with forbidden characters

## Testing
- php supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8a18296c832e85b21770d2f342e4