### PR TITLE
Refactor preset row creation to avoid raw interpolation

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/preset-designer.js
+++ b/supersede-css-jlg-enhanced/assets/js/preset-designer.js
@@ -85,13 +85,31 @@
 
     // Créer une nouvelle ligne de propriété CSS
     function createPropRow(key = '', value = '') {
-        return $(`
-            <div class="kv-row" style="display:flex; gap:8px; margin-bottom:8px;">
-                <input type="text" class="prop-key regular-text" placeholder="propriété (ex: background-color)" value="${key}">
-                <input type="text" class="prop-val regular-text" placeholder="valeur (ex: #ff0000)" value="${value}">
-                <button type="button" class="button button-link-delete remove-prop-btn">X</button>
-            </div>
-        `);
+        const row = $('<div>')
+            .addClass('kv-row')
+            .css({ display: 'flex', gap: '8px', marginBottom: '8px' });
+
+        const keyInput = $('<input>', {
+            type: 'text',
+            class: 'prop-key regular-text',
+            placeholder: 'propriété (ex: background-color)'
+        }).val(key);
+
+        const valueInput = $('<input>', {
+            type: 'text',
+            class: 'prop-val regular-text',
+            placeholder: 'valeur (ex: #ff0000)'
+        }).val(value);
+
+        const removeButton = $('<button>', {
+            type: 'button',
+            class: 'button button-link-delete remove-prop-btn',
+            text: 'X'
+        });
+
+        row.append(keyInput, valueInput, removeButton);
+
+        return row;
     }
 
     $(document).ready(function() {


### PR DESCRIPTION
## Summary
- rebuild preset property rows using jQuery element creation instead of template interpolation
- keep event delegation and add-prop button behavior intact while allowing values with quotes to persist safely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce8efb497c832ebfacbec195296611