### PR TITLE
Handle non-string option name in saveCss

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -103,9 +103,13 @@ final class Routes {
     public function saveCss(\WP_REST_Request $request): \WP_REST_Response {
         $css_raw = $request->get_param('css');
         $option_name = $request->get_param('option_name') ?: 'ssc_active_css';
+        if (!is_string($option_name)) {
+            $option_name = 'ssc_active_css';
+        } else {
+            $option_name = sanitize_key($option_name);
+        }
         // Enforce whitelist for option_name to avoid clobbering unintended options.
         $allowed_options = ['ssc_active_css','ssc_tokens_css'];
-        $option_name = sanitize_key($option_name);
         if (!in_array($option_name, $allowed_options, true)) {
             $option_name = 'ssc_active_css';
         }


### PR DESCRIPTION
## Summary
- default to `ssc_active_css` when `option_name` is not a string before sanitizing in the `saveCss` route handler
- add a regression test exercising the save-css route with an array `option_name` to ensure a safe 200 response

## Testing
- php tests/Infra/RoutesAuthorizationTest.php
- php tests/Infra/RoutesImportTest.php
- php tests/Infra/RoutesSaveCssTest.php
- php tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cfcee2e47c832ea0cb4df1a50ecd02