### PR TITLE
Add structured token registry API and editor

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
@@ -3,6 +3,7 @@
 namespace SSC\Admin\Pages;
 
 use SSC\Admin\AbstractPage;
+use SSC\Support\TokenRegistry;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -10,12 +11,14 @@ if (!defined('ABSPATH')) {
 
 class Tokens extends AbstractPage
 {
-    private const DEFAULT_CSS = ":root {\n  --couleur-principale: #4f46e5;\n  --radius-moyen: 8px;\n}";
-
     public function render(): void
     {
+        $registry = TokenRegistry::getRegistry();
+
         $this->render_view('tokens', [
-            'tokens_css' => get_option('ssc_tokens_css', self::DEFAULT_CSS),
+            'tokens_registry' => $registry,
+            'tokens_css' => TokenRegistry::tokensToCss($registry),
+            'token_types' => TokenRegistry::getSupportedTypes(),
         ]);
     }
 }

--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -1,0 +1,242 @@
+<?php declare(strict_types=1);
+
+namespace SSC\Support;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class TokenRegistry
+{
+    private const OPTION_REGISTRY = 'ssc_tokens_registry';
+    private const OPTION_CSS = 'ssc_tokens_css';
+    private const REGISTRY_NOT_FOUND = '__ssc_tokens_registry_missing__';
+
+    /**
+     * @var array<string, array{label: string, input: string}>
+     */
+    private const SUPPORTED_TYPES = [
+        'color' => [
+            'label' => 'Couleur',
+            'input' => 'color',
+        ],
+        'text' => [
+            'label' => 'Texte',
+            'input' => 'text',
+        ],
+        'number' => [
+            'label' => 'Nombre',
+            'input' => 'number',
+        ],
+    ];
+
+    /**
+     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     */
+    public static function getRegistry(): array
+    {
+        $stored = get_option(self::OPTION_REGISTRY, self::REGISTRY_NOT_FOUND);
+
+        if ($stored !== self::REGISTRY_NOT_FOUND && is_array($stored)) {
+            $normalized = self::normalizeRegistry($stored);
+            if ($stored !== $normalized) {
+                update_option(self::OPTION_REGISTRY, $normalized, false);
+            }
+            self::persistCss($normalized);
+            return $normalized;
+        }
+
+        $legacyCss = get_option(self::OPTION_CSS, '');
+        if (is_string($legacyCss) && trim($legacyCss) !== '') {
+            $fromCss = self::normalizeRegistry(self::convertCssToRegistry($legacyCss));
+            if ($fromCss !== []) {
+                update_option(self::OPTION_REGISTRY, $fromCss, false);
+                self::persistCss($fromCss);
+                return $fromCss;
+            }
+        }
+
+        $defaults = self::normalizeRegistry(self::getDefaultRegistry());
+        update_option(self::OPTION_REGISTRY, $defaults, false);
+        self::persistCss($defaults);
+
+        return $defaults;
+    }
+
+    /**
+     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     */
+    public static function getDefaultRegistry(): array
+    {
+        return [
+            [
+                'name' => '--couleur-principale',
+                'value' => '#4f46e5',
+                'type' => 'color',
+                'description' => 'Couleur principale utilisée pour les éléments interactifs.',
+                'group' => 'Couleurs',
+            ],
+            [
+                'name' => '--radius-moyen',
+                'value' => '8px',
+                'type' => 'text',
+                'description' => 'Rayon par défaut appliqué aux composants principaux.',
+                'group' => 'Général',
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array{name?: mixed, value?: mixed, type?: mixed, description?: mixed, group?: mixed}> $tokens
+     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     */
+    public static function saveRegistry(array $tokens): array
+    {
+        $normalized = self::normalizeRegistry($tokens);
+        update_option(self::OPTION_REGISTRY, $normalized, false);
+        self::persistCss($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string, array{label: string, input: string}>
+     */
+    public static function getSupportedTypes(): array
+    {
+        return self::SUPPORTED_TYPES;
+    }
+
+    /**
+     * @param array<int, array{name?: mixed, value?: mixed, type?: mixed, description?: mixed, group?: mixed}> $tokens
+     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     */
+    public static function normalizeRegistry(array $tokens): array
+    {
+        $normalized = [];
+
+        foreach ($tokens as $token) {
+            if (!is_array($token)) {
+                continue;
+            }
+
+            $name = isset($token['name']) ? (string) $token['name'] : '';
+            $name = trim($name);
+            if ($name === '') {
+                continue;
+            }
+
+            if (strpos($name, '--') !== 0) {
+                $name = '--' . ltrim($name, '-');
+            }
+
+            $name = '--' . preg_replace('/[^a-z0-9\-]+/i', '-', ltrim($name, '-'));
+            $name = strtolower($name);
+
+            $valueRaw = isset($token['value']) ? (string) $token['value'] : '';
+            $value = trim(sanitize_textarea_field($valueRaw));
+            if ($value === '') {
+                continue;
+            }
+
+            $type = isset($token['type']) ? (string) $token['type'] : 'text';
+            if (!isset(self::SUPPORTED_TYPES[$type])) {
+                $type = 'text';
+            }
+
+            $description = isset($token['description']) ? sanitize_textarea_field((string) $token['description']) : '';
+            $group = isset($token['group']) ? sanitize_text_field((string) $token['group']) : '';
+            if ($group === '') {
+                $group = 'Général';
+            }
+
+            $normalized[] = [
+                'name' => $name,
+                'value' => $value,
+                'type' => $type,
+                'description' => $description,
+                'group' => $group,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param string $css
+     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     */
+    public static function convertCssToRegistry(string $css): array
+    {
+        $tokens = [];
+        $pattern = '/--([\w\-]+)\s*:\s*([^;]+);/';
+
+        if (preg_match_all($pattern, $css, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $rawName = isset($match[1]) ? '--' . $match[1] : '';
+                $rawValue = isset($match[2]) ? trim($match[2]) : '';
+
+                if ($rawName === '' || $rawValue === '') {
+                    continue;
+                }
+
+                $type = self::guessTypeFromValue($rawValue);
+
+                $tokens[] = [
+                    'name' => $rawName,
+                    'value' => $rawValue,
+                    'type' => $type,
+                    'description' => '',
+                    'group' => 'Legacy',
+                ];
+            }
+        }
+
+        return self::normalizeRegistry($tokens);
+    }
+
+    /**
+     * @param array<int, array{name: string, value: string, type: string, description: string, group: string}> $tokens
+     */
+    public static function tokensToCss(array $tokens): string
+    {
+        if ($tokens === []) {
+            return ':root {\n}\n';
+        }
+
+        $lines = [];
+
+        foreach ($tokens as $token) {
+            $lines[] = sprintf('    %s: %s;', $token['name'], $token['value']);
+        }
+
+        $css = ":root {\n" . implode("\n", $lines) . "\n}";
+
+        return CssSanitizer::sanitize($css);
+    }
+
+    /**
+     * @param array<int, array{name: string, value: string, type: string, description: string, group: string}> $tokens
+     */
+    private static function persistCss(array $tokens): void
+    {
+        $css = self::tokensToCss($tokens);
+        update_option(self::OPTION_CSS, $css, false);
+    }
+
+    private static function guessTypeFromValue(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return 'text';
+        }
+
+        if ($value[0] === '#' || str_starts_with(strtolower($value), 'rgb') || str_starts_with(strtolower($value), 'hsl')) {
+            return 'color';
+        }
+
+        if (preg_match('/^-?\d+(?:\.\d+)?$/', $value)) {
+            return 'number';
+        }
+
+        return 'text';
+    }
+}

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -3,18 +3,40 @@ if (!defined('ABSPATH')) {
     exit;
 }
 /** @var string $tokens_css */
+/** @var array<int, array{name: string, value: string, type: string, description: string, group: string}> $tokens_registry */
+/** @var array<string, array{label: string, input: string}> $token_types */
+
+if (function_exists('wp_localize_script')) {
+    wp_localize_script('ssc-tokens', 'SSC_TOKENS_DATA', [
+        'tokens' => $tokens_registry,
+        'types' => $token_types,
+        'css' => $tokens_css,
+        'i18n' => [
+            'addToken' => __('Ajouter un token', 'supersede-css-jlg'),
+            'emptyState' => __('Aucun token pour le moment. Utilisez le bouton ci-dessous pour commencer.', 'supersede-css-jlg'),
+            'groupLabel' => __('Groupe', 'supersede-css-jlg'),
+            'nameLabel' => __('Nom', 'supersede-css-jlg'),
+            'valueLabel' => __('Valeur', 'supersede-css-jlg'),
+            'typeLabel' => __('Type', 'supersede-css-jlg'),
+            'descriptionLabel' => __('Description', 'supersede-css-jlg'),
+            'deleteLabel' => __('Supprimer', 'supersede-css-jlg'),
+            'saveSuccess' => __('Tokens enregistrés', 'supersede-css-jlg'),
+            'saveError' => __('Impossible d’enregistrer les tokens.', 'supersede-css-jlg'),
+        ],
+    ]);
+}
 ?>
 <div class="ssc-app ssc-fullwidth">
     <div class="ssc-panel">
         <h2>🚀 Bienvenue dans le Gestionnaire de Tokens</h2>
-        <p>Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, etc.) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.</p>
+        <p>Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, espacements…) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.</p>
     </div>
 
     <div class="ssc-two" style="margin-top:16px; align-items: flex-start;">
         <div class="ssc-pane">
             <h3>👨‍🏫 Qu'est-ce qu'un Token (ou Variable CSS) ?</h3>
-            <p>Imaginez que vous décidiez d'utiliser une couleur bleue spécifique (`#3498db`) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C'est long et risqué !</p>
-            <p>Un <strong>token</strong> est un "raccourci". Vous donnez un nom facile à retenir à votre couleur, comme <code>--couleur-principale</code>. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.</p>
+            <p>Imaginez que vous décidiez d'utiliser une couleur bleue spécifique (<code>#3498db</code>) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C'est long et risqué !</p>
+            <p>Un <strong>token</strong> est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme <code>--couleur-principale</code>. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.</p>
             <p><strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s'applique partout !</strong></p>
             <hr>
             <h4>Exemple Concret</h4>
@@ -36,24 +58,36 @@ if (!defined('ABSPATH')) {
         </div>
         <div class="ssc-pane">
             <h3>🎨 Éditeur Visuel de Tokens</h3>
-            <p>Utilisez cet éditeur pour créer et gérer vos tokens sans écrire de code. Les modifications apparaîtront dans la zone de texte ci-dessous.</p>
+            <p>Gérez vos tokens sous forme de fiches structurées : nom technique, valeur, type de champ, description et groupe d'appartenance. Chaque catégorie est listée séparément pour garder une vision claire de votre système de design.</p>
 
-            <div id="ssc-token-builder">
-                <!-- Les tokens seront ajoutés ici par JavaScript -->
+            <style>
+                .ssc-token-builder { display: flex; flex-direction: column; gap: 16px; }
+                .ssc-token-group { border: 1px solid #e2e8f0; border-radius: 6px; padding: 12px; background: #fff; }
+                .ssc-token-group h4 { margin: 0 0 8px; }
+                .ssc-token-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; }
+                .ssc-token-field { display: flex; flex-direction: column; gap: 4px; flex: 1 1 180px; min-width: 180px; }
+                .ssc-token-field__label { font-weight: 600; font-size: 13px; }
+                .ssc-token-field-input { width: 100%; }
+                .ssc-token-field textarea { resize: vertical; }
+                .ssc-token-empty { margin: 0; font-style: italic; }
+            </style>
+
+            <div class="ssc-token-toolbar" style="margin-bottom:12px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+                <button id="ssc-token-add" class="button">+ Ajouter un Token</button>
             </div>
 
-            <div class="ssc-actions" style="margin-top:12px;">
-                <button id="ssc-token-add" class="button">+ Ajouter un Token</button>
+            <div id="ssc-token-builder" class="ssc-token-builder" aria-live="polite">
+                <!-- Hydraté par JavaScript -->
             </div>
 
             <hr>
 
-            <h3>📜 Code CSS des Tokens (`:root`)</h3>
-            <p>C'est ici que le code généré par l'éditeur visuel apparaît. Vous pouvez aussi y coller directement votre propre code.</p>
-            <textarea id="ssc-tokens" rows="10" class="large-text"><?php echo esc_textarea($tokens_css); ?></textarea>
-            <div class="ssc-actions" style="margin-top:8px;">
-                <button id="ssc-tokens-apply" class="button button-primary">Appliquer les Tokens sur le site</button>
-                <button id="ssc-tokens-copy" class="button">Copier le Code</button>
+            <h3>📜 Code CSS généré (<code>:root</code>)</h3>
+            <p>Le code ci-dessous est synchronisé automatiquement avec la configuration JSON. Il est proposé en lecture seule pour vérification ou copie rapide.</p>
+            <textarea id="ssc-tokens" rows="10" class="large-text" readonly><?php echo esc_textarea($tokens_css); ?></textarea>
+            <div class="ssc-actions" style="margin-top:8px; display:flex; gap:8px; flex-wrap:wrap;">
+                <button id="ssc-tokens-save" class="button button-primary">Enregistrer les Tokens</button>
+                <button id="ssc-tokens-copy" class="button">Copier le CSS</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a TokenRegistry helper that stores structured tokens, provides defaults and keeps the legacy CSS option in sync
- expose a dedicated /tokens REST endpoint that reads/writes the registry and updates imports, resets and CSS fallbacks accordingly
- refresh the tokens admin page, view and JavaScript editor to operate on the structured registry data with grouped inputs and localized bootstrap data

## Testing
- php -l supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php
- php -l supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
- php -l supersede-css-jlg-enhanced/views/tokens.php

------
https://chatgpt.com/codex/tasks/task_e_68cfdfe70640832e9f6bc32085e55442