### PR TITLE
Remove token registry option on uninstall

### DIFF
--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -10,6 +10,7 @@ $ssc_options_to_delete = [
     'ssc_presets',
     'ssc_active_css',
     'ssc_tokens_css',
+    'ssc_tokens_registry',
     'ssc_settings', // Legacy
     'ssc_secret', // Legacy
     'ssc_modules_enabled', // Legacy


### PR DESCRIPTION
## Summary
- include the ssc_tokens_registry option in the uninstall cleanup list so the registry row is removed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfef183854832e846ae446cc7dfe40