### PR TITLE
Add shared clipboard helper and use across editors

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/animation-studio.js
+++ b/supersede-css-jlg-enhanced/assets/js/animation-studio.js
@@ -74,8 +74,10 @@
         $('#ssc-anim-preset, #ssc-anim-duration').on('input', generateAnimationCSS);
 
         $('#ssc-anim-copy').on('click', () => {
-            navigator.clipboard.writeText($('#ssc-anim-css').text());
-            window.sscToast('CSS de l\'animation copié !');
+            window.sscCopyToClipboard($('#ssc-anim-css').text(), {
+                successMessage: 'CSS de l\'animation copié !',
+                errorMessage: 'Impossible de copier le CSS de l\'animation.'
+            }).catch(() => {});
         });
 
         $('#ssc-anim-apply').on('click', () => {

--- a/supersede-css-jlg-enhanced/assets/js/clip-path-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/clip-path-editor.js
@@ -23,8 +23,10 @@
         $('#ssc-clip-preview-size').on('input', updatePreviewSize);
 
         $('#ssc-clip-copy').on('click', () => {
-            navigator.clipboard.writeText($('#ssc-clip-css').text());
-            window.sscToast('CSS du clip-path copié !');
+            window.sscCopyToClipboard($('#ssc-clip-css').text(), {
+                successMessage: 'CSS du clip-path copié !',
+                errorMessage: 'Impossible de copier le CSS du clip-path.'
+            }).catch(() => {});
         });
 
         applyClipPath();

--- a/supersede-css-jlg-enhanced/assets/js/filter-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/filter-editor.js
@@ -56,8 +56,10 @@
         $('.ssc-filter-prop, #ssc-glass-enable').on('input change', updateFilters);
         
         $('#ssc-filter-copy').on('click', () => {
-            navigator.clipboard.writeText($('#ssc-filter-css').text());
-            window.sscToast('CSS copié !');
+            window.sscCopyToClipboard($('#ssc-filter-css').text(), {
+                successMessage: 'CSS copié !',
+                errorMessage: 'Impossible de copier le CSS du filtre.'
+            }).catch(() => {});
         });
 
         updateFilters();

--- a/supersede-css-jlg-enhanced/assets/js/gradient-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/gradient-editor.js
@@ -89,7 +89,12 @@
         });
 
         // Action buttons
-        $('#ssc-grad-copy').on('click', () => navigator.clipboard.writeText($('#ssc-grad-css').text()).then(() => window.sscToast('CSS copié !')));
+        $('#ssc-grad-copy').on('click', () => {
+            window.sscCopyToClipboard($('#ssc-grad-css').text(), {
+                successMessage: 'CSS copié !',
+                errorMessage: 'Impossible de copier le CSS du dégradé.'
+            }).catch(() => {});
+        });
         $('#ssc-grad-apply').on('click', () => {
              const css = $('#ssc-grad-css').text();
              $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)

--- a/supersede-css-jlg-enhanced/assets/js/grid-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/grid-editor.js
@@ -32,8 +32,10 @@
         $('#ssc-grid-cols, #ssc-grid-gap').on('input', generateGrid);
         
         $('#ssc-grid-copy').on('click', () => {
-            navigator.clipboard.writeText($('#ssc-grid-css').text());
-            window.sscToast('CSS de la grille copié !');
+            window.sscCopyToClipboard($('#ssc-grid-css').text(), {
+                successMessage: 'CSS de la grille copié !',
+                errorMessage: 'Impossible de copier le CSS de la grille.'
+            }).catch(() => {});
         });
         
         $('#ssc-grid-apply').on('click', () => {

--- a/supersede-css-jlg-enhanced/assets/js/shadow-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/shadow-editor.js
@@ -80,8 +80,10 @@
 
         // Action buttons
         $('#ssc-shadow-copy').on('click', () => {
-            navigator.clipboard.writeText($('#ssc-shadow-css').text());
-            window.sscToast('CSS copié !');
+            window.sscCopyToClipboard($('#ssc-shadow-css').text(), {
+                successMessage: 'CSS copié !',
+                errorMessage: 'Impossible de copier le CSS de l\'ombre.'
+            }).catch(() => {});
         });
         $('#ssc-shadow-apply').on('click', () => {
             const css = $('#ssc-shadow-css').text();

--- a/supersede-css-jlg-enhanced/assets/js/typography-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/typography-editor.js
@@ -93,8 +93,10 @@
         $('#ssc-typo-vp-slider').on('input', updatePreview);
         
         $('#ssc-typo-copy').on('click', () => {
-            navigator.clipboard.writeText($('#ssc-typo-css').text());
-            window.sscToast('CSS de la typographie copié !');
+            window.sscCopyToClipboard($('#ssc-typo-css').text(), {
+                successMessage: 'CSS de la typographie copié !',
+                errorMessage: 'Impossible de copier le CSS de la typographie.'
+            }).catch(() => {});
         });
 
         generateClamp();


### PR DESCRIPTION
## Summary
- add a shared `sscCopyToClipboard` helper that falls back to a hidden textarea when the Clipboard API is unavailable
- switch all editors using copy buttons to call the helper with contextual success and error toasts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d045d75fb8832e915f84659f2abb4a