### PR TITLE
Ensure token CSS import updates registry

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -477,6 +477,16 @@ final class Routes {
                 continue;
             }
 
+            if ($optionName === 'ssc_tokens_css') {
+                $tokens = TokenRegistry::convertCssToRegistry($sanitizedValue);
+
+                if ($tokens !== []) {
+                    TokenRegistry::saveRegistry($tokens);
+                    $applied[] = $optionName;
+                    continue;
+                }
+            }
+
             update_option($optionName, $sanitizedValue, false);
             $applied[] = $optionName;
         }

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
@@ -30,6 +30,34 @@ if (!function_exists('sanitize_text_field')) {
     }
 }
 
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($value)
+    {
+        return trim(strip_tags((string) $value));
+    }
+}
+
+if (!function_exists('wp_kses')) {
+    function wp_kses($string, $allowed_html = [], $allowed_protocols = [])
+    {
+        return strip_tags((string) $string);
+    }
+}
+
+if (!function_exists('wp_kses_bad_protocol')) {
+    function wp_kses_bad_protocol($string, $allowed_protocols)
+    {
+        return (string) $string;
+    }
+}
+
+if (!function_exists('wp_allowed_protocols')) {
+    function wp_allowed_protocols()
+    {
+        return ['http', 'https', 'data'];
+    }
+}
+
 /** @var array<string, mixed> $ssc_options_store */
 $ssc_options_store = [
     'ssc_admin_log' => [
@@ -64,6 +92,8 @@ if (!function_exists('update_option')) {
     }
 }
 
+require_once __DIR__ . '/../../src/Support/CssSanitizer.php';
+require_once __DIR__ . '/../../src/Support/TokenRegistry.php';
 require_once __DIR__ . '/../../src/Infra/Logger.php';
 require_once __DIR__ . '/../../src/Infra/Routes.php';
 
@@ -86,5 +116,38 @@ if ($ssc_options_store['ssc_admin_log'] !== $originalLog) {
 
 if (!is_array($result) || !isset($result['skipped']) || !in_array('ssc_admin_log', $result['skipped'], true)) {
     fwrite(STDERR, "Invalid admin log import should be reported as skipped." . PHP_EOL);
+    exit(1);
+}
+
+$ssc_options_store['ssc_tokens_registry'] = [];
+$ssc_options_store['ssc_tokens_css'] = '';
+
+$tokensCss = ":root {\n    --brand-color: #123456;\n    --spacing-small: 8px;\n}";
+$sanitizedTokensCss = \SSC\Support\CssSanitizer::sanitize($tokensCss);
+$expectedRegistry = \SSC\Support\TokenRegistry::convertCssToRegistry($sanitizedTokensCss);
+
+if ($expectedRegistry === []) {
+    fwrite(STDERR, "Test fixture should yield at least one token." . PHP_EOL);
+    exit(1);
+}
+
+$result = $applyMethod->invoke($routes, [
+    'ssc_tokens_css' => $tokensCss,
+]);
+
+if (!is_array($result) || !isset($result['applied']) || !in_array('ssc_tokens_css', $result['applied'], true)) {
+    fwrite(STDERR, "Token CSS import should be reported as applied." . PHP_EOL);
+    exit(1);
+}
+
+if ($ssc_options_store['ssc_tokens_registry'] !== $expectedRegistry) {
+    fwrite(STDERR, "Token registry should reflect imported CSS tokens." . PHP_EOL);
+    exit(1);
+}
+
+$expectedCss = \SSC\Support\TokenRegistry::tokensToCss($expectedRegistry);
+
+if ($ssc_options_store['ssc_tokens_css'] !== $expectedCss) {
+    fwrite(STDERR, "Token CSS option should be synchronized with registry output." . PHP_EOL);
     exit(1);
 }


### PR DESCRIPTION
## Summary
- ensure importing `ssc_tokens_css` uses the token registry conversion path so both options stay consistent
- add a regression test that imports only token CSS and verifies registry and CSS outputs are synchronized

## Testing
- php tests/Infra/RoutesImportTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d054a63108832e891bbbceff16f7ab