### PR TITLE
Handle object values during import sanitation

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -592,6 +592,33 @@ final class Routes {
                 continue;
             }
 
+            if (is_object($item)) {
+                $objectVars = get_object_vars($item);
+                if (is_array($objectVars) && $objectVars !== []) {
+                    $nested = $this->sanitizeImportArray($objectVars);
+                    if ($nested !== null) {
+                        $sanitized[$sanitizedKey] = $nested;
+                        continue;
+                    }
+                }
+
+                $jsonOptions = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+                if (defined('JSON_PARTIAL_OUTPUT_ON_ERROR')) {
+                    $jsonOptions |= JSON_PARTIAL_OUTPUT_ON_ERROR;
+                }
+
+                $encoded = function_exists('wp_json_encode')
+                    ? wp_json_encode($item, $jsonOptions)
+                    : json_encode($item, $jsonOptions);
+
+                if (!is_string($encoded)) {
+                    $encoded = '';
+                }
+
+                $sanitized[$sanitizedKey] = sanitize_text_field($encoded);
+                continue;
+            }
+
             $sanitized[$sanitizedKey] = sanitize_text_field((string) $item);
         }
 


### PR DESCRIPTION
## Summary
- extend import array sanitation to handle object payloads by recursing over public properties or serializing values safely
- cover stdClass and JsonSerializable payload imports with a regression test to ensure normalization

## Testing
- php tests/Infra/RoutesImportTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d07ea6b684832e905765f4e4405e39