### PR TITLE
Handle empty token CSS import

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -479,12 +479,9 @@ final class Routes {
 
             if ($optionName === 'ssc_tokens_css') {
                 $tokens = TokenRegistry::convertCssToRegistry($sanitizedValue);
-
-                if ($tokens !== []) {
-                    TokenRegistry::saveRegistry($tokens);
-                    $applied[] = $optionName;
-                    continue;
-                }
+                TokenRegistry::saveRegistry($tokens);
+                $applied[] = $optionName;
+                continue;
             }
 
             update_option($optionName, $sanitizedValue, false);

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
@@ -147,6 +147,37 @@ if ($ssc_options_store['ssc_tokens_css'] !== $expectedCss) {
     exit(1);
 }
 
+\SSC\Support\TokenRegistry::saveRegistry([
+    [
+        'name' => '--existing-token',
+        'value' => '#abcdef',
+        'type' => 'color',
+        'description' => '',
+        'group' => 'Legacy',
+    ],
+]);
+
+$emptyTokensResult = $applyMethod->invoke($routes, [
+    'ssc_tokens_css' => '',
+]);
+
+if (!is_array($emptyTokensResult) || !in_array('ssc_tokens_css', $emptyTokensResult['applied'] ?? [], true)) {
+    fwrite(STDERR, "Empty token CSS import should be reported as applied." . PHP_EOL);
+    exit(1);
+}
+
+if ($ssc_options_store['ssc_tokens_registry'] !== []) {
+    fwrite(STDERR, "Empty token CSS import should reset the token registry." . PHP_EOL);
+    exit(1);
+}
+
+$expectedEmptyCss = \SSC\Support\TokenRegistry::tokensToCss([]);
+
+if ($ssc_options_store['ssc_tokens_css'] !== $expectedEmptyCss) {
+    fwrite(STDERR, "Empty token CSS import should persist an empty CSS template." . PHP_EOL);
+    exit(1);
+}
+
 $objectPayload = new stdClass();
 $objectPayload->title = '<strong>Title</strong>';
 $objectPayload->count = 5;


### PR DESCRIPTION
## Summary
- ensure token CSS imports always persist the registry, even when the resulting token list is empty
- add a regression test covering empty token CSS imports and verifying that the registry and CSS storage are cleared

## Testing
- php tests/Infra/RoutesImportTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d13f8b88ac832e89b800e64e0f190f