### PR TITLE
Handle token CSS without trailing semicolons

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -167,7 +167,7 @@ final class TokenRegistry
     public static function convertCssToRegistry(string $css): array
     {
         $tokens = [];
-        $pattern = '/--([\w\-]+)\s*:\s*([^;]+);/';
+        $pattern = '/--([\w\-]+)\s*:\s*([^;\}]+)\s*(?:;|(?=\}))/';
 
         if (preg_match_all($pattern, $css, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {


### PR DESCRIPTION
## Summary
- allow token conversion to parse variable declarations that omit the trailing semicolon
- cover sanitized import flows to ensure single-token and trailing-token CSS are preserved
- verify the save-css REST route stores normalized token registries when receiving CSS without trailing semicolons

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesSaveCssTest.php
- php supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d14ca53484832e9035d5e7fd24c90b