### PR TITLE
Handle missing CodeMirror gracefully

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -1,9 +1,30 @@
 (function($) {
     let editors = {};
     let pickerActive = false;
+    const editorViews = ['desktop', 'tablet', 'mobile'];
+    const codeMirrorAvailable = typeof window !== 'undefined' && typeof window.CodeMirror !== 'undefined';
+    let codeMirrorWarningShown = false;
+
+    function notifyCodeMirrorUnavailable() {
+        if (codeMirrorWarningShown) return;
+        const message = "Éditeur enrichi indisponible : CodeMirror n'est pas chargé. Les champs texte classiques seront utilisés.";
+        if (typeof window !== 'undefined' && typeof window.sscToast === 'function') {
+            window.sscToast(message);
+        } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+            window.alert(message);
+        } else {
+            console.warn(message);
+        }
+        codeMirrorWarningShown = true;
+    }
 
     function initCodeMirrors() {
-        ['desktop', 'tablet', 'mobile'].forEach(view => {
+        if (!codeMirrorAvailable) {
+            notifyCodeMirrorUnavailable();
+            return;
+        }
+
+        editorViews.forEach(view => {
             const textarea = document.getElementById(`ssc-css-editor-${view}`);
             if (textarea) {
                 editors[view] = CodeMirror.fromTextArea(textarea, {
@@ -14,7 +35,12 @@
     }
 
     function getEditorValue(view) {
-        return editors[view] ? editors[view].getValue() : '';
+        if (editors[view]) {
+            return editors[view].getValue();
+        }
+
+        const textarea = document.getElementById(`ssc-css-editor-${view}`);
+        return textarea ? textarea.value : '';
     }
 
     function getFullCss() {


### PR DESCRIPTION
## Summary
- guard CodeMirror initialization to avoid errors when the library is missing
- fall back to reading textarea values directly when no CodeMirror instance exists
- surface a toast notification to inform users when the rich editor is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1810c5508832eb1bc4cfc8f9da593