### PR TITLE
Ensure uninstall removes options from all multisite blogs

### DIFF
--- a/supersede-css-jlg-enhanced/manual-tests/uninstall-multisite.md
+++ b/supersede-css-jlg-enhanced/manual-tests/uninstall-multisite.md
@@ -1,0 +1,29 @@
+# Test manuel : désinstallation complète en multisite
+
+Objectif : vérifier qu'une suppression du plugin en environnement multisite élimine toutes les options `ssc_*` sur l'ensemble du réseau.
+
+## Pré-requis
+
+- Un réseau WordPress multisite (au moins deux sites) avec Supersede CSS activé sur chaque site.
+- Accès administrateur au réseau et, idéalement, à WP-CLI.
+
+## Étapes
+
+1. **Générer des données sur plusieurs sites**
+   1. Depuis l'admin du site principal, ouvrir Supersede CSS et ajouter un CSS personnalisé (ex. `body { background: #efe; }`).
+   2. Répéter l'opération sur au moins un site secondaire (via « Mes sites > [Nom du site] > Tableau de bord »).
+2. **Confirmer la présence des options avant la désinstallation**
+   1. Dans un terminal, exécuter `wp site list --fields=blog_id` afin d'obtenir la liste des sites.
+   2. Pour chaque `blog_id`, exécuter `wp option list --url=<url-du-site> --search='ssc_%'` et vérifier qu'au moins une option est retournée.
+3. **Supprimer le plugin**
+   1. Aller dans « Mes sites > Admin réseau > Extensions ».
+   2. Désactiver Supersede CSS puis cliquer sur **Supprimer** afin de lancer le processus de désinstallation.
+4. **Valider le nettoyage des options**
+   1. Réexécuter la commande `wp site list --fields=blog_id`.
+   2. Pour chaque site, exécuter à nouveau `wp option list --url=<url-du-site> --search='ssc_%'`.
+   3. Vérifier qu'aucune ligne n'est retournée.
+
+## Résultat attendu
+
+- Plus aucune option commençant par `ssc_` n'est présente dans les tables `wp_options` (ou équivalentes) de chacun des sites du réseau après la suppression du plugin.
+- Aucune option réseau `ssc_*` n'apparaît dans `wp_sitemeta` (`wp site meta list --search='ssc_%'`).

--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -22,12 +22,33 @@ $ssc_options_to_delete = [
     'ssc_optimization_settings', // Ajouté
 ];
 
-// Boucle sur la liste et supprime chaque option
+// Supprime les options du site courant
 foreach ($ssc_options_to_delete as $option_name) {
-    if (is_multisite()) {
-        delete_site_option($option_name);
-    } else {
+    delete_option($option_name);
+}
+
+if (!is_multisite()) {
+    return;
+}
+
+// Supprime également les éventuelles options réseau
+foreach ($ssc_options_to_delete as $option_name) {
+    delete_site_option($option_name);
+}
+
+// Parcourt tous les sites du réseau pour supprimer les options locales
+$site_ids = get_sites([
+    'fields' => 'ids',
+    'number' => 0,
+]);
+
+foreach ($site_ids as $site_id) {
+    switch_to_blog($site_id);
+
+    foreach ($ssc_options_to_delete as $option_name) {
         delete_option($option_name);
     }
+
+    restore_current_blog();
 }
 


### PR DESCRIPTION
## Summary
- always delete Supersede CSS options from the current site during uninstall
- iterate over every network site to clear the same options and keep network cleanup via delete_site_option
- document a multisite uninstall manual test covering the absence of remaining `ssc_*` options

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1c976cf5c832eba116407ae04648b