### PR TITLE
Handle dangling CSS blocks in sanitizer

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -216,6 +216,21 @@ assertNotContains(
     'URL sanitizer should not expose sanitizer placeholder markers.'
 );
 
+$danglingBlockCss = 'body { width: expression(alert(1))';
+$sanitizedDanglingBlock = CssSanitizer::sanitize($danglingBlockCss);
+
+assertNotContains(
+    'expression',
+    $sanitizedDanglingBlock,
+    'Dangling blocks without a closing brace should not retain disallowed expressions.'
+);
+
+assertNotContains(
+    'width',
+    $sanitizedDanglingBlock,
+    'Dangling blocks without a closing brace should not keep unsafe declarations.'
+);
+
 $sanitizeImports = $reflection->getMethod('sanitizeImports');
 $sanitizeImports->setAccessible(true);
 


### PR DESCRIPTION
## Summary
- ensure CssSanitizer reuses filtering logic when a block is missing its closing brace instead of outputting raw CSS
- add a regression test covering dangling blocks without a closing brace

## Testing
- php tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d25d98fc50832eb78f65c72e8481bf