### PR TITLE
Refine CSS import sanitization state machine

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -240,4 +240,22 @@ assertNotContains(
     'Import sanitizer should strip unknown sanitizer markers.'
 );
 
+assertSameResult(
+    '@import url("https://example.com/style.css");',
+    $sanitizeImports->invoke(null, '@import "https://example.com/style.css";'),
+    'Actual @import at-rules should keep being normalized to safe URLs.'
+);
+
+assertSameResult(
+    'content: "@import url(foo)"',
+    $sanitizeImports->invoke(null, 'content: "@import url(foo)"'),
+    'Literal strings containing @import should remain untouched by the import sanitizer.'
+);
+
+assertSameResult(
+    '--example: "@import url(foo)"',
+    $sanitizeImports->invoke(null, '--example: "@import url(foo)"'),
+    'Custom property values containing @import should remain untouched by the import sanitizer.'
+);
+
 echo "All CssSanitizer tests passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- replace the regex-based @import sanitizer with a stateful scan that ignores directives inside comments and string literals
- reuse the existing import normalization in a helper to keep url/qualifier cleanup for real at-rules
- extend the CssSanitizer tests to cover literal "@import" occurrences in content and custom properties alongside a positive at-rule case

## Testing
- php tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d26baff940832ea0205266b1616b33