### PR TITLE
Handle @import rules missing semicolons safely

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
@@ -690,6 +690,10 @@ final class CssSanitizer
                             continue;
                         }
 
+                        if ($scanChar === '{' && $parenDepth === 0) {
+                            break;
+                        }
+
                         if ($scanChar === ';' && $parenDepth === 0) {
                             break;
                         }
@@ -703,8 +707,13 @@ final class CssSanitizer
                         $scan++;
                     }
 
+                    if (!$hasSemicolon) {
+                        $index++;
+                        continue;
+                    }
+
                     $ruleEnd = $scan;
-                    $bodyEnd = $hasSemicolon ? $ruleEnd - 1 : $ruleEnd;
+                    $bodyEnd = $ruleEnd - 1;
                     $body = substr($css, $bodyStart, $bodyEnd - $bodyStart);
 
                     $sanitizedRule = self::sanitizeImportBody($body);

--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -258,4 +258,13 @@ assertSameResult(
     'Custom property values containing @import should remain untouched by the import sanitizer.'
 );
 
+$cssWithDanglingImport = '@import url("https://example.com/style.css")' . PHP_EOL . 'body { color: red; }';
+$sanitizedDanglingImport = CssSanitizer::sanitize($cssWithDanglingImport);
+
+assertSameResult(
+    '@import url("https://example.com/style.css")' . PHP_EOL . 'body {color:red}',
+    $sanitizedDanglingImport,
+    'Body rules following an @import without semicolon should remain intact after sanitation.'
+);
+
 echo "All CssSanitizer tests passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- guard the @import scanner against encountering structural blocks when no terminating semicolon is present
- skip sanitizing import rules without semicolons while keeping subsequent CSS rules intact
- add regression coverage ensuring body blocks survive sanitation when preceded by an unterminated @import

## Testing
- php tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d27360efbc832ea67cdfaf300d5525