### PR TITLE
Handle rejected URL tokens without leaving stray commas

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
@@ -954,12 +954,24 @@ final class CssSanitizer
 
                 if ($sanitizedToken !== '') {
                     $result .= $sanitizedToken;
+                    $offset = $cursor + 1;
                 } else {
                     $result = rtrim($result);
                     $result = preg_replace('/,\s*$/', '', $result);
+
+                    $offset = $cursor + 1;
+                    while ($offset < $length && ctype_space($css[$offset])) {
+                        $offset++;
+                    }
+
+                    if ($offset < $length && $css[$offset] === ',') {
+                        $offset++;
+                        while ($offset < $length && ctype_space($css[$offset])) {
+                            $offset++;
+                        }
+                    }
                 }
 
-                $offset = $cursor + 1;
                 $index = $offset;
                 $escaped = false;
                 continue;

--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -104,6 +104,17 @@ assertSameResult(
 assertNotContains('javascript', $sanitizedFontFace, 'Dangerous javascript URLs should be stripped from font-face declarations.');
 assertNotContains(',;', $sanitizedFontFace, 'Sanitized font-face declarations should not contain trailing comma-semicolon sequences.');
 
+$multiBackgroundCss = "body { background-image: url('javascript:alert(1)'), url('https://example.com/safe.png'), url('data:image/png;base64,AAAA'); }";
+$sanitizedMultiBackground = CssSanitizer::sanitize($multiBackgroundCss);
+
+assertSameResult(
+    "body {background-image:url('https://example.com/safe.png'), url('data:image/png;base64,AAAA')}",
+    $sanitizedMultiBackground,
+    'Background images with multiple URLs should drop rejected entries without leaving stray commas.'
+);
+
+assertNotContains('javascript:alert(1)', $sanitizedMultiBackground, 'Rejected background-image URLs should not remain in the sanitized output.');
+
 $mediaCss = '@media screen and (min-width: 600px) { .foo { color: red; behavior: url(http://evil); } }';
 $sanitizedMedia = CssSanitizer::sanitize($mediaCss);
 


### PR DESCRIPTION
## Summary
- ensure rejected url() tokens consume trailing commas and whitespace before resuming copy
- add coverage for background-image lists with a rejected entry to guard against stray separators

## Testing
- php supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d2f296a45c832e89e7ba77c46bc177