### PR TITLE
Avoid redundant token CSS regeneration and validate segments

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -191,18 +191,28 @@ final class Routes {
                 'mobile' => ['param' => 'css_mobile', 'option' => 'ssc_css_mobile'],
             ];
 
+            $pendingUpdates = [];
+
             foreach ($segments_config as $key => $config) {
                 $raw_value = $request->get_param($config['param']);
                 if ($raw_value !== null) {
                     $segment_payload = true;
+                    if (!is_string($raw_value)) {
+                        return new \WP_REST_Response(['ok' => false, 'message' => 'Invalid CSS segment.'], 400);
+                    }
+
                     $sanitized_value = $this->sanitizeCssSegment($raw_value);
-                    update_option($config['option'], $sanitized_value, false);
+                    $pendingUpdates[$config['option']] = $sanitized_value;
                     $sanitized_segments[$key] = $sanitized_value;
                 } else {
                     $existing_value = get_option($config['option'], '');
                     $existing_value = is_string($existing_value) ? $existing_value : '';
                     $sanitized_segments[$key] = CssSanitizer::sanitize($existing_value);
                 }
+            }
+
+            foreach ($pendingUpdates as $option => $value) {
+                update_option($option, $value, false);
             }
         }
 

--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -37,10 +37,22 @@ final class TokenRegistry
 
         if ($stored !== self::REGISTRY_NOT_FOUND && is_array($stored)) {
             $normalized = self::normalizeRegistry($stored);
+            $shouldPersistCss = false;
+
             if ($stored !== $normalized) {
                 update_option(self::OPTION_REGISTRY, $normalized, false);
+                $shouldPersistCss = true;
             }
-            self::persistCss($normalized);
+
+            $existingCss = get_option(self::OPTION_CSS, null);
+            if (!is_string($existingCss) || trim($existingCss) === '') {
+                $shouldPersistCss = true;
+            }
+
+            if ($shouldPersistCss) {
+                self::persistCss($normalized);
+            }
+
             return $normalized;
         }
 
@@ -91,7 +103,12 @@ final class TokenRegistry
     public static function saveRegistry(array $tokens): array
     {
         $normalized = self::normalizeRegistry($tokens);
-        update_option(self::OPTION_REGISTRY, $normalized, false);
+
+        $stored = get_option(self::OPTION_REGISTRY, null);
+        if (!is_array($stored) || $stored !== $normalized) {
+            update_option(self::OPTION_REGISTRY, $normalized, false);
+        }
+
         self::persistCss($normalized);
 
         return $normalized;


### PR DESCRIPTION
## Summary
- avoid regenerating token CSS on every registry read by persisting only when needed
- ensure responsive CSS segments are validated before updating options

## Testing
- `php -l supersede-css-jlg-enhanced/src/Support/TokenRegistry.php`
- `php -l supersede-css-jlg-enhanced/src/Infra/Routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68d3c5119d9c832e8abab153d5e2ff3f