### PR TITLE
Ensure default avatar URL handles missing trailing slash

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
+++ b/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
@@ -2,7 +2,11 @@
     let presets = {};
     let activePresetId = null;
     // **LA CORRECTION EST SUR LA LIGNE CI-DESSOUS**
-    let defaultAvatarUrl = typeof SSC !== 'undefined' ? SSC.pluginUrl + 'assets/images/placeholder-avatar.png' : '';
+    let defaultAvatarUrl = '';
+    if (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string') {
+        const pluginUrl = SSC.pluginUrl.endsWith('/') ? SSC.pluginUrl : SSC.pluginUrl + '/';
+        defaultAvatarUrl = pluginUrl + 'assets/images/placeholder-avatar.png';
+    }
     let currentAvatarUrl = defaultAvatarUrl;
 
     // Charger les presets depuis la base de données


### PR DESCRIPTION
## Summary
- guard against undefined SSC globals when building the avatar placeholder URL
- normalize the plugin URL to always include a trailing slash before appending the image path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e649870c832eb2a630c7dfd00b8d