### PR TITLE
Derive avatar placeholder from preview element

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
+++ b/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
@@ -2,7 +2,21 @@
     let presets = {};
     let activePresetId = null;
     // **LA CORRECTION EST SUR LA LIGNE CI-DESSOUS**
-    let defaultAvatarUrl = typeof SSC !== 'undefined' ? SSC.pluginUrl + 'assets/images/placeholder-avatar.png' : '';
+    const ensureTrailingSlash = (url) => url.endsWith('/') ? url : url + '/';
+    function resolveDefaultAvatarUrl() {
+        const previewImg = document.getElementById('ssc-glow-preview-img');
+        if (previewImg && previewImg.getAttribute('src')) {
+            return previewImg.getAttribute('src');
+        }
+
+        if (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string' && SSC.pluginUrl.length) {
+            return ensureTrailingSlash(SSC.pluginUrl) + 'assets/images/placeholder-avatar.png';
+        }
+
+        return '';
+    }
+
+    const defaultAvatarUrl = resolveDefaultAvatarUrl();
     let currentAvatarUrl = defaultAvatarUrl;
 
     // Charger les presets depuis la base de données


### PR DESCRIPTION
## Summary
- read the default avatar URL from the rendered preview image when available
- fall back to a normalized plugin URL when the preview markup is unavailable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3e649870c832eb2a630c7dfd00b8d