### PR TITLE
Normalize plugin asset URL handling

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
+++ b/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
@@ -1,30 +1,10 @@
 (function($) {
     let presets = {};
     let activePresetId = null;
-    const buildPluginAssetUrl = (baseUrl, assetPath) => {
-        if (typeof baseUrl !== 'string' || !baseUrl.length) {
-            return '';
-        }
-
-        const normalizedBase = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
-        const normalizedAsset = typeof assetPath === 'string' ? assetPath.replace(/^\//, '') : '';
-
-        return normalizedBase + normalizedAsset;
-    };
-    function resolveDefaultAvatarUrl() {
-        const previewImg = document.getElementById('ssc-glow-preview-img');
-        if (previewImg && previewImg.getAttribute('src')) {
-            return previewImg.getAttribute('src');
-        }
-
-        if (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string') {
-            return buildPluginAssetUrl(SSC.pluginUrl, 'assets/images/placeholder-avatar.png');
-        }
-
-        return '';
-    }
-
-    const defaultAvatarUrl = resolveDefaultAvatarUrl();
+    const pluginUrl = (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string')
+        ? SSC.pluginUrl.replace(/\/?$/, '/')
+        : '';
+    const defaultAvatarUrl = pluginUrl ? pluginUrl + 'assets/images/placeholder-avatar.png' : '';
     let currentAvatarUrl = defaultAvatarUrl;
 
     // Charger les presets depuis la base de données

--- a/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
+++ b/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
@@ -1,8 +1,30 @@
 (function($) {
     let presets = {};
     let activePresetId = null;
-    // **LA CORRECTION EST SUR LA LIGNE CI-DESSOUS**
-    let defaultAvatarUrl = typeof SSC !== 'undefined' ? SSC.pluginUrl + 'assets/images/placeholder-avatar.png' : '';
+    const buildPluginAssetUrl = (baseUrl, assetPath) => {
+        if (typeof baseUrl !== 'string' || !baseUrl.length) {
+            return '';
+        }
+
+        const normalizedBase = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+        const normalizedAsset = typeof assetPath === 'string' ? assetPath.replace(/^\//, '') : '';
+
+        return normalizedBase + normalizedAsset;
+    };
+    function resolveDefaultAvatarUrl() {
+        const previewImg = document.getElementById('ssc-glow-preview-img');
+        if (previewImg && previewImg.getAttribute('src')) {
+            return previewImg.getAttribute('src');
+        }
+
+        if (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string') {
+            return buildPluginAssetUrl(SSC.pluginUrl, 'assets/images/placeholder-avatar.png');
+        }
+
+        return '';
+    }
+
+    const defaultAvatarUrl = resolveDefaultAvatarUrl();
     let currentAvatarUrl = defaultAvatarUrl;
 
     // Charger les presets depuis la base de données


### PR DESCRIPTION
## Summary
- replace the inline trailing-slash hack with a reusable helper for joining plugin asset URLs
- guard the fallback placeholder resolution so it only attempts to join valid strings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3e649870c832eb2a630c7dfd00b8d