### PR TITLE
Normalize plugin asset URLs for avatar fallback

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
+++ b/supersede-css-jlg-enhanced/assets/js/effects-avatar.js
@@ -1,11 +1,14 @@
 (function($) {
     let presets = {};
     let activePresetId = null;
-    // **LA CORRECTION EST SUR LA LIGNE CI-DESSOUS**
+    const placeholderAssetPath = 'assets/images/placeholder-avatar.png';
     let defaultAvatarUrl = '';
-    if (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string') {
+
+    if (typeof window.sscPluginAssetUrl === 'function') {
+        defaultAvatarUrl = window.sscPluginAssetUrl(placeholderAssetPath);
+    } else if (typeof SSC !== 'undefined' && SSC && typeof SSC.pluginUrl === 'string') {
         const pluginUrl = SSC.pluginUrl.endsWith('/') ? SSC.pluginUrl : SSC.pluginUrl + '/';
-        defaultAvatarUrl = pluginUrl + 'assets/images/placeholder-avatar.png';
+        defaultAvatarUrl = pluginUrl + placeholderAssetPath;
     }
     let currentAvatarUrl = defaultAvatarUrl;
 

--- a/supersede-css-jlg-enhanced/assets/js/ux.js
+++ b/supersede-css-jlg-enhanced/assets/js/ux.js
@@ -7,6 +7,22 @@
         setTimeout(() => toast.remove(), 3000);
     };
 
+    // --- Plugin Asset URL Helper ---
+    window.sscPluginAssetUrl = function(relativePath) {
+        if (typeof relativePath !== 'string' || relativePath.trim() === '') {
+            return '';
+        }
+
+        const sanitizedPath = relativePath.replace(/^\/+/, '');
+
+        if (typeof SSC === 'undefined' || !SSC || typeof SSC.pluginUrl !== 'string') {
+            return sanitizedPath;
+        }
+
+        const baseUrl = SSC.pluginUrl.endsWith('/') ? SSC.pluginUrl : SSC.pluginUrl + '/';
+        return baseUrl + sanitizedPath;
+    };
+
     // --- Clipboard Helper ---
     window.sscCopyToClipboard = function(text, {
         successMessage = 'Texte copié !',


### PR DESCRIPTION
## Summary
- add a shared helper to build plugin-relative asset URLs with normalized slashes
- reuse the helper when generating the default avatar fallback path in the avatar glow editor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3f561d064832e9d6bbe9a42692d91