### PR TITLE
Improve CSS sanitizer URL parsing and performance

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -985,7 +985,7 @@ final class Routes {
             return $part !== '';
         }));
 
-        return $combined === '' ? '' : CssSanitizer::sanitize($combined);
+        return $combined === '' ? '' : trim($combined);
     }
 
     /**

--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -225,9 +225,21 @@ assertSameResult(
 );
 
 assertSameResult(
+    'background:url("https://example.com/image.png")',
+    $sanitizeUrls->invoke(null, 'background:url ( "https://example.com/image.png" )'),
+    'URL sanitizer should allow insignificant whitespace between the keyword and the opening parenthesis.'
+);
+
+assertSameResult(
     'background:)',
     $sanitizeUrls->invoke(null, 'background: url(javascript:alert(1))'),
     'Dangerous url() tokens should keep being stripped.'
+);
+
+assertSameResult(
+    'background:',
+    $sanitizeUrls->invoke(null, "background:url ( '\\6a\\61\\76\\61\\73\\63\\72\\69\\70\\74:alert(1)' )"),
+    'Whitespace before the url parenthesis should not allow escaped dangerous protocols.'
 );
 
 assertSameResult(


### PR DESCRIPTION
## Summary
- reuse the structural sanitizer pipeline for nested CSS blocks and cache normalized property values to avoid repeated stripping and URL scans
- allow optional whitespace between `url` and `(` while still rejecting dangerous tokens
- stop re-sanitizing responsive CSS when combining segments and extend the CssSanitizer tests to cover the new URL handling

## Testing
- php tests/Support/CssSanitizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d4169c6574832eb2455ec8b557df25