### PR TITLE
Fix behavior stripping and defer token registry persistence

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -692,6 +692,17 @@ final class Routes {
                 continue;
             }
 
+            if ($optionName === 'ssc_tokens_registry') {
+                if (!is_array($sanitizedValue)) {
+                    $skipped[] = $optionName;
+                    continue;
+                }
+
+                TokenRegistry::saveRegistry($sanitizedValue);
+                $applied[] = $optionName;
+                continue;
+            }
+
             update_option($optionName, $sanitizedValue, false);
             $applied[] = $optionName;
         }
@@ -724,7 +735,7 @@ final class Routes {
             return null;
         }
 
-        return TokenRegistry::saveRegistry($value);
+        return TokenRegistry::normalizeRegistry($value);
     }
 
     /**

--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -92,6 +92,15 @@ assertSameResult(
 
 assertNotContains('behavior', $sanitizedWithDoubleBrace, 'Behavior property should not survive in the sanitized CSS.');
 
+$customPropertyWithScrollBehavior = ':root { --snippet: scroll-behavior: smooth; color: red; }';
+$sanitizedCustomProperty = CssSanitizer::sanitize($customPropertyWithScrollBehavior);
+
+if (preg_match('/scroll-behavior:\s*smooth/', $sanitizedCustomProperty) !== 1) {
+    fwrite(STDERR, 'Custom property snippets should preserve scroll-behavior declarations.' . PHP_EOL);
+    fwrite(STDERR, 'Sanitized CSS: ' . $sanitizedCustomProperty . PHP_EOL);
+    exit(1);
+}
+
 $fontFaceCss = "@font-face { font-family: 'Custom'; src: url('https://example.com/font.woff2') format('woff2'), url('data:font/woff2;base64,AAAA'), url('javascript:alert(1)'); font-display: swap; unicode-range: U+000-5FF; }";
 $sanitizedFontFace = CssSanitizer::sanitize($fontFaceCss);
 


### PR DESCRIPTION
## Summary
- update custom property sanitization to ignore scroll-behavior snippets while still dropping legacy behavior declarations
- defer token registry persistence until options are actually applied and add coverage for the new import flow
- extend test doubles and assertions to capture the new scenarios

## Testing
- php supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d42f339ea8832eb71616c76fbb4f55