### PR TITLE
Add CSS cache invalidation and improve i18n

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -17,98 +17,106 @@ final class Admin
     }
 
     public function menu(): void {
-        add_menu_page('Supersede CSS', 'Supersede CSS', $this->cap, $this->slug, [$this, 'renderDashboard'], 'dashicons-art', 58);
+        add_menu_page(
+            __('Supersede CSS', 'supersede-css-jlg'),
+            __('Supersede CSS', 'supersede-css-jlg'),
+            $this->cap,
+            $this->slug,
+            [$this, 'renderDashboard'],
+            'dashicons-art',
+            58
+        );
         
         // Tous les modules sont déclarés ici pour simplifier la maintenance.
         $modules = [
             [
                 'slug'   => 'layout-builder',
-                'label'  => 'Maquettage de Page',
+                'label'  => __('Maquettage de Page', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\PageLayoutBuilder',
             ],
             [
                 'slug'   => 'utilities',
-                'label'  => 'Utilities',
+                'label'  => __('Utilities', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\Utilities',
             ],
             [
                 'slug'   => 'tokens',
-                'label'  => 'Tokens Manager',
+                'label'  => __('Tokens Manager', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\Tokens',
             ],
             [
                 'slug'   => 'effects',
-                'label'  => 'Effets Visuels',
+                'label'  => __('Effets Visuels', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\VisualEffects',
             ],
             [
                 'slug'   => 'filters',
-                'label'  => 'Filtres & Verre',
+                'label'  => __('Filtres & Verre', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\FilterEditor',
             ],
             [
                 'slug'   => 'clip-path',
-                'label'  => 'Découpe (Clip-Path)',
+                'label'  => __('Découpe (Clip-Path)', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\ClipPathEditor',
             ],
             [
                 'slug'   => 'typography',
-                'label'  => 'Typographie Fluide',
+                'label'  => __('Typographie Fluide', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\TypographyEditor',
             ],
             [
                 'slug'   => 'tron',
-                'label'  => 'Tron Grid',
+                'label'  => __('Tron Grid', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\TronGrid',
             ],
             [
                 'slug'   => 'avatar',
-                'label'  => 'Avatar Glow',
+                'label'  => __('Avatar Glow', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\AvatarGlow',
             ],
             [
                 'slug'   => 'anim',
-                'label'  => 'Animation Studio',
+                'label'  => __('Animation Studio', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\AnimationStudio',
             ],
             [
                 'slug'   => 'grid',
-                'label'  => 'Grid Editor',
+                'label'  => __('Grid Editor', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\GridEditor',
             ],
             [
                 'slug'   => 'shadow',
-                'label'  => 'Shadow Editor',
+                'label'  => __('Shadow Editor', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\ShadowEditor',
             ],
             [
                 'slug'   => 'gradient',
-                'label'  => 'Gradient Editor',
+                'label'  => __('Gradient Editor', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\GradientEditor',
             ],
             [
                 'slug'   => 'scope',
-                'label'  => 'Scope Builder',
+                'label'  => __('Scope Builder', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\ScopeBuilder',
             ],
             [
                 'slug'   => 'preset',
-                'label'  => 'Preset Designer',
+                'label'  => __('Preset Designer', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\PresetDesigner',
             ],
             [
                 'slug'   => 'import',
-                'label'  => 'Import / Export',
+                'label'  => __('Import / Export', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\ImportExport',
             ],
             [
                 'slug'   => 'css-viewer',
-                'label'  => 'Visualiseur CSS',
+                'label'  => __('Visualiseur CSS', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\CssViewer',
             ],
             [
                 'slug'   => 'debug-center',
-                'label'  => 'Debug Center',
+                'label'  => __('Debug Center', 'supersede-css-jlg'),
                 'class'  => '\\SSC\\Admin\\Pages\\DebugCenter',
             ],
         ];
@@ -126,11 +134,24 @@ final class Admin
         add_submenu_page($this->slug, $label, $label, $this->cap, $slug, function () use ($fqcn, $label, $slug): void {
             ob_start();
             try {
-                if (class_exists($fqcn)) { (new $fqcn())->render(); }
-                else { echo '<div class="notice notice-error"><p>Erreur : La classe pour le module <strong>' . esc_html($label) . '</strong> est introuvable.</p></div>'; }
+                if (class_exists($fqcn)) {
+                    (new $fqcn())->render();
+                } else {
+                    $message = sprintf(
+                        /* translators: %s: Supersede CSS module label. */
+                        __('Error: The class for the "%s" module could not be found.', 'supersede-css-jlg'),
+                        $label
+                    );
+                    echo '<div class="notice notice-error"><p>' . esc_html($message) . '</p></div>';
+                }
             } catch (\Throwable $e) {
                 if (class_exists('\SSC\Infra\Logger')) { \SSC\Infra\Logger::add('render_error', ['module' => $label, 'error' => $e->getMessage()]); }
-                echo '<div class="notice notice-error"><p><strong>Supersede CSS:</strong> Le module <em>' . esc_html($label) . '</em> a échoué.</p></div>';
+                $error_message = sprintf(
+                    /* translators: %s: Supersede CSS module label. */
+                    __('Supersede CSS: The "%s" module failed to render.', 'supersede-css-jlg'),
+                    $label
+                );
+                echo '<div class="notice notice-error"><p>' . esc_html($error_message) . '</p></div>';
                 if (defined('WP_DEBUG') && WP_DEBUG) { echo '<pre>' . esc_html($e->getMessage() . "\n" . $e->getTraceAsString()) . '</pre>'; }
             }
             $page_content = ob_get_clean();

--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -111,6 +111,10 @@ final class TokenRegistry
 
         self::persistCss($normalized);
 
+        if (function_exists('\ssc_invalidate_css_cache')) {
+            \ssc_invalidate_css_cache();
+        }
+
         return $normalized;
     }
 

--- a/supersede-css-jlg-enhanced/views/debug-center.php
+++ b/supersede-css-jlg-enhanced/views/debug-center.php
@@ -16,34 +16,56 @@ $php_version       = $system_info['php_version'] ?? '';
         <div class="ssc-pane">
             <h2><?php echo esc_html__('Informations Système', 'supersede-css-jlg'); ?></h2>
             <table class="widefat striped" style="margin: 0;"><tbody>
-                <tr><td><strong>Version du Plugin</strong></td><td><?php echo esc_html($plugin_version); ?></td></tr>
-                <tr><td><strong>Version WordPress</strong></td><td><?php echo esc_html($wordpress_version); ?></td></tr>
-                <tr><td><strong>Version PHP</strong></td><td><?php echo esc_html($php_version); ?></td></tr>
+                <tr>
+                    <td><strong><?php esc_html_e('Version du Plugin', 'supersede-css-jlg'); ?></strong></td>
+                    <td><?php echo esc_html($plugin_version); ?></td>
+                </tr>
+                <tr>
+                    <td><strong><?php esc_html_e('Version WordPress', 'supersede-css-jlg'); ?></strong></td>
+                    <td><?php echo esc_html($wordpress_version); ?></td>
+                </tr>
+                <tr>
+                    <td><strong><?php esc_html_e('Version PHP', 'supersede-css-jlg'); ?></strong></td>
+                    <td><?php echo esc_html($php_version); ?></td>
+                </tr>
             </tbody></table>
         </div>
         <div class="ssc-pane">
             <h2><?php echo esc_html__('Actions Globales', 'supersede-css-jlg'); ?></h2>
             <div class="ssc-actions">
-                <button class="button button-primary" id="ssc-health-run">Lancer Health Check</button>
+                <button class="button button-primary" id="ssc-health-run"><?php esc_html_e('Lancer Health Check', 'supersede-css-jlg'); ?></button>
             </div>
             <pre id="ssc-health-json" class="ssc-code" style="max-height:120px; margin-top:10px;"></pre>
         </div>
     </div>
 
     <div class="ssc-panel ssc-danger-zone" style="margin-top: 16px;">
-         <h2>🛑 Zone de Danger</h2>
-         <p id="ssc-danger-intro">Les actions ci-dessous sont irréversibles. Soyez certain de vouloir continuer.</p>
-         <button id="ssc-reset-all-css" class="button" style="background: #dc2626; border-color: #991b1b; color: white;">Réinitialiser tout le CSS</button>
-         <p id="ssc-danger-desc" class="description">Cette action videra les options <code>ssc_active_css</code> et <code>ssc_tokens_css</code> de votre base de données, désactivant tous les styles ajoutés par Supersede.</p>
+         <h2><?php echo esc_html__('🛑 Zone de Danger', 'supersede-css-jlg'); ?></h2>
+         <p id="ssc-danger-intro"><?php echo esc_html__('Les actions ci-dessous sont irréversibles. Soyez certain de vouloir continuer.', 'supersede-css-jlg'); ?></p>
+         <button id="ssc-reset-all-css" class="button" style="background: #dc2626; border-color: #991b1b; color: white;"><?php esc_html_e('Réinitialiser tout le CSS', 'supersede-css-jlg'); ?></button>
+         <?php
+         $danger_desc = sprintf(
+             /* translators: 1: Supersede CSS option name, 2: Supersede CSS option name. */
+             __('Cette action videra les options %1$s et %2$s de votre base de données, désactivant tous les styles ajoutés par Supersede.', 'supersede-css-jlg'),
+             '<code>ssc_active_css</code>',
+             '<code>ssc_tokens_css</code>'
+         );
+         ?>
+         <p id="ssc-danger-desc" class="description"><?php echo wp_kses_post($danger_desc); ?></p>
     </div>
 
     <div class="ssc-panel" style="margin-top: 16px;">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
             <h2><?php echo esc_html__('Journal d\'Activité Récent', 'supersede-css-jlg'); ?></h2>
-            <button id="ssc-clear-log" class="button button-link-delete">Vider le journal</button>
+            <button id="ssc-clear-log" class="button button-link-delete"><?php esc_html_e('Vider le journal', 'supersede-css-jlg'); ?></button>
         </div>
         <?php if (!empty($log_entries)) : ?>
-            <table class="widefat striped"><thead><tr><th>Date (UTC)</th><th>Utilisateur</th><th>Action</th><th>Données</th></tr></thead><tbody>
+            <table class="widefat striped"><thead><tr>
+                <th><?php esc_html_e('Date (UTC)', 'supersede-css-jlg'); ?></th>
+                <th><?php esc_html_e('Utilisateur', 'supersede-css-jlg'); ?></th>
+                <th><?php esc_html_e('Action', 'supersede-css-jlg'); ?></th>
+                <th><?php esc_html_e('Données', 'supersede-css-jlg'); ?></th>
+            </tr></thead><tbody>
                 <?php foreach ($log_entries as $row) : ?>
                     <tr>
                         <td><?php echo esc_html($row['t'] ?? ''); ?></td>
@@ -54,7 +76,7 @@ $php_version       = $system_info['php_version'] ?? '';
                 <?php endforeach; ?>
             </tbody></table>
         <?php else : ?>
-            <p>Aucune entrée dans le journal.</p>
+            <p><?php esc_html_e('Aucune entrée dans le journal.', 'supersede-css-jlg'); ?></p>
         <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- cache the sanitized CSS once and serve it from a dedicated option on the frontend
- invalidate the cached CSS whenever REST updates, imports or token registry saves modify Supersede styles
- wrap admin menu labels and Debug Center strings with translation helpers for localization and sanitize nested import keys

## Testing
- php -l supersede-css-jlg-enhanced/supersede-css-jlg.php
- php -l supersede-css-jlg-enhanced/src/Admin/Admin.php
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php
- php -l supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
- php -l supersede-css-jlg-enhanced/views/debug-center.php

------
https://chatgpt.com/codex/tasks/task_e_68d44c1d8040832e8e4065300767afd8