### PR TITLE
Guard sanitize import utf8 helper and stub in tests

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -933,7 +933,9 @@ final class Routes {
 
     private function sanitizeImportStringValue(string $value): string
     {
-        $value = wp_check_invalid_utf8($value);
+        if (function_exists('wp_check_invalid_utf8')) {
+            $value = wp_check_invalid_utf8($value);
+        }
 
         if ($value === false) {
             return '';

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesExportFilterTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesExportFilterTest.php
@@ -106,6 +106,13 @@ if (!function_exists('sanitize_text_field')) {
     }
 }
 
+if (!function_exists('wp_check_invalid_utf8')) {
+    function wp_check_invalid_utf8($string)
+    {
+        return is_string($string) ? $string : '';
+    }
+}
+
 if (!function_exists('__')) {
     function __(string $text, string $domain = ''): string
     {
@@ -123,6 +130,15 @@ if (!function_exists('maybe_unserialize')) {
 if (!function_exists('wp_kses_post')) {
     function wp_kses_post($value)
     {
+        return is_string($value) ? strip_tags($value) : $value;
+    }
+}
+
+if (!function_exists('wp_kses')) {
+    function wp_kses($value, $allowed_html = [])
+    {
+        unset($allowed_html);
+
         return is_string($value) ? strip_tags($value) : $value;
     }
 }


### PR DESCRIPTION
## Summary
- avoid calling wp_check_invalid_utf8() when it is not available so imports still sanitize strings in test environments
- provide lightweight stubs for wp_check_invalid_utf8() and wp_kses() in the export filter test harness to mirror WordPress helpers

## Testing
- php tests/Support/CssSanitizerTest.php
- php tests/Infra/RoutesAuthorizationTest.php
- php tests/Infra/RoutesExportFilterTest.php
- php tests/Infra/RoutesImportTest.php
- php tests/Infra/RoutesSaveCssTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d50aa4d9ec832e96ad44e594fd5d27