### PR TITLE
Strip comments before sanitizing @import bodies

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -309,6 +309,12 @@ assertSameResult(
 );
 
 assertSameResult(
+    '@import url("https://example.com/style.css");',
+    $sanitizeImports->invoke(null, '@import/*comment*/ url("https://example.com/style.css");'),
+    'CSS comments adjacent to @import should be stripped before sanitization.'
+);
+
+assertSameResult(
     'content: "@import url(foo)"',
     $sanitizeImports->invoke(null, 'content: "@import url(foo)"'),
     'Literal strings containing @import should remain untouched by the import sanitizer.'


### PR DESCRIPTION
## Summary
- strip CSS comments from @import bodies before parsing URLs
- add a regression test covering comment-adjacent @import syntax

## Testing
- php supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
- for f in supersede-css-jlg-enhanced/tests/Infra/*.php; do php $f; done

------
https://chatgpt.com/codex/tasks/task_e_68d59079d514832e8acb9015cfa19f20