### PR TITLE
Preserve token casing in registry

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -150,7 +150,7 @@ final class TokenRegistry
             }
 
             $name = '--' . preg_replace('/[^a-z0-9\-]+/i', '-', ltrim($name, '-'));
-            $name = strtolower($name);
+            $normalizedKey = strtolower($name);
 
             $valueRaw = isset($token['value']) ? (string) $token['value'] : '';
             $value = trim(sanitize_textarea_field($valueRaw));
@@ -177,11 +177,11 @@ final class TokenRegistry
                 'group' => $group,
             ];
 
-            if (array_key_exists($name, $normalizedByName)) {
-                unset($normalizedByName[$name]);
+            if (array_key_exists($normalizedKey, $normalizedByName)) {
+                unset($normalizedByName[$normalizedKey]);
             }
 
-            $normalizedByName[$name] = $normalizedToken;
+            $normalizedByName[$normalizedKey] = $normalizedToken;
         }
 
         return array_values($normalizedByName);

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
@@ -382,7 +382,7 @@ if (!is_array($storedRegistryAfterDirectImport) || count($storedRegistryAfterDir
 
 $storedDirectToken = $storedRegistryAfterDirectImport[0];
 
-if ($storedDirectToken['name'] !== '--primary-color' || $storedDirectToken['value'] !== '#FFFFFF') {
+if ($storedDirectToken['name'] !== '--Primary-Color' || $storedDirectToken['value'] !== '#FFFFFF') {
     fwrite(STDERR, "Token registry imports should normalize token names and values." . PHP_EOL);
     exit(1);
 }

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+use SSC\Support\TokenRegistry;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value)
+    {
+        return trim(strip_tags((string) $value));
+    }
+}
+
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($value)
+    {
+        return trim(strip_tags((string) $value));
+    }
+}
+
+if (!function_exists('wp_kses')) {
+    function wp_kses(string $string, array $allowed_html = []): string
+    {
+        return strip_tags($string);
+    }
+}
+
+if (!function_exists('wp_kses_bad_protocol')) {
+    function wp_kses_bad_protocol(string $string, array $allowed_protocols): string
+    {
+        return $string;
+    }
+}
+
+if (!function_exists('wp_allowed_protocols')) {
+    function wp_allowed_protocols(): array
+    {
+        return ['http', 'https'];
+    }
+}
+
+/** @var array<string, mixed> $ssc_options_store */
+$ssc_options_store = [];
+
+global $ssc_options_store;
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false)
+    {
+        global $ssc_options_store;
+
+        return $ssc_options_store[$name] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value, $autoload = false)
+    {
+        global $ssc_options_store;
+
+        $ssc_options_store[$name] = $value;
+
+        return true;
+    }
+}
+
+require_once __DIR__ . '/../../src/Support/CssSanitizer.php';
+require_once __DIR__ . '/../../src/Support/TokenRegistry.php';
+
+$registry = TokenRegistry::saveRegistry([
+    [
+        'name' => '--BrandPrimary',
+        'value' => '#3366ff',
+        'type' => 'color',
+        'description' => 'Primary brand color.',
+        'group' => 'Brand',
+    ],
+]);
+
+if ($registry === [] || $registry[0]['name'] !== '--BrandPrimary') {
+    fwrite(STDERR, 'TokenRegistry::saveRegistry should preserve the original token casing.' . PHP_EOL);
+    exit(1);
+}
+
+if (!isset($ssc_options_store['ssc_tokens_css']) || !is_string($ssc_options_store['ssc_tokens_css'])) {
+    fwrite(STDERR, 'TokenRegistry::saveRegistry should persist CSS using the original token name.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos($ssc_options_store['ssc_tokens_css'], '--BrandPrimary') === false) {
+    fwrite(STDERR, 'Persisted CSS should contain the original token casing.' . PHP_EOL);
+    exit(1);
+}
+
+$roundTripRegistry = TokenRegistry::convertCssToRegistry($ssc_options_store['ssc_tokens_css']);
+
+if ($roundTripRegistry === [] || $roundTripRegistry[0]['name'] !== '--BrandPrimary') {
+    fwrite(STDERR, 'convertCssToRegistry should keep the original casing after import.' . PHP_EOL);
+    exit(1);
+}
+
+$regeneratedCss = TokenRegistry::tokensToCss($roundTripRegistry);
+
+if (strpos($regeneratedCss, '--BrandPrimary') === false) {
+    fwrite(STDERR, 'tokensToCss should keep the original casing when exporting.' . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- keep token names' original casing during registry normalization while still deduplicating on a lowercase key
- update import test expectations and add regression coverage for preserving casing through save/convert/export flows

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/RoutesAuthorizationTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesExportFilterTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesSaveCssTest.php
- php supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
- php supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d5c04f7830832eb7ace3a65a0a96e0