### PR TITLE
Preserve token casing in registry

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -139,18 +139,22 @@ final class TokenRegistry
                 continue;
             }
 
-            $name = isset($token['name']) ? (string) $token['name'] : '';
-            $name = trim($name);
-            if ($name === '') {
+            $rawName = isset($token['name']) ? (string) $token['name'] : '';
+            $rawName = trim($rawName);
+            if ($rawName === '') {
                 continue;
             }
 
-            if (strpos($name, '--') !== 0) {
-                $name = '--' . ltrim($name, '-');
+            if (strpos($rawName, '--') !== 0) {
+                $rawName = '--' . ltrim($rawName, '-');
             }
 
-            $name = '--' . preg_replace('/[^a-z0-9\-]+/i', '-', ltrim($name, '-'));
-            $normalizedKey = strtolower($name);
+            $normalizedName = '--' . preg_replace('/[^a-z0-9\-]+/i', '-', ltrim($rawName, '-'));
+            if ($normalizedName === '--') {
+                continue;
+            }
+
+            $normalizedKey = strtolower($normalizedName);
 
             $valueRaw = isset($token['value']) ? (string) $token['value'] : '';
             $value = trim(sanitize_textarea_field($valueRaw));
@@ -170,7 +174,7 @@ final class TokenRegistry
             }
 
             $normalizedToken = [
-                'name' => $name,
+                'name' => $normalizedName,
                 'value' => $value,
                 'type' => $type,
                 'description' => $description,

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -69,6 +69,21 @@ if (!function_exists('update_option')) {
 require_once __DIR__ . '/../../src/Support/CssSanitizer.php';
 require_once __DIR__ . '/../../src/Support/TokenRegistry.php';
 
+$normalized = TokenRegistry::normalizeRegistry([
+    [
+        'name' => '--BrandPrimary',
+        'value' => '#3366ff',
+        'type' => 'color',
+        'description' => 'Primary brand color.',
+        'group' => 'Brand',
+    ],
+]);
+
+if ($normalized === [] || $normalized[0]['name'] !== '--BrandPrimary') {
+    fwrite(STDERR, 'TokenRegistry::normalizeRegistry should preserve the original token casing.' . PHP_EOL);
+    exit(1);
+}
+
 $registry = TokenRegistry::saveRegistry([
     [
         'name' => '--BrandPrimary',


### PR DESCRIPTION
## Summary
- adjust token normalization to keep the cleaned original casing while deduplicating via a normalized key
- extend the TokenRegistry test coverage to ensure registry persistence, CSS export/import, and normalization keep token names case-sensitive

## Testing
- php tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d651088a14832ead52eeaa79a36d95