### PR TITLE
Add uninstall cleanup coverage for CSS cache option

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    define('WP_UNINSTALL_PLUGIN', true);
+}
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+/** @var list<string> $ssc_deleted_options */
+$ssc_deleted_options = [];
+
+if (!function_exists('delete_option')) {
+    function delete_option(string $option_name): void
+    {
+        global $ssc_deleted_options;
+
+        $ssc_deleted_options[] = $option_name;
+    }
+}
+
+if (!function_exists('is_multisite')) {
+    function is_multisite(): bool
+    {
+        return false;
+    }
+}
+
+require __DIR__ . '/../../uninstall.php';
+
+if (!function_exists('assertOptionDeleted')) {
+    function assertOptionDeleted(string $option_name, array $deleted_options): void
+    {
+        if (!in_array($option_name, $deleted_options, true)) {
+            fwrite(
+                STDERR,
+                sprintf(
+                    'Failed asserting that option "%s" was deleted. Deleted options: %s' . PHP_EOL,
+                    $option_name,
+                    implode(', ', $deleted_options)
+                )
+            );
+
+            exit(1);
+        }
+    }
+}
+
+assertOptionDeleted('ssc_css_cache', $ssc_deleted_options);

--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -18,6 +18,7 @@ $ssc_options_to_delete = [
     'ssc_css_desktop', // Ajouté
     'ssc_css_tablet', // Ajouté
     'ssc_css_mobile', // Ajouté
+    'ssc_css_cache', // Ajouté
     'ssc_avatar_glow_presets', // Ajouté
     'ssc_optimization_settings', // Ajouté
 ];


### PR DESCRIPTION
## Summary
- add the CSS cache option to the uninstall cleanup list
- add a regression test that ensures uninstall.php deletes the cached CSS option

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d65d7b0c54832eb3d0be4449f41036