### PR TITLE
Add Playwright UI test for token manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+supersede-css-jlg-enhanced/node_modules/
+playwright-report/
+supersede-css-jlg-enhanced/playwright-report/
+test-results/
+supersede-css-jlg-enhanced/test-results/
+.DS_Store

--- a/supersede-css-jlg-enhanced/manual-tests/README.md
+++ b/supersede-css-jlg-enhanced/manual-tests/README.md
@@ -1,0 +1,34 @@
+# Procédures de test
+
+Ce dossier regroupe les scénarios manuels (fichiers `*.md`) à rejouer avant une publication majeure. Les scénarios peuvent être exécutés dans l'ordre de votre choix en fonction des changements apportés.
+
+## Test UI automatisé
+
+Un test Playwright couvre désormais le gestionnaire de tokens (ajout, édition, suppression et mise à jour du CSS d'aperçu).
+
+1. Installer les dépendances JS (à effectuer une seule fois) :
+   ```bash
+   cd supersede-css-jlg-enhanced
+   npm install
+   npx playwright install
+   # Selon votre distribution, installez aussi les dépendances système :
+   npx playwright install-deps
+   ```
+2. Lancer le test UI :
+   ```bash
+   npm run test:ui
+   ```
+
+Le test s'exécute de manière isolée grâce au moquage des appels REST. Aucun site WordPress n'est requis.
+
+## Tests manuels disponibles
+
+- `advanced-properties.php`
+- `import-config.md`
+- `property-syntax.php`
+- `sanitize-declarations.php`
+- `sanitize-imports.php`
+- `sanitize-urls.php`
+- `uninstall-multisite.md`
+
+Consultez chaque fichier pour les prérequis et étapes détaillées.

--- a/supersede-css-jlg-enhanced/package-lock.json
+++ b/supersede-css-jlg-enhanced/package-lock.json
@@ -1,0 +1,86 @@
+{
+  "name": "supersede-css-jlg-enhanced",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "supersede-css-jlg-enhanced",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.45.0",
+        "jquery": "^3.7.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/supersede-css-jlg-enhanced/package.json
+++ b/supersede-css-jlg-enhanced/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "supersede-css-jlg-enhanced",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "test:ui": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0",
+    "jquery": "^3.7.1"
+  }
+}

--- a/supersede-css-jlg-enhanced/playwright.config.js
+++ b/supersede-css-jlg-enhanced/playwright.config.js
@@ -1,0 +1,20 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/ui',
+  timeout: 60000,
+  expect: {
+    timeout: 5000,
+  },
+  use: {
+    headless: true,
+    locale: 'en-US',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  reporter: [['list']],
+});

--- a/supersede-css-jlg-enhanced/tests/ui/tokens.spec.js
+++ b/supersede-css-jlg-enhanced/tests/ui/tokens.spec.js
@@ -1,0 +1,164 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const pluginRoot = path.resolve(__dirname, '..', '..');
+const restRoot = 'https://example.test/wp-json/ssc/v1/';
+
+function generateCss(tokens) {
+  if (!tokens.length) {
+    return ':root {\n}\n';
+  }
+  const lines = tokens.map((token) => `    ${token.name}: ${token.value};`);
+  return `:root {\n${lines.join('\n')}\n}`;
+}
+
+test.describe('Token manager admin UI', () => {
+  test('adds, edits and deletes tokens with live CSS preview updates', async ({ page }) => {
+    const jqueryPath = require.resolve('jquery/dist/jquery.min.js');
+    const tokensScriptPath = path.resolve(pluginRoot, 'assets/js/tokens.js');
+
+    let serverTokens = [
+      {
+        name: '--primary-color',
+        value: '#123456',
+        type: 'color',
+        description: 'Primary brand color',
+        group: 'Brand',
+      },
+    ];
+
+    await page.route(restRoot + 'tokens', async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            tokens: serverTokens,
+            css: generateCss(serverTokens),
+          }),
+        });
+        return;
+      }
+
+      if (request.method() === 'POST') {
+        const payload = request.postDataJSON() || {};
+        if (Array.isArray(payload.tokens)) {
+          serverTokens = payload.tokens;
+        }
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            tokens: serverTokens,
+            css: generateCss(serverTokens),
+          }),
+        });
+        return;
+      }
+
+      await route.fallback();
+    });
+
+    await page.addInitScript(({ restEndpoint }) => {
+      window.SSC = {
+        rest: {
+          root: restEndpoint,
+          nonce: 'ui-test-nonce',
+        },
+      };
+      window.SSC_TOKENS_DATA = {
+        tokens: [],
+        css: '',
+        types: {
+          color: { label: 'Colour', input: 'color' },
+          text: { label: 'Text', input: 'text' },
+        },
+        i18n: {
+          addToken: 'Add token',
+          emptyState: 'No tokens yet',
+          groupLabel: 'Group',
+          nameLabel: 'Name',
+          valueLabel: 'Value',
+          typeLabel: 'Type',
+          descriptionLabel: 'Description',
+          deleteLabel: 'Delete',
+          saveSuccess: 'Tokens saved',
+          saveError: 'Unable to save tokens',
+        },
+      };
+      window.sscToast = () => {};
+    }, { restEndpoint: restRoot });
+
+    await page.setContent(`
+      <html>
+        <head>
+          <meta charset="utf-8" />
+          <title>Tokens Admin Test</title>
+        </head>
+        <body>
+          <div class="ssc-app ssc-fullwidth">
+            <div class="ssc-token-toolbar">
+              <button id="ssc-token-add" class="button">Add token</button>
+            </div>
+            <div id="ssc-token-builder" class="ssc-token-builder" aria-live="polite"></div>
+            <textarea id="ssc-tokens" rows="10" class="large-text" readonly></textarea>
+            <div class="ssc-actions">
+              <button id="ssc-tokens-save" class="button button-primary">Save tokens</button>
+              <button id="ssc-tokens-copy" class="button">Copy CSS</button>
+            </div>
+            <style id="ssc-tokens-preview-style"></style>
+            <div id="ssc-tokens-preview"></div>
+          </div>
+        </body>
+      </html>
+    `, { waitUntil: 'domcontentloaded' });
+
+    const initialFetch = page.waitForResponse((response) =>
+      response.url() === restRoot + 'tokens' && response.request().method() === 'GET'
+    );
+
+    await page.addScriptTag({ path: jqueryPath });
+    await page.addScriptTag({ path: tokensScriptPath });
+    await initialFetch;
+
+    const builder = page.locator('#ssc-token-builder');
+    const rows = builder.locator('.ssc-token-row');
+    const previewStyle = page.locator('#ssc-tokens-preview-style');
+    const cssTextarea = page.locator('#ssc-tokens');
+
+    await expect(rows).toHaveCount(1);
+    await expect(previewStyle).toContainText('--primary-color: #123456;');
+
+    await page.locator('#ssc-token-add').click();
+    await expect(rows).toHaveCount(2);
+
+    const newRow = builder.locator('.ssc-token-row').last();
+    await newRow.locator('.token-name').fill('--secondary-color');
+    await newRow.locator('.token-value').fill('#ff0000');
+
+    await expect(previewStyle).toContainText('--secondary-color: #ff0000;');
+
+    const saveResponse = page.waitForResponse((response) =>
+      response.url() === restRoot + 'tokens' && response.request().method() === 'POST'
+    );
+    await page.locator('#ssc-tokens-save').click();
+    await saveResponse;
+    expect(serverTokens.length).toBe(2);
+
+    await newRow.locator('.token-value').fill('#00ff00');
+    await expect(previewStyle).toContainText('--secondary-color: #00ff00;');
+
+    await builder.locator('.ssc-token-row').last().locator('.token-delete').click();
+    await expect(rows).toHaveCount(1);
+    await expect(previewStyle).not.toContainText('--secondary-color');
+
+    const deleteSave = page.waitForResponse((response) =>
+      response.url() === restRoot + 'tokens' && response.request().method() === 'POST'
+    );
+    await page.locator('#ssc-tokens-save').click();
+    await deleteSave;
+
+    expect(serverTokens.length).toBe(1);
+    await expect(previewStyle).toContainText('--primary-color: #123456;');
+    await expect(cssTextarea).toHaveValue(/--primary-color: #123456;/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tooling and dependencies for running headless UI checks
- create a Playwright spec that mocks REST endpoints and exercises the tokens admin workflow
- document how to run the automated UI test alongside the existing manual test scripts

## Testing
- npm run test:ui *(fails: missing system dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66fc37d68832eb245e98e5f075a68