### PR TITLE
Fix sanitization of legacy responsive CSS segments

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -209,7 +209,16 @@ final class Routes {
                 } else {
                     $existing_value = get_option($config['option'], '');
                     $existing_value = is_string($existing_value) ? $existing_value : '';
-                    $sanitized_segments[$key] = CssSanitizer::sanitize($existing_value);
+                    $sanitized_value = CssSanitizer::sanitize($existing_value);
+                    $sanitized_segments[$key] = $sanitized_value;
+
+                    if ($sanitized_value !== $existing_value) {
+                        update_option($config['option'], $sanitized_value, false);
+
+                        if (function_exists('\\ssc_invalidate_css_cache')) {
+                            \ssc_invalidate_css_cache();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- persist sanitized responsive CSS when legacy segments are missing from save requests
- ensure cache invalidation runs during implicit responsive CSS rewrites
- extend RoutesSaveCssTest to cover legacy tablet CSS sanitization

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/RoutesSaveCssTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d6ac439d5c832e98451f6e2c3bd18b