### PR TITLE
Add translation support for utilities admin script

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -1,4 +1,6 @@
 (function($) {
+    const wpI18n = typeof window !== 'undefined' && window.wp && window.wp.i18n ? window.wp.i18n : { __: (text) => text };
+    const { __ } = wpI18n;
     let editors = {};
     let pickerActive = false;
     const editorViews = ['desktop', 'tablet', 'mobile'];
@@ -7,7 +9,7 @@
 
     function notifyCodeMirrorUnavailable() {
         if (codeMirrorWarningShown) return;
-        const message = "Éditeur enrichi indisponible : CodeMirror n'est pas chargé. Les champs texte classiques seront utilisés.";
+        const message = __("Éditeur enrichi indisponible : CodeMirror n'est pas chargé. Les champs texte classiques seront utilisés.", 'supersede-css-jlg');
         if (typeof window !== 'undefined' && typeof window.sscToast === 'function') {
             window.sscToast(message);
         } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
@@ -114,7 +116,7 @@
                     _wpnonce: SSC.rest.nonce
                 },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-            }).done(() => window.sscToast('CSS enregistré !'));
+            }).done(() => window.sscToast(__('CSS enregistré !', 'supersede-css-jlg')));
         });
 
         const pickerToggle = $('#ssc-element-picker-toggle');
@@ -175,7 +177,11 @@
                     }
                     pickerToggle.click();
                 });
-            } catch(e) { console.warn("Impossible d'accéder au contenu de l'iframe. Assurez-vous que l'URL chargée est sur le même domaine que votre page d'administration WordPress."); }
+            } catch(e) {
+                console.warn(
+                    __("Impossible d'accéder au contenu de l'iframe. Assurez-vous que l'URL chargée est sur le même domaine que votre page d'administration WordPress.", 'supersede-css-jlg')
+                );
+            }
         });
         
         $('#ssc-preview-load').on('click', function(e) {
@@ -184,7 +190,7 @@
 
             if (!rawValue) {
                 if (!e.isTrigger) {
-                    notifyInvalidUrl('Veuillez saisir une URL valide pour l\'aperçu.');
+                    notifyInvalidUrl(__('Veuillez saisir une URL valide pour l\'aperçu.', 'supersede-css-jlg'));
                     if (lastValidPreviewUrl) {
                         urlField.val(lastValidPreviewUrl);
                     }
@@ -197,7 +203,7 @@
                 parsedUrl = new URL(rawValue, window.location.origin);
             } catch (error) {
                 if (!e.isTrigger) {
-                    notifyInvalidUrl('URL invalide. Veuillez saisir une adresse commençant par http:// ou https://');
+                    notifyInvalidUrl(__('URL invalide. Veuillez saisir une adresse commençant par http:// ou https://', 'supersede-css-jlg'));
                     if (lastValidPreviewUrl) {
                         urlField.val(lastValidPreviewUrl);
                     }
@@ -207,7 +213,7 @@
 
             if (!/^https?:$/i.test(parsedUrl.protocol)) {
                 if (!e.isTrigger) {
-                    notifyInvalidUrl('Seules les URL http et https sont autorisées.');
+                    notifyInvalidUrl(__('Seules les URL http et https sont autorisées.', 'supersede-css-jlg'));
                     if (lastValidPreviewUrl) {
                         urlField.val(lastValidPreviewUrl);
                     }

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -233,7 +233,16 @@ final class Admin
             foreach ($scripts_by_page[$page] as $handle) {
                 $path = 'assets/js/' . $handle . '.js';
                 if (is_file(SSC_PLUGIN_DIR . $path)) {
-                    wp_enqueue_script('ssc-'.$handle, SSC_PLUGIN_URL.$path, ['jquery'], SSC_VERSION, true);
+                    $dependencies = ['jquery'];
+                    if ($handle === 'utilities') {
+                        $dependencies[] = 'wp-i18n';
+                    }
+
+                    wp_enqueue_script('ssc-'.$handle, SSC_PLUGIN_URL.$path, $dependencies, SSC_VERSION, true);
+
+                    if ($handle === 'utilities' && function_exists('wp_set_script_translations')) {
+                        wp_set_script_translations('ssc-utilities', 'supersede-css-jlg');
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- import `wp.i18n` in the utilities script and wrap admin notifications in translation calls
- ensure the utilities asset declares the `wp-i18n` dependency and registers script translations

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6b35782f0832ebb9feb0337097d94