### PR TITLE
Localize view templates

### DIFF
--- a/supersede-css-jlg-enhanced/views/animation-studio.php
+++ b/supersede-css-jlg-enhanced/views/animation-studio.php
@@ -4,31 +4,31 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>🎬 Animation Studio</h2>
-    <p>Choisissez un preset d'animation, personnalisez-le et appliquez-le à vos éléments.</p>
+    <h2><?php esc_html_e('🎬 Animation Studio', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e("Choisissez un preset d'animation, personnalisez-le et appliquez-le à vos éléments.", 'supersede-css-jlg'); ?></p>
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Paramètres de l'Animation</h3>
-            <label><strong>Preset d'animation</strong></label>
+            <h3><?php esc_html_e("Paramètres de l'Animation", 'supersede-css-jlg'); ?></h3>
+            <label><strong><?php esc_html_e("Preset d'animation", 'supersede-css-jlg'); ?></strong></label>
             <select id="ssc-anim-preset" class="regular-text">
-                <option value="bounce">Bounce (Rebond)</option>
-                <option value="pulse">Pulse (Pulsation)</option>
-                <option value="fade-in">Fade In (Apparition)</option>
-                <option value="slide-in-left">Slide In Left (Glisse depuis la gauche)</option>
+                <option value="bounce"><?php esc_html_e('Bounce (Rebond)', 'supersede-css-jlg'); ?></option>
+                <option value="pulse"><?php esc_html_e('Pulse (Pulsation)', 'supersede-css-jlg'); ?></option>
+                <option value="fade-in"><?php esc_html_e('Fade In (Apparition)', 'supersede-css-jlg'); ?></option>
+                <option value="slide-in-left"><?php esc_html_e('Slide In Left (Glisse depuis la gauche)', 'supersede-css-jlg'); ?></option>
             </select>
-            <label style="margin-top:16px; display:block;"><strong>Durée (secondes)</strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Durée (secondes)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-anim-duration" min="0.1" max="5" value="1.5" step="0.1">
             <span id="ssc-anim-duration-val">1.5s</span>
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                <button id="ssc-anim-apply" class="button button-primary">Appliquer</button>
-                <button id="ssc-anim-copy" class="button">Copier CSS</button>
+                <button id="ssc-anim-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-anim-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button>
             </div>
-            <h3 style="margin-top:24px;">Code CSS Généré</h3>
-            <p class="description">Appliquez la classe <code>.ssc-animated</code> et la classe du preset (ex: <code>.ssc-bounce</code>) à votre élément.</p>
+            <h3 style="margin-top:24px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
+            <p class="description"><?php echo wp_kses_post(__('Appliquez la classe <code>.ssc-animated</code> et la classe du preset (ex: <code>.ssc-bounce</code>) à votre élément.', 'supersede-css-jlg')); ?></p>
             <pre id="ssc-anim-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
-            <h3>Aperçu en Direct</h3>
+            <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
             <div id="ssc-anim-preview-container" style="display:grid; place-items:center; height:200px;">
                 <div id="ssc-anim-preview-box" style="width: 100px; height: 100px; background: var(--ssc-accent); border-radius: 12px;"></div>
             </div>

--- a/supersede-css-jlg-enhanced/views/avatar-glow.php
+++ b/supersede-css-jlg-enhanced/views/avatar-glow.php
@@ -5,59 +5,59 @@ if (!defined('ABSPATH')) {
 /** @var string $avatar_placeholder */
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>✨ Gestionnaire de Presets Avatar Glow</h2>
-    <p>Créez et gérez des effets d'aura réutilisables pour vos rédacteurs. Chaque preset aura son propre nom de classe.</p>
+    <h2><?php esc_html_e('✨ Gestionnaire de Presets Avatar Glow', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e("Créez et gérez des effets d'aura réutilisables pour vos rédacteurs. Chaque preset aura son propre nom de classe.", 'supersede-css-jlg'); ?></p>
 
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Éditeur de Presets</h3>
-            <label><strong>Preset Actif</strong></label>
+            <h3><?php esc_html_e('Éditeur de Presets', 'supersede-css-jlg'); ?></h3>
+            <label><strong><?php esc_html_e('Preset Actif', 'supersede-css-jlg'); ?></strong></label>
             <div class="ssc-actions">
                 <select id="ssc-glow-preset-select" class="regular-text" style="flex: 1;"></select>
-                <button id="ssc-glow-new-preset" class="button">Nouveau</button>
+                <button id="ssc-glow-new-preset" class="button"><?php esc_html_e('Nouveau', 'supersede-css-jlg'); ?></button>
             </div>
 
             <div id="ssc-glow-editor-fields">
                 <hr>
                 <div class="ssc-two">
-                    <div><label><strong>Nom du Preset</strong></label><input type="text" id="ssc-glow-preset-name" class="regular-text" placeholder="Aura Bleue Rapide"></div>
-                    <div><label><strong>Nom de la Classe CSS</strong></label><input type="text" id="ssc-glow-preset-class" class="regular-text" placeholder=".avatar-glow-blue"></div>
+                    <div><label><strong><?php esc_html_e('Nom du Preset', 'supersede-css-jlg'); ?></strong></label><input type="text" id="ssc-glow-preset-name" class="regular-text" placeholder="<?php echo esc_attr__('Aura Bleue Rapide', 'supersede-css-jlg'); ?>"></div>
+                    <div><label><strong><?php esc_html_e('Nom de la Classe CSS', 'supersede-css-jlg'); ?></strong></label><input type="text" id="ssc-glow-preset-class" class="regular-text" placeholder="<?php echo esc_attr__('.avatar-glow-blue', 'supersede-css-jlg'); ?>"></div>
                 </div>
-                <p class="description">Le nom de la classe doit être unique et commencer par un point (ex: <code>.glow-team-1</code>).</p>
+                <p class="description"><?php echo wp_kses_post(__('Le nom de la classe doit être unique et commencer par un point (ex: <code>.glow-team-1</code>).', 'supersede-css-jlg')); ?></p>
                 <hr>
 
-                <h4>Paramètres de l'Effet</h4>
-                <label><strong>Couleur du dégradé</strong></label>
+                <h4><?php esc_html_e("Paramètres de l'Effet", 'supersede-css-jlg'); ?></h4>
+                <label><strong><?php esc_html_e('Couleur du dégradé', 'supersede-css-jlg'); ?></strong></label>
                 <div class="ssc-actions">
-                    <span>Début :</span> <input type="color" id="ssc-glow-color1" value="#8b5cf6">
-                    <span>Fin :</span> <input type="color" id="ssc-glow-color2" value="#ec4899">
+                    <span><?php esc_html_e('Début :', 'supersede-css-jlg'); ?></span> <input type="color" id="ssc-glow-color1" value="#8b5cf6">
+                    <span><?php esc_html_e('Fin :', 'supersede-css-jlg'); ?></span> <input type="color" id="ssc-glow-color2" value="#ec4899">
                 </div>
-                <label style="margin-top:16px;"><strong>Vitesse (secondes)</strong></label>
+                <label style="margin-top:16px;"><strong><?php esc_html_e('Vitesse (secondes)', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-glow-speed" min="1" max="20" value="5" step="0.5">
                 <span id="ssc-glow-speed-val">5s</span>
-                <label style="margin-top:16px;"><strong>Épaisseur (pixels)</strong></label>
+                <label style="margin-top:16px;"><strong><?php esc_html_e('Épaisseur (pixels)', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-glow-thickness" min="2" max="12" value="4" step="1">
                 <span id="ssc-glow-thickness-val">4px</span>
             </div>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                <button id="ssc-glow-save-preset" class="button button-primary">Enregistrer ce Preset</button>
-                <button id="ssc-glow-apply" class="button">Appliquer sur le site</button>
-                <button id="ssc-glow-delete-preset" class="button button-link-delete" style="display: none;">Supprimer ce Preset</button>
+                <button id="ssc-glow-save-preset" class="button button-primary"><?php esc_html_e('Enregistrer ce Preset', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-glow-apply" class="button"><?php esc_html_e('Appliquer sur le site', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-glow-delete-preset" class="button button-link-delete" style="display: none;"><?php esc_html_e('Supprimer ce Preset', 'supersede-css-jlg'); ?></button>
             </div>
         </div>
 
         <div class="ssc-pane">
-            <h3>Aperçu en Direct</h3>
+            <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
             <div id="ssc-glow-preview-bg" style="display:grid; place-items:center; height:250px; background: #0b1020; border-radius: 12px; transition: background 0.3s; border: 1px solid var(--ssc-border);">
                 <div id="ssc-glow-preview-container" style="width: 128px; height: 128px;">
-                    <img id="ssc-glow-preview-img" src="<?php echo esc_url($avatar_placeholder); ?>" alt="avatar" style="width:100%; height:100%; border-radius:50%; object-fit:cover;">
+                    <img id="ssc-glow-preview-img" src="<?php echo esc_url($avatar_placeholder); ?>" alt="<?php echo esc_attr__('Avatar', 'supersede-css-jlg'); ?>" style="width:100%; height:100%; border-radius:50%; object-fit:cover;">
                 </div>
             </div>
-            <button id="ssc-glow-upload-btn" class="button" style="margin-top:16px;">Changer l'image d'avatar</button>
+            <button id="ssc-glow-upload-btn" class="button" style="margin-top:16px;"><?php esc_html_e("Changer l'image d'avatar", 'supersede-css-jlg'); ?></button>
 
-             <h4 style="margin-top:16px;">Comment l'utiliser ?</h4>
-             <p class="description">Une fois le preset enregistré et appliqué, demandez à vos rédacteurs d'ajouter la classe <code id="ssc-glow-how-to-use-class">.avatar-glow-blue</code> au conteneur (la `div`) de leur image.</p>
+             <h4 style="margin-top:16px;"><?php esc_html_e("Comment l'utiliser ?", 'supersede-css-jlg'); ?></h4>
+             <p class="description"><?php printf(wp_kses_post(__('Une fois le preset enregistré et appliqué, demandez à vos rédacteurs d\'ajouter la classe %s au conteneur (la `div`) de leur image.', 'supersede-css-jlg')), '<code id="ssc-glow-how-to-use-class">.avatar-glow-blue</code>'); ?></p>
              <pre id="ssc-glow-css-output" class="ssc-code"></pre>
         </div>
     </div>

--- a/supersede-css-jlg-enhanced/views/clip-path-editor.php
+++ b/supersede-css-jlg-enhanced/views/clip-path-editor.php
@@ -22,28 +22,28 @@ if (!defined('ABSPATH')) {
     }
 </style>
 <div class="ssc-app ssc-fullwidth">
-    <h2>✂️ Générateur de Formes (Clip-Path)</h2>
-    <p>Découpez vos conteneurs et images dans des formes géométriques pour des designs plus dynamiques.</p>
+    <h2><?php esc_html_e('✂️ Générateur de Formes (Clip-Path)', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e('Découpez vos conteneurs et images dans des formes géométriques pour des designs plus dynamiques.', 'supersede-css-jlg'); ?></p>
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Formes Prédéfinies</h3>
+            <h3><?php esc_html_e('Formes Prédéfinies', 'supersede-css-jlg'); ?></h3>
             <select id="ssc-clip-preset">
-                <option value="none">Aucune (Rectangle)</option>
-                <option value="circle(50% at 50% 50%)">Cercle</option>
-                <option value="ellipse(50% 30% at 50% 50%)">Ellipse</option>
-                <option value="polygon(50% 0%, 0% 100%, 100% 100%)">Triangle</option>
-                <option value="polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)">Hexagone</option>
-                <option value="polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)">Étoile</option>
-                <option value="polygon(0 15%, 15% 15%, 15% 0, 85% 0, 85% 15%, 100% 15%, 100% 85%, 85% 85%, 85% 100%, 15% 100%, 15% 85%, 0 85%)">Croix</option>
+                <option value="none"><?php esc_html_e('Aucune (Rectangle)', 'supersede-css-jlg'); ?></option>
+                <option value="circle(50% at 50% 50%)"><?php esc_html_e('Cercle', 'supersede-css-jlg'); ?></option>
+                <option value="ellipse(50% 30% at 50% 50%)"><?php esc_html_e('Ellipse', 'supersede-css-jlg'); ?></option>
+                <option value="polygon(50% 0%, 0% 100%, 100% 100%)"><?php esc_html_e('Triangle', 'supersede-css-jlg'); ?></option>
+                <option value="polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)"><?php esc_html_e('Hexagone', 'supersede-css-jlg'); ?></option>
+                <option value="polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)"><?php esc_html_e('Étoile', 'supersede-css-jlg'); ?></option>
+                <option value="polygon(0 15%, 15% 15%, 15% 0, 85% 0, 85% 15%, 100% 15%, 100% 85%, 85% 85%, 85% 100%, 15% 100%, 15% 85%, 0 85%)"><?php esc_html_e('Croix', 'supersede-css-jlg'); ?></option>
             </select>
-            <label style="margin-top:16px; display:block;"><strong>Taille de l'aperçu: <span id="ssc-clip-size-val">300px</span></strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e("Taille de l'aperçu:", 'supersede-css-jlg'); ?> <span id="ssc-clip-size-val">300px</span></strong></label>
             <input type="range" id="ssc-clip-preview-size" min="100" max="500" value="300" step="10" style="width:100%;">
-            <h3 style="margin-top:16px;">Code CSS Généré</h3>
+            <h3 style="margin-top:16px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
             <pre id="ssc-clip-css" class="ssc-code"></pre>
-            <div class="ssc-actions"><button id="ssc-clip-copy" class="button">Copier le CSS</button></div>
+            <div class="ssc-actions"><button id="ssc-clip-copy" class="button"><?php esc_html_e('Copier le CSS', 'supersede-css-jlg'); ?></button></div>
         </div>
         <div class="ssc-pane">
-             <h3>Aperçu</h3>
+             <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
              <div id="ssc-clip-preview-wrapper">
                 <div id="ssc-clip-preview"></div>
              </div>

--- a/supersede-css-jlg-enhanced/views/css-viewer.php
+++ b/supersede-css-jlg-enhanced/views/css-viewer.php
@@ -6,18 +6,18 @@ if (!defined('ABSPATH')) {
 /** @var string $tokens_css */
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>🔍 Visualiseur de CSS Actif</h2>
-    <p>Ce module affiche le contenu brut des options CSS de Supersede telles qu'elles sont enregistrées dans votre base de données. C'est un outil de débogage utile pour voir le code final appliqué à votre site.</p>
+    <h2><?php esc_html_e('🔍 Visualiseur de CSS Actif', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e("Ce module affiche le contenu brut des options CSS de Supersede telles qu'elles sont enregistrées dans votre base de données. C'est un outil de débogage utile pour voir le code final appliqué à votre site.", 'supersede-css-jlg'); ?></p>
 
     <div class="ssc-panel" style="margin-top: 16px;">
-        <h3>Contenu de : <code>ssc_active_css</code></h3>
-        <p class="description">C'est la feuille de style principale où la plupart des modules (Utilities, effets visuels, etc.) enregistrent leur code.</p>
+        <h3><?php echo wp_kses_post(__('Contenu de : <code>ssc_active_css</code>', 'supersede-css-jlg')); ?></h3>
+        <p class="description"><?php esc_html_e("C'est la feuille de style principale où la plupart des modules (Utilities, effets visuels, etc.) enregistrent leur code.", 'supersede-css-jlg'); ?></p>
         <textarea readonly class="large-text code" rows="15" style="background: #f0f0f0; color: #333; font-family: monospace; width: 100%;"><?php echo esc_textarea($active_css); ?></textarea>
     </div>
 
     <div class="ssc-panel" style="margin-top: 16px;">
-        <h3>Contenu de : <code>ssc_tokens_css</code></h3>
-        <p class="description">Cette option contient les variables CSS (Tokens) que vous avez définies dans le "Tokens Manager".</p>
+        <h3><?php echo wp_kses_post(__('Contenu de : <code>ssc_tokens_css</code>', 'supersede-css-jlg')); ?></h3>
+        <p class="description"><?php esc_html_e('Cette option contient les variables CSS (Tokens) que vous avez définies dans le "Tokens Manager".', 'supersede-css-jlg'); ?></p>
         <textarea readonly class="large-text code" rows="10" style="background: #f0f0f0; color: #333; font-family: monospace; width: 100%;"><?php echo esc_textarea($tokens_css); ?></textarea>
     </div>
 </div>

--- a/supersede-css-jlg-enhanced/views/dashboard.php
+++ b/supersede-css-jlg-enhanced/views/dashboard.php
@@ -11,33 +11,33 @@ if (!defined('ABSPATH')) {
     <div class="ssc-panel" style="margin-top: 24px;">
         <h2><?php echo esc_html__('Accès Rapide', 'supersede-css-jlg'); ?></h2>
         <p>
-            <a class="button button-primary" href="<?php echo esc_url($quick_links['utilities'] ?? '#'); ?>">Éditeur CSS</a>
-            <a class="button" href="<?php echo esc_url($quick_links['tokens'] ?? '#'); ?>">Tokens Manager</a>
-            <a class="button" href="<?php echo esc_url($quick_links['avatar'] ?? '#'); ?>">Avatar Glow</a>
-            <a class="button" href="<?php echo esc_url($quick_links['debug_center'] ?? '#'); ?>">Centre de Débogage</a>
+            <a class="button button-primary" href="<?php echo esc_url($quick_links['utilities'] ?? '#'); ?>"><?php esc_html_e('Éditeur CSS', 'supersede-css-jlg'); ?></a>
+            <a class="button" href="<?php echo esc_url($quick_links['tokens'] ?? '#'); ?>"><?php esc_html_e('Tokens Manager', 'supersede-css-jlg'); ?></a>
+            <a class="button" href="<?php echo esc_url($quick_links['avatar'] ?? '#'); ?>"><?php esc_html_e('Avatar Glow', 'supersede-css-jlg'); ?></a>
+            <a class="button" href="<?php echo esc_url($quick_links['debug_center'] ?? '#'); ?>"><?php esc_html_e('Centre de Débogage', 'supersede-css-jlg'); ?></a>
         </p>
     </div>
 
     <div class="ssc-panel" style="margin-top: 24px;">
-        <h2>💡 Comprendre le Workflow (Créer et Activer un Style)</h2>
-        <p>Pour utiliser efficacement les modules créatifs comme <strong>Avatar Glow</strong> ou <strong>Preset Designer</strong>, suivez ces 3 étapes logiques :</p>
+        <h2><?php esc_html_e('💡 Comprendre le Workflow (Créer et Activer un Style)', 'supersede-css-jlg'); ?></h2>
+        <p><?php echo wp_kses_post(__("Pour utiliser efficacement les modules créatifs comme <strong>Avatar Glow</strong> ou <strong>Preset Designer</strong>, suivez ces 3 étapes logiques :", 'supersede-css-jlg')); ?></p>
         <ol style="list-style-type: decimal; margin-left: 20px;">
             <li style="margin-bottom: 15px;">
-                <strong>ÉTAPE 1 : CRÉER ET ENREGISTRER</strong><br>
-                Allez dans un module (ex: Avatar Glow). Personnalisez votre effet (couleurs, vitesse...). Donnez-lui un nom et une classe CSS unique (ex: <code>.aura-speciale</code>), puis cliquez sur <strong>"Enregistrer le Preset"</strong>.<br>
-                <em>➡️ <strong>Résultat :</strong> La "recette" de votre effet est sauvegardée dans la bibliothèque du plugin. Elle n'est pas encore visible sur le site.</em>
+                <strong><?php esc_html_e('ÉTAPE 1 : CRÉER ET ENREGISTRER', 'supersede-css-jlg'); ?></strong><br>
+                <?php echo wp_kses_post(__("Allez dans un module (ex: Avatar Glow). Personnalisez votre effet (couleurs, vitesse...). Donnez-lui un nom et une classe CSS unique (ex: <code>.aura-speciale</code>), puis cliquez sur <strong>\"Enregistrer le Preset\"</strong>.", 'supersede-css-jlg')); ?><br>
+                <em><?php echo wp_kses_post(__("➡️ <strong>Résultat :</strong> La \"recette\" de votre effet est sauvegardée dans la bibliothèque du plugin. Elle n'est pas encore visible sur le site.", 'supersede-css-jlg')); ?></em>
             </li>
             <li style="margin-bottom: 15px;">
-                <strong>ÉTAPE 2 : APPLIQUER (Activer)</strong><br>
-                Avec votre preset fraîchement enregistré toujours sélectionné, cliquez sur <strong>"Appliquer sur le site"</strong>.<br>
-                <em>➡️ <strong>Résultat :</strong> Le code CSS de votre effet est ajouté à la feuille de style globale de votre site. L'effet est maintenant "disponible" et prêt à être utilisé.</em>
+                <strong><?php esc_html_e('ÉTAPE 2 : APPLIQUER (Activer)', 'supersede-css-jlg'); ?></strong><br>
+                <?php echo wp_kses_post(__("Avec votre preset fraîchement enregistré toujours sélectionné, cliquez sur <strong>\"Appliquer sur le site\"</strong>.", 'supersede-css-jlg')); ?><br>
+                <em><?php echo wp_kses_post(__("➡️ <strong>Résultat :</strong> Le code CSS de votre effet est ajouté à la feuille de style globale de votre site. L'effet est maintenant \"disponible\" et prêt à être utilisé.", 'supersede-css-jlg')); ?></em>
             </li>
             <li style="margin-bottom: 15px;">
-                <strong>ÉTAPE 3 : UTILISER</strong><br>
-                Vos rédacteurs peuvent maintenant aller dans l'éditeur de page ou d'article, sélectionner le conteneur d'une image et lui ajouter la classe CSS que vous avez définie (<code>aura-speciale</code>) dans les réglages avancés du bloc.<br>
-                <em>➡️ <strong>Résultat :</strong> L'effet d'aura apparaît sur l'image sur le site public !</em>
+                <strong><?php esc_html_e('ÉTAPE 3 : UTILISER', 'supersede-css-jlg'); ?></strong><br>
+                <?php echo wp_kses_post(__("Vos rédacteurs peuvent maintenant aller dans l'éditeur de page ou d'article, sélectionner le conteneur d'une image et lui ajouter la classe CSS que vous avez définie (<code>aura-speciale</code>) dans les réglages avancés du bloc.", 'supersede-css-jlg')); ?><br>
+                <em><?php echo wp_kses_post(__("➡️ <strong>Résultat :</strong> L'effet d'aura apparaît sur l'image sur le site public !", 'supersede-css-jlg')); ?></em>
             </li>
         </ol>
-        <p>En résumé : <strong>On enregistre</strong> un preset pour le sauvegarder pour le futur, et <strong>on l'applique</strong> pour le rendre utilisable dès maintenant.</p>
+        <p><?php echo wp_kses_post(__("En résumé : <strong>On enregistre</strong> un preset pour le sauvegarder pour le futur, et <strong>on l'applique</strong> pour le rendre utilisable dès maintenant.", 'supersede-css-jlg')); ?></p>
     </div>
 </div>

--- a/supersede-css-jlg-enhanced/views/filter-editor.php
+++ b/supersede-css-jlg-enhanced/views/filter-editor.php
@@ -34,31 +34,31 @@ if (!defined('ABSPATH')) {
     }
 </style>
 <div class="ssc-app ssc-fullwidth">
-    <h2>🎨 Éditeur de Filtres & Effets de Verre</h2>
-    <p>Appliquez des filtres visuels à vos images et conteneurs, ou créez un effet "Glassmorphism" tendance.</p>
+    <h2><?php esc_html_e('🎨 Éditeur de Filtres & Effets de Verre', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e('Appliquez des filtres visuels à vos images et conteneurs, ou créez un effet "Glassmorphism" tendance.', 'supersede-css-jlg'); ?></p>
 
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Filtres CSS (<code>filter</code>)</h3>
+            <h3><?php echo wp_kses_post(__('Filtres CSS (<code>filter</code>)', 'supersede-css-jlg')); ?></h3>
             <div class="ssc-two">
-                <div><label>Flou (Blur)</label><input type="range" class="ssc-filter-prop" data-prop="blur" min="0" max="20" value="0" step="1"> <span id="val-blur">0px</span></div>
-                <div><label>Luminosité</label><input type="range" class="ssc-filter-prop" data-prop="brightness" min="0" max="200" value="100" step="5"> <span id="val-brightness">100%</span></div>
-                <div><label>Contraste</label><input type="range" class="ssc-filter-prop" data-prop="contrast" min="0" max="200" value="100" step="5"> <span id="val-contrast">100%</span></div>
-                <div><label>Niveaux de gris</label><input type="range" class="ssc-filter-prop" data-prop="grayscale" min="0" max="100" value="0" step="5"> <span id="val-grayscale">0%</span></div>
-                <div><label>Rotation de teinte</label><input type="range" class="ssc-filter-prop" data-prop="hue-rotate" min="0" max="360" value="0" step="15"> <span id="val-hue-rotate">0deg</span></div>
-                <div><label>Saturation</label><input type="range" class="ssc-filter-prop" data-prop="saturate" min="0" max="200" value="100" step="5"> <span id="val-saturate">100%</span></div>
+                <div><label><?php esc_html_e('Flou (Blur)', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="blur" min="0" max="20" value="0" step="1"> <span id="val-blur">0px</span></div>
+                <div><label><?php esc_html_e('Luminosité', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="brightness" min="0" max="200" value="100" step="5"> <span id="val-brightness">100%</span></div>
+                <div><label><?php esc_html_e('Contraste', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="contrast" min="0" max="200" value="100" step="5"> <span id="val-contrast">100%</span></div>
+                <div><label><?php esc_html_e('Niveaux de gris', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="grayscale" min="0" max="100" value="0" step="5"> <span id="val-grayscale">0%</span></div>
+                <div><label><?php esc_html_e('Rotation de teinte', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="hue-rotate" min="0" max="360" value="0" step="15"> <span id="val-hue-rotate">0deg</span></div>
+                <div><label><?php esc_html_e('Saturation', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="saturate" min="0" max="200" value="100" step="5"> <span id="val-saturate">100%</span></div>
             </div>
             <hr>
-            <h3>Effet Verre (<code>backdrop-filter</code>)</h3>
-            <label><input type="checkbox" id="ssc-glass-enable"> <strong>Activer le Glassmorphism</strong></label>
+            <h3><?php echo wp_kses_post(__('Effet Verre (<code>backdrop-filter</code>)', 'supersede-css-jlg')); ?></h3>
+            <label><input type="checkbox" id="ssc-glass-enable"> <strong><?php esc_html_e('Activer le Glassmorphism', 'supersede-css-jlg'); ?></strong></label>
             <pre id="ssc-filter-css" class="ssc-code" style="margin-top:16px;"></pre>
-            <div class="ssc-actions"><button id="ssc-filter-copy" class="button">Copier le CSS</button></div>
+            <div class="ssc-actions"><button id="ssc-filter-copy" class="button"><?php esc_html_e('Copier le CSS', 'supersede-css-jlg'); ?></button></div>
         </div>
         <div class="ssc-pane">
-            <h3>Aperçu en Direct</h3>
+            <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
             <div id="ssc-filter-preview-bg">
                 <div id="ssc-filter-preview-box">
-                    Votre Contenu Ici
+                    <?php esc_html_e('Votre Contenu Ici', 'supersede-css-jlg'); ?>
                 </div>
             </div>
         </div>

--- a/supersede-css-jlg-enhanced/views/gradient-editor.php
+++ b/supersede-css-jlg-enhanced/views/gradient-editor.php
@@ -3,15 +3,15 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<div class="ssc-app ssc-fullwidth"><h2>Visual Gradient Editor</h2><div class="ssc-two" style="align-items: flex-start;">
+<div class="ssc-app ssc-fullwidth"><h2><?php esc_html_e('Visual Gradient Editor', 'supersede-css-jlg'); ?></h2><div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
             <div class="ssc-grad-controls">
-                <div class="ssc-control-group"><label>Type</label><select id="ssc-grad-type"><option value="linear-gradient">Linéaire</option><option value="radial-gradient">Radial</option><option value="conic-gradient">Conique</option></select></div>
-                <div id="ssc-grad-angle-control" class="ssc-control-group"><label>Angle</label><input type="range" id="ssc-grad-angle" min="0" max="360" value="90" step="1"><input type="number" id="ssc-grad-angle-num" min="0" max="360" value="90" class="small-text"> deg</div>
+                <div class="ssc-control-group"><label><?php esc_html_e('Type', 'supersede-css-jlg'); ?></label><select id="ssc-grad-type"><option value="linear-gradient"><?php esc_html_e('Linéaire', 'supersede-css-jlg'); ?></option><option value="radial-gradient"><?php esc_html_e('Radial', 'supersede-css-jlg'); ?></option><option value="conic-gradient"><?php esc_html_e('Conique', 'supersede-css-jlg'); ?></option></select></div>
+                <div id="ssc-grad-angle-control" class="ssc-control-group"><label><?php esc_html_e('Angle', 'supersede-css-jlg'); ?></label><input type="range" id="ssc-grad-angle" min="0" max="360" value="90" step="1"><input type="number" id="ssc-grad-angle-num" min="0" max="360" value="90" class="small-text"> <?php esc_html_e('deg', 'supersede-css-jlg'); ?></div>
             </div>
-            <div class="ssc-control-group"><label>Color Stops</label><div id="ssc-grad-stops-preview" class="ssc-grad-preview-bar"></div><div id="ssc-grad-stops-ui"></div></div>
-            <div class="ssc-actions"><button id="ssc-grad-apply" class="button button-primary">Appliquer</button><button id="ssc-grad-copy" class="button">Copier CSS</button></div>
+            <div class="ssc-control-group"><label><?php esc_html_e('Color Stops', 'supersede-css-jlg'); ?></label><div id="ssc-grad-stops-preview" class="ssc-grad-preview-bar"></div><div id="ssc-grad-stops-ui"></div></div>
+            <div class="ssc-actions"><button id="ssc-grad-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button><button id="ssc-grad-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button></div>
             <pre id="ssc-grad-css" class="ssc-code"></pre>
         </div>
-        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-grad-preview" style="height:200px;border-radius:12px;border:1px solid var(--ssc-border);"></div></div>
+        <div class="ssc-pane"><h3><?php esc_html_e('Preview', 'supersede-css-jlg'); ?></h3><div id="ssc-grad-preview" style="height:200px;border-radius:12px;border:1px solid var(--ssc-border);"></div></div>
     </div></div>

--- a/supersede-css-jlg-enhanced/views/grid-editor.php
+++ b/supersede-css-jlg-enhanced/views/grid-editor.php
@@ -4,31 +4,31 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>📏 Visual Grid Editor</h2>
-    <p>Construisez des mises en page CSS Grid de manière intuitive, sans écrire de code.</p>
+    <h2><?php esc_html_e('📏 Visual Grid Editor', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e('Construisez des mises en page CSS Grid de manière intuitive, sans écrire de code.', 'supersede-css-jlg'); ?></p>
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Paramètres de la Grille</h3>
+            <h3><?php esc_html_e('Paramètres de la Grille', 'supersede-css-jlg'); ?></h3>
 
-            <label><strong>Nombre de colonnes</strong></label>
+            <label><strong><?php esc_html_e('Nombre de colonnes', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
             <span id="ssc-grid-cols-val">3</span>
 
-            <label style="margin-top:16px; display:block;"><strong>Espacement (gap) en pixels</strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Espacement (gap) en pixels', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
             <span id="ssc-grid-gap-val">16px</span>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                <button id="ssc-grid-apply" class="button button-primary">Appliquer</button>
-                <button id="ssc-grid-copy" class="button">Copier CSS</button>
+                <button id="ssc-grid-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-grid-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button>
             </div>
 
-            <h3 style="margin-top:24px;">Code CSS Généré</h3>
-            <p class="description">Appliquez la classe <code>.ssc-grid-container</code> à votre conteneur.</p>
+            <h3 style="margin-top:24px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
+            <p class="description"><?php echo wp_kses_post(__('Appliquez la classe <code>.ssc-grid-container</code> à votre conteneur.', 'supersede-css-jlg')); ?></p>
             <pre id="ssc-grid-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
-            <h3>Aperçu en Direct</h3>
+            <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
             <div id="ssc-grid-preview" style="display:grid; border:1px dashed var(--ssc-border); padding:10px; border-radius:8px;">
                 <!-- Les éléments de la grille seront générés par JS -->
             </div>

--- a/supersede-css-jlg-enhanced/views/import-export.php
+++ b/supersede-css-jlg-enhanced/views/import-export.php
@@ -8,18 +8,18 @@ if (!defined('ABSPATH')) {
 $modules = Routes::getConfigModules();
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>Import / Export</h2>
+    <h2><?php esc_html_e('Import / Export', 'supersede-css-jlg'); ?></h2>
     <div class="ssc-panel" style="margin-bottom: 16px;">
-        <h3>Sauvegardez et restaurez votre configuration</h3>
+        <h3><?php esc_html_e('Sauvegardez et restaurez votre configuration', 'supersede-css-jlg'); ?></h3>
         <ul>
-            <li><strong>Exporter Config (.json) :</strong> Télécharge un fichier JSON contenant vos configurations Supersede CSS (presets, tokens, etc.). Utilisez les cases ci-dessous pour inclure uniquement les ensembles souhaités.</li>
-            <li><strong>Exporter CSS (.css) :</strong> Télécharge uniquement le code CSS final qui est appliqué sur votre site. Utile pour une utilisation externe ou une simple sauvegarde du style.</li>
-            <li><strong>Importer (.json) :</strong> Restaure une configuration complète depuis un fichier JSON que vous avez précédemment exporté. Seules les options associées aux ensembles cochés seront écrasées.</li>
+            <li><?php echo wp_kses_post(__('<strong>Exporter Config (.json) :</strong> Télécharge un fichier JSON contenant vos configurations Supersede CSS (presets, tokens, etc.). Utilisez les cases ci-dessous pour inclure uniquement les ensembles souhaités.', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Exporter CSS (.css) :</strong> Télécharge uniquement le code CSS final qui est appliqué sur votre site. Utile pour une utilisation externe ou une simple sauvegarde du style.', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Importer (.json) :</strong> Restaure une configuration complète depuis un fichier JSON que vous avez précédemment exporté. Seules les options associées aux ensembles cochés seront écrasées.', 'supersede-css-jlg')); ?></li>
         </ul>
     </div>
     <div class="ssc-panel" style="margin-bottom: 16px;">
-        <h3>Choisissez les ensembles à transférer</h3>
-        <p class="description">Les ensembles sélectionnés seront utilisés lors de l'export <strong>et</strong> de l'import.</p>
+        <h3><?php esc_html_e('Choisissez les ensembles à transférer', 'supersede-css-jlg'); ?></h3>
+        <p class="description"><?php echo wp_kses_post(__("Les ensembles sélectionnés seront utilisés lors de l'export <strong>et</strong> de l'import.", 'supersede-css-jlg')); ?></p>
         <div class="ssc-module-grid" style="display: flex; flex-wrap: wrap; gap: 12px;">
             <?php foreach ($modules as $slug => $module) : ?>
                 <label class="ssc-module-option" style="display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border: 1px solid #e0e0e0; border-radius: 4px; background: #fff;">
@@ -31,16 +31,16 @@ $modules = Routes::getConfigModules();
     </div>
     <div class="ssc-two">
         <div class="ssc-pane">
-            <h3>Exporter</h3><p>Téléchargez vos configurations ou uniquement le CSS actif.</p>
+            <h3><?php esc_html_e('Exporter', 'supersede-css-jlg'); ?></h3><p><?php esc_html_e('Téléchargez vos configurations ou uniquement le CSS actif.', 'supersede-css-jlg'); ?></p>
             <div class="ssc-actions">
-                <button id="ssc-export-config" class="button button-primary">Exporter Config (.json)</button>
-                <button id="ssc-export-css" class="button">Exporter CSS (.css)</button>
+                <button id="ssc-export-config" class="button button-primary"><?php esc_html_e('Exporter Config (.json)', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-export-css" class="button"><?php esc_html_e('Exporter CSS (.css)', 'supersede-css-jlg'); ?></button>
             </div>
         </div>
         <div class="ssc-pane">
-            <h3>Importer</h3><p>Importez un fichier de configuration (.json).</p>
+            <h3><?php esc_html_e('Importer', 'supersede-css-jlg'); ?></h3><p><?php esc_html_e('Importez un fichier de configuration (.json).', 'supersede-css-jlg'); ?></p>
             <input type="file" id="ssc-import-file" accept=".json">
-            <button id="ssc-import-btn" class="button">Importer</button>
+            <button id="ssc-import-btn" class="button"><?php esc_html_e('Importer', 'supersede-css-jlg'); ?></button>
             <div id="ssc-import-msg" class="ssc-muted"></div>
         </div>
     </div>

--- a/supersede-css-jlg-enhanced/views/page-layout-builder.php
+++ b/supersede-css-jlg-enhanced/views/page-layout-builder.php
@@ -12,55 +12,55 @@ if (!defined('ABSPATH')) {
     .ssc-tutorial-panel ul, .ssc-tutorial-panel ol { margin-left: 20px; }
 </style>
 <div class="ssc-app ssc-fullwidth">
-    <h2>📐 Maquettage de Page (CSS Grid)</h2>
-    <p>Préparez des mises en page complexes pour vos thèmes ou des sections spécifiques de vos pages.</p>
+    <h2><?php esc_html_e('📐 Maquettage de Page (CSS Grid)', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e('Préparez des mises en page complexes pour vos thèmes ou des sections spécifiques de vos pages.', 'supersede-css-jlg'); ?></p>
 
     <div class="ssc-panel ssc-tutorial-panel" style="margin-bottom:16px;">
-        <h3>💡 Tutoriel : Comment Utiliser le Maquettage de Page dans WordPress</h3>
-        <p>Cet outil génère le "plan" CSS de votre mise en page. Pour l'utiliser, vous devez ensuite construire la structure HTML correspondante dans votre page WordPress.</p>
+        <h3><?php esc_html_e('💡 Tutoriel : Comment Utiliser le Maquettage de Page dans WordPress', 'supersede-css-jlg'); ?></h3>
+        <p><?php esc_html_e('Cet outil génère le "plan" CSS de votre mise en page. Pour l\'utiliser, vous devez ensuite construire la structure HTML correspondante dans votre page WordPress.', 'supersede-css-jlg'); ?></p>
 
-        <h4>Étape 1 : Générer et Appliquer le CSS</h4>
+        <h4><?php esc_html_e('Étape 1 : Générer et Appliquer le CSS', 'supersede-css-jlg'); ?></h4>
         <ol>
-            <li>Choisissez un "Modèle de layout" dans le menu déroulant ci-dessous. Le code CSS est généré instantanément.</li>
-            <li>Copiez l'intégralité de ce code.</li>
-            <li>Allez dans le menu <strong>Supersede CSS → Utilities</strong>, collez le code dans l'éditeur (onglet Desktop) et cliquez sur <strong>"Save CSS"</strong>.</li>
+            <li><?php esc_html_e('Choisissez un "Modèle de layout" dans le menu déroulant ci-dessous. Le code CSS est généré instantanément.', 'supersede-css-jlg'); ?></li>
+            <li><?php esc_html_e("Copiez l'intégralité de ce code.", 'supersede-css-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Allez dans le menu <strong>Supersede CSS → Utilities</strong>, collez le code dans l\'éditeur (onglet Desktop) et cliquez sur <strong>"Save CSS"</strong>.', 'supersede-css-jlg')); ?></li>
         </ol>
 
-        <h4>Étape 2 : Créer la Structure HTML avec l'Éditeur de Blocs</h4>
+        <h4><?php esc_html_e('Étape 2 : Créer la Structure HTML avec l’Éditeur de Blocs', 'supersede-css-jlg'); ?></h4>
         <ol>
-            <li>Modifiez la page ou l'article où vous souhaitez appliquer cette mise en page.</li>
-            <li>Ajoutez un bloc <strong>Groupe</strong>. Ce sera votre conteneur principal.</li>
-            <li>Sélectionnez ce bloc Groupe, allez dans le panneau des réglages à droite, section <strong>"Avancé"</strong>.</li>
-            <li>Dans le champ "Classe(s) CSS additionnelle(s)", collez la classe principale du layout (par exemple, <code>ssc-layout-holy-grail</code>).</li>
-            <li>À l'intérieur de ce groupe principal, ajoutez un bloc (un "Groupe" est idéal) pour chaque zone définie dans le CSS (par exemple, 5 blocs pour le "Saint Graal").</li>
-            <li>Pour chaque bloc intérieur, assignez la classe CSS de sa zone dans ses réglages "Avancé" (<code>header</code>, <code>content</code>, <code>footer</code>, etc.).</li>
-            <li>Vous pouvez maintenant remplir ces blocs de zone avec votre contenu (textes, images, titres...).</li>
+            <li><?php esc_html_e("Modifiez la page ou l'article où vous souhaitez appliquer cette mise en page.", 'supersede-css-jlg'); ?></li>
+            <li><?php echo wp_kses_post(__('Ajoutez un bloc <strong>Groupe</strong>. Ce sera votre conteneur principal.', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Sélectionnez ce bloc Groupe, allez dans le panneau des réglages à droite, section <strong>"Avancé"</strong>.', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Dans le champ "Classe(s) CSS additionnelle(s)", collez la classe principale du layout (par exemple, <code>ssc-layout-holy-grail</code>).', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('À l\'intérieur de ce groupe principal, ajoutez un bloc (un "Groupe" est idéal) pour chaque zone définie dans le CSS (par exemple, 5 blocs pour le "Saint Graal").', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('Pour chaque bloc intérieur, assignez la classe CSS de sa zone dans ses réglages "Avancé" (<code>header</code>, <code>content</code>, <code>footer</code>, etc.).', 'supersede-css-jlg')); ?></li>
+            <li><?php esc_html_e('Vous pouvez maintenant remplir ces blocs de zone avec votre contenu (textes, images, titres...).', 'supersede-css-jlg'); ?></li>
         </ol>
-        <p>Votre mise en page est prête ! Elle s'adaptera automatiquement sur les écrans plus petits.</p>
+        <p><?php esc_html_e('Votre mise en page est prête ! Elle s’adaptera automatiquement sur les écrans plus petits.', 'supersede-css-jlg'); ?></p>
     </div>
 
 
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Paramètres & Code</h3>
-            <label><strong>Modèle de layout</strong></label>
+            <h3><?php esc_html_e('Paramètres & Code', 'supersede-css-jlg'); ?></h3>
+            <label><strong><?php esc_html_e('Modèle de layout', 'supersede-css-jlg'); ?></strong></label>
             <select id="layout-preset">
-                <option value="holy-grail">Saint Graal (Header, 3 colonnes, Footer)</option>
-                <option value="sidebar-right">Contenu + Sidebar à Droite</option>
-                <option value="hero-features">Section Héro + 3 Cartes</option>
-                <option value="dashboard">Tableau de Bord Asymétrique</option>
+                <option value="holy-grail"><?php esc_html_e('Saint Graal (Header, 3 colonnes, Footer)', 'supersede-css-jlg'); ?></option>
+                <option value="sidebar-right"><?php esc_html_e('Contenu + Sidebar à Droite', 'supersede-css-jlg'); ?></option>
+                <option value="hero-features"><?php esc_html_e('Section Héro + 3 Cartes', 'supersede-css-jlg'); ?></option>
+                <option value="dashboard"><?php esc_html_e('Tableau de Bord Asymétrique', 'supersede-css-jlg'); ?></option>
             </select>
             <hr>
-            <label><strong>Vue :</strong></label>
+            <label><strong><?php esc_html_e('Vue :', 'supersede-css-jlg'); ?></strong></label>
             <div class="ssc-actions">
-                <button class="button button-primary" id="view-desktop">Desktop</button>
-                <button class="button" id="view-mobile">Mobile</button>
+                <button class="button button-primary" id="view-desktop"><?php esc_html_e('Desktop', 'supersede-css-jlg'); ?></button>
+                <button class="button" id="view-mobile"><?php esc_html_e('Mobile', 'supersede-css-jlg'); ?></button>
             </div>
-            <h3 style="margin-top:24px;">Code CSS Généré</h3>
+            <h3 style="margin-top:24px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
             <pre id="layout-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
-            <h3>Aperçu Visuel</h3>
+            <h3><?php esc_html_e('Aperçu Visuel', 'supersede-css-jlg'); ?></h3>
             <div id="layout-preview-container">
                 <div id="layout-grid-desktop" class="ssc-layout-grid"></div>
                 <div id="layout-grid-mobile" class="ssc-layout-grid ssc-layout-preview-mobile" style="display:none;"></div>
@@ -69,20 +69,20 @@ if (!defined('ABSPATH')) {
     </div>
 
     <div class="ssc-panel ssc-tutorial-panel" style="margin-top:16px;">
-        <h3>🚀 Idées d'Amélioration & Inspiration</h3>
-        <h4>Ajouter de l'Espacement (Gap)</h4>
-        <p>Par défaut, les blocs sont collés. Pour ajouter un espacement uniforme entre toutes les zones, modifiez la classe principale dans votre CSS et ajoutez la propriété <code>gap</code> :</p>
+        <h3><?php esc_html_e('🚀 Idées d’Amélioration & Inspiration', 'supersede-css-jlg'); ?></h3>
+        <h4><?php esc_html_e('Ajouter de l’Espacement (Gap)', 'supersede-css-jlg'); ?></h4>
+        <p><?php echo wp_kses_post(__('Par défaut, les blocs sont collés. Pour ajouter un espacement uniforme entre toutes les zones, modifiez la classe principale dans votre CSS et ajoutez la propriété <code>gap</code> :', 'supersede-css-jlg')); ?></p>
         <pre class="ssc-code">.ssc-layout-holy-grail {
   display: grid;
   gap: 1rem; /* ou 16px, 2em, etc. */
   /* ... autres propriétés ... */
 }</pre>
 
-        <h4>Layouts pour des Sections de Page</h4>
-        <p>N'hésitez pas à utiliser ces layouts non pas pour une page entière, mais pour une section spécifique. Le modèle "Héro + 3 Cartes" est parfait pour une section "Nos services" sur votre page d'accueil.</p>
+        <h4><?php esc_html_e('Layouts pour des Sections de Page', 'supersede-css-jlg'); ?></h4>
+        <p><?php esc_html_e('N’hésitez pas à utiliser ces layouts non pas pour une page entière, mais pour une section spécifique. Le modèle "Héro + 3 Cartes" est parfait pour une section "Nos services" sur votre page d’accueil.', 'supersede-css-jlg'); ?></p>
 
-        <h4>Combiner avec les Tokens</h4>
-        <p>Pour une maintenance facile, définissez vos espacements ou tailles de colonnes avec des <a href="<?php echo esc_url($tokens_page_url); ?>">Tokens</a>. Par exemple :</p>
+        <h4><?php esc_html_e('Combiner avec les Tokens', 'supersede-css-jlg'); ?></h4>
+        <p><?php printf(wp_kses_post(__('Pour une maintenance facile, définissez vos espacements ou tailles de colonnes avec des %s. Par exemple :', 'supersede-css-jlg')), '<a href="' . esc_url($tokens_page_url) . '">' . esc_html__('Tokens', 'supersede-css-jlg') . '</a>'); ?></p>
         <pre class="ssc-code">:root { --spacing-medium: 1.5rem; }
 
 .ssc-layout-sidebar-right {
@@ -91,7 +91,7 @@ if (!defined('ABSPATH')) {
   gap: var(--spacing-medium);
 }</pre>
 
-        <h4>Créer vos propres modèles</h4>
-        <p>Utilisez les modèles générés comme base. En modifiant les valeurs de <code>grid-template-areas</code> et <code>grid-template-columns</code>, vous pouvez inventer n'importe quelle mise en page imaginable !</p>
+        <h4><?php esc_html_e('Créer vos propres modèles', 'supersede-css-jlg'); ?></h4>
+        <p><?php echo wp_kses_post(__('Utilisez les modèles générés comme base. En modifiant les valeurs de <code>grid-template-areas</code> et <code>grid-template-columns</code>, vous pouvez inventer n\'importe quelle mise en page imaginable !', 'supersede-css-jlg')); ?></p>
     </div>
 </div>

--- a/supersede-css-jlg-enhanced/views/preset-designer.php
+++ b/supersede-css-jlg-enhanced/views/preset-designer.php
@@ -4,33 +4,33 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>Preset Designer</h2>
+    <h2><?php esc_html_e('Preset Designer', 'supersede-css-jlg'); ?></h2>
     <div class="ssc-panel" style="margin-bottom: 16px;">
-        <h3>Comment utiliser les Presets ?</h3>
-        <p>Les presets sont des ensembles de styles réutilisables que vous pouvez créer une fois et appliquer à n'importe quel élément de votre site.</p>
+        <h3><?php esc_html_e('Comment utiliser les Presets ?', 'supersede-css-jlg'); ?></h3>
+        <p><?php esc_html_e("Les presets sont des ensembles de styles réutilisables que vous pouvez créer une fois et appliquer à n'importe quel élément de votre site.", 'supersede-css-jlg'); ?></p>
         <ol style="margin-left: 20px;">
-            <li><strong>Créer un Preset :</strong> Dans l'éditeur ci-dessous, donnez un nom (ex: "Bouton Principal Rouge"), un sélecteur CSS (<code>.btn-red</code>) et ajoutez les propriétés CSS (<code>background-color</code>, <code>color</code>, etc.).</li>
-            <li><strong>Enregistrer :</strong> Cliquez sur "Enregistrer". Votre preset apparaît maintenant dans la liste des "Presets Existants".</li>
-            <li><strong>Appliquer un Preset :</strong> Utilisez la section "Quick Apply" en haut. Cherchez votre preset, sélectionnez-le et cliquez sur "Appliquer". Le CSS du preset sera ajouté à votre feuille de style globale.</li>
+            <li><?php echo wp_kses_post(__('<strong>Créer un Preset :</strong> Dans l\'éditeur ci-dessous, donnez un nom (ex: "Bouton Principal Rouge"), un sélecteur CSS (<code>.btn-red</code>) et ajoutez les propriétés CSS (<code>background-color</code>, <code>color</code>, etc.).', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Enregistrer :</strong> Cliquez sur "Enregistrer". Votre preset apparaît maintenant dans la liste des "Presets Existants".', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Appliquer un Preset :</strong> Utilisez la section "Quick Apply" en haut. Cherchez votre preset, sélectionnez-le et cliquez sur "Appliquer". Le CSS du preset sera ajouté à votre feuille de style globale.', 'supersede-css-jlg')); ?></li>
         </ol>
     </div>
 
     <div class="ssc-two" style="align-items: flex-start;">
-        <div class="ssc-pane" style="flex: 1.5;"><h3>Quick Apply</h3><div class="ssc-actions"><input type="search" id="ssc-qa-search" class="regular-text" placeholder="Rechercher..."><select id="ssc-qa-select" class="regular-text"></select><button id="ssc-qa-apply" class="button button-primary">Appliquer</button></div></div>
-        <div class="ssc-pane" style="flex: 1;"><h3>Presets Existants</h3><ul id="ssc-presets-list" class="ssc-list"></ul></div>
+        <div class="ssc-pane" style="flex: 1.5;"><h3><?php esc_html_e('Quick Apply', 'supersede-css-jlg'); ?></h3><div class="ssc-actions"><input type="search" id="ssc-qa-search" class="regular-text" placeholder="<?php echo esc_attr__('Rechercher...', 'supersede-css-jlg'); ?>"><select id="ssc-qa-select" class="regular-text"></select><button id="ssc-qa-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button></div></div>
+        <div class="ssc-pane" style="flex: 1;"><h3><?php esc_html_e('Presets Existants', 'supersede-css-jlg'); ?></h3><ul id="ssc-presets-list" class="ssc-list"></ul></div>
     </div>
     <div class="ssc-panel" style="margin-top: 16px;">
-        <h3>Créer / Modifier un Preset</h3>
+        <h3><?php esc_html_e('Créer / Modifier un Preset', 'supersede-css-jlg'); ?></h3>
         <div class="ssc-two">
-            <div><label><strong>Nom</strong></label><input type="text" id="ssc-preset-name" class="regular-text" placeholder="ex: Bouton arrondi"></div>
-            <div><label><strong>Sélecteur CSS</strong></label><input type="text" id="ssc-preset-scope" class="regular-text" placeholder=".btn:hover"></div>
+            <div><label><strong><?php esc_html_e('Nom', 'supersede-css-jlg'); ?></strong></label><input type="text" id="ssc-preset-name" class="regular-text" placeholder="<?php echo esc_attr__('ex: Bouton arrondi', 'supersede-css-jlg'); ?>"></div>
+            <div><label><strong><?php esc_html_e('Sélecteur CSS', 'supersede-css-jlg'); ?></strong></label><input type="text" id="ssc-preset-scope" class="regular-text" placeholder="<?php echo esc_attr__('.btn:hover', 'supersede-css-jlg'); ?>"></div>
         </div>
-        <label style="margin-top: 12px; display: block;"><strong>Propriétés CSS</strong></label>
+        <label style="margin-top: 12px; display: block;"><strong><?php esc_html_e('Propriétés CSS', 'supersede-css-jlg'); ?></strong></label>
         <div id="ssc-preset-props-builder" class="ssc-kv-builder"></div>
-        <button type="button" id="ssc-preset-add-prop" class="button" style="margin-top:8px;">+ Ajouter</button>
+        <button type="button" id="ssc-preset-add-prop" class="button" style="margin-top:8px;"><?php esc_html_e('+ Ajouter', 'supersede-css-jlg'); ?></button>
         <div class="ssc-actions" style="margin-top:16px; border-top: 1px solid #eee; padding-top: 16px;">
-            <button id="ssc-save-preset" class="button button-primary">Enregistrer</button>
-            <button id="ssc-delete-preset" class="button button-link-delete" style="display:none;">Supprimer</button>
+            <button id="ssc-save-preset" class="button button-primary"><?php esc_html_e('Enregistrer', 'supersede-css-jlg'); ?></button>
+            <button id="ssc-delete-preset" class="button button-link-delete" style="display:none;"><?php esc_html_e('Supprimer', 'supersede-css-jlg'); ?></button>
         </div>
         <div id="ssc-preset-msg" class="ssc-muted"></div>
     </div>

--- a/supersede-css-jlg-enhanced/views/scope-builder.php
+++ b/supersede-css-jlg-enhanced/views/scope-builder.php
@@ -4,27 +4,27 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>Scope Builder</h2>
+    <h2><?php esc_html_e('Scope Builder', 'supersede-css-jlg'); ?></h2>
 
     <div class="ssc-panel" style="margin-bottom: 16px;">
-        <h3>Comment utiliser le Scope Builder ?</h3>
-        <p>Cet outil vous permet d'appliquer rapidement des styles CSS à des éléments très spécifiques de votre site sans avoir à naviguer dans l'éditeur principal.</p>
+        <h3><?php esc_html_e('Comment utiliser le Scope Builder ?', 'supersede-css-jlg'); ?></h3>
+        <p><?php esc_html_e("Cet outil vous permet d'appliquer rapidement des styles CSS à des éléments très spécifiques de votre site sans avoir à naviguer dans l'éditeur principal.", 'supersede-css-jlg'); ?></p>
         <ol style="margin-left: 20px;">
-            <li><strong>Sélecteur(s) :</strong> C'est la cible de votre style. Entrez une classe (<code>.mon-bouton</code>), un ID (<code>#logo</code>) ou une combinaison plus complexe (<code>.card > a</code>).</li>
-            <li><strong>Pseudo-classe :</strong> (Optionnel) Choisissez un état pour appliquer le style, comme lorsque l'utilisateur survole l'élément (<code>:hover</code>) ou clique dessus (<code>:focus</code>).</li>
-            <li><strong>Propriétés CSS :</strong> Écrivez le code CSS à appliquer dans la zone de texte. Par exemple : <code>background-color: #e73c7e;<br>color: white;<br>border-radius: 50px;</code></li>
-            <li><strong>Aperçu :</strong> Le résultat est visible en direct sur les éléments de démo à droite.</li>
-            <li><strong>Appliquer :</strong> Ajoute le CSS généré à la feuille de style globale de votre site.</li>
+            <li><?php echo wp_kses_post(__('<strong>Sélecteur(s) :</strong> C\'est la cible de votre style. Entrez une classe (<code>.mon-bouton</code>), un ID (<code>#logo</code>) ou une combinaison plus complexe (<code>.card > a</code>).', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Pseudo-classe :</strong> (Optionnel) Choisissez un état pour appliquer le style, comme lorsque l\'utilisateur survole l\'élément (<code>:hover</code>) ou clique dessus (<code>:focus</code>).', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Propriétés CSS :</strong> Écrivez le code CSS à appliquer dans la zone de texte. Par exemple : <code>background-color: #e73c7e;<br>color: white;<br>border-radius: 50px;</code>', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Aperçu :</strong> Le résultat est visible en direct sur les éléments de démo à droite.', 'supersede-css-jlg')); ?></li>
+            <li><?php echo wp_kses_post(__('<strong>Appliquer :</strong> Ajoute le CSS généré à la feuille de style globale de votre site.', 'supersede-css-jlg')); ?></li>
         </ol>
     </div>
 
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <label>Sélecteur(s)</label><input type="text" id="ssc-sel" class="large-text" placeholder=".btn, .card > a">
-            <label>Pseudo-classe</label><select id="ssc-pseudo"><option value="">(aucune)</option><option value=":hover">:hover</option><option value=":focus">:focus</option></select>
-            <label>Propriétés CSS</label><textarea id="ssc-css" rows="12" class="code"></textarea>
-            <div class="ssc-actions"><button id="ssc-apply" class="button button-primary">Appliquer</button><button id="ssc-copy" class="button">Copier</button></div>
+            <label><?php esc_html_e('Sélecteur(s)', 'supersede-css-jlg'); ?></label><input type="text" id="ssc-sel" class="large-text" placeholder="<?php echo esc_attr__('.btn, .card > a', 'supersede-css-jlg'); ?>">
+            <label><?php esc_html_e('Pseudo-classe', 'supersede-css-jlg'); ?></label><select id="ssc-pseudo"><option value=""><?php esc_html_e('(aucune)', 'supersede-css-jlg'); ?></option><option value=":hover"><?php esc_html_e(':hover', 'supersede-css-jlg'); ?></option><option value=":focus"><?php esc_html_e(':focus', 'supersede-css-jlg'); ?></option></select>
+            <label><?php esc_html_e('Propriétés CSS', 'supersede-css-jlg'); ?></label><textarea id="ssc-css" rows="12" class="code"></textarea>
+            <div class="ssc-actions"><button id="ssc-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button><button id="ssc-copy" class="button"><?php esc_html_e('Copier', 'supersede-css-jlg'); ?></button></div>
         </div>
-        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-scope-preview-container" style="border: 1px dashed #ccc; padding: 1em; border-radius: 8px;"><style id="ssc-scope-preview-style"></style><button class="btn demo">Bouton</button><a href="#" class="link demo">Lien</a></div></div>
+        <div class="ssc-pane"><h3><?php esc_html_e('Preview', 'supersede-css-jlg'); ?></h3><div id="ssc-scope-preview-container" style="border: 1px dashed #ccc; padding: 1em; border-radius: 8px;"><style id="ssc-scope-preview-style"></style><button class="btn demo"><?php esc_html_e('Bouton', 'supersede-css-jlg'); ?></button><a href="#" class="link demo"><?php esc_html_e('Lien', 'supersede-css-jlg'); ?></a></div></div>
     </div>
 </div>

--- a/supersede-css-jlg-enhanced/views/shadow-editor.php
+++ b/supersede-css-jlg-enhanced/views/shadow-editor.php
@@ -3,12 +3,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<div class="ssc-app ssc-fullwidth"><h2>Visual Shadow Editor</h2><div class="ssc-two" style="align-items: flex-start;">
+<div class="ssc-app ssc-fullwidth"><h2><?php esc_html_e('Visual Shadow Editor', 'supersede-css-jlg'); ?></h2><div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
             <div id="ssc-shadow-layers-container"></div>
-            <div class="ssc-actions" style="margin-top: 16px;"><button id="ssc-shadow-add-layer" class="button">Ajouter un calque</button></div><hr>
-            <div class="ssc-actions"><button id="ssc-shadow-apply" class="button button-primary">Appliquer</button><button id="ssc-shadow-copy" class="button">Copier CSS</button></div>
+            <div class="ssc-actions" style="margin-top: 16px;"><button id="ssc-shadow-add-layer" class="button"><?php esc_html_e('Ajouter un calque', 'supersede-css-jlg'); ?></button></div><hr>
+            <div class="ssc-actions"><button id="ssc-shadow-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button><button id="ssc-shadow-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button></div>
             <pre id="ssc-shadow-css" class="ssc-code"></pre>
         </div>
-        <div class="ssc-pane"><h3>Preview</h3><div id="ssc-shadow-preview" style="width: 200px; height: 120px; background: #fff; border-radius: 12px; margin: 2em auto; display: grid; place-items: center; border: 1px solid #e5e7eb; transition: all 0.2s ease;">Aperçu</div></div>
+        <div class="ssc-pane"><h3><?php esc_html_e('Preview', 'supersede-css-jlg'); ?></h3><div id="ssc-shadow-preview" style="width: 200px; height: 120px; background: #fff; border-radius: 12px; margin: 2em auto; display: grid; place-items: center; border: 1px solid #e5e7eb; transition: all 0.2s ease;"><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></div></div>
     </div></div>

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -28,24 +28,24 @@ if (function_exists('wp_localize_script')) {
 ?>
 <div class="ssc-app ssc-fullwidth">
     <div class="ssc-panel">
-        <h2>🚀 Bienvenue dans le Gestionnaire de Tokens</h2>
-        <p>Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, espacements…) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.</p>
+        <h2><?php esc_html_e('🚀 Bienvenue dans le Gestionnaire de Tokens', 'supersede-css-jlg'); ?></h2>
+        <p><?php esc_html_e('Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, espacements…) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.', 'supersede-css-jlg'); ?></p>
     </div>
 
     <div class="ssc-two" style="margin-top:16px; align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>👨‍🏫 Qu'est-ce qu'un Token (ou Variable CSS) ?</h3>
-            <p>Imaginez que vous décidiez d'utiliser une couleur bleue spécifique (<code>#3498db</code>) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C'est long et risqué !</p>
-            <p>Un <strong>token</strong> est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme <code>--couleur-principale</code>. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.</p>
-            <p><strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s'applique partout !</strong></p>
+            <h3><?php esc_html_e('👨‍🏫 Qu’est-ce qu’un Token (ou Variable CSS) ?', 'supersede-css-jlg'); ?></h3>
+            <p><?php echo wp_kses_post(__('Imaginez que vous décidiez d\'utiliser une couleur bleue spécifique (<code>#3498db</code>) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C\'est long et risqué !', 'supersede-css-jlg')); ?></p>
+            <p><?php echo wp_kses_post(__('Un <strong>token</strong> est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme <code>--couleur-principale</code>. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.', 'supersede-css-jlg')); ?></p>
+            <p><?php echo wp_kses_post(__('<strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s\'applique partout !</strong>', 'supersede-css-jlg')); ?></p>
             <hr>
-            <h4>Exemple Concret</h4>
-            <p><strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l'élément <code>:root</code> (la racine de votre page).</p>
+            <h4><?php esc_html_e('Exemple Concret', 'supersede-css-jlg'); ?></h4>
+            <p><?php echo wp_kses_post(__('<strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l\'élément <code>:root</code> (la racine de votre page).', 'supersede-css-jlg')); ?></p>
             <pre class="ssc-code">:root {
    --couleur-principale: #3498db;
    --radius-arrondi: 8px;
 }</pre>
-            <p><strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction <code>var()</code> pour appeler la valeur du token.</p>
+            <p><?php echo wp_kses_post(__('<strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction <code>var()</code> pour appeler la valeur du token.', 'supersede-css-jlg')); ?></p>
             <pre class="ssc-code">.mon-bouton {
    background-color: var(--couleur-principale);
    border-radius: var(--radius-arrondi);
@@ -57,8 +57,8 @@ if (function_exists('wp_localize_script')) {
 }</pre>
         </div>
         <div class="ssc-pane">
-            <h3>🎨 Éditeur Visuel de Tokens</h3>
-            <p>Gérez vos tokens sous forme de fiches structurées : nom technique, valeur, type de champ, description et groupe d'appartenance. Chaque catégorie est listée séparément pour garder une vision claire de votre système de design.</p>
+            <h3><?php esc_html_e('🎨 Éditeur Visuel de Tokens', 'supersede-css-jlg'); ?></h3>
+            <p><?php esc_html_e("Gérez vos tokens sous forme de fiches structurées : nom technique, valeur, type de champ, description et groupe d'appartenance. Chaque catégorie est listée séparément pour garder une vision claire de votre système de design.", 'supersede-css-jlg'); ?></p>
 
             <style>
                 .ssc-token-builder { display: flex; flex-direction: column; gap: 16px; }
@@ -73,7 +73,7 @@ if (function_exists('wp_localize_script')) {
             </style>
 
             <div class="ssc-token-toolbar" style="margin-bottom:12px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
-                <button id="ssc-token-add" class="button">+ Ajouter un Token</button>
+                <button id="ssc-token-add" class="button"><?php esc_html_e('+ Ajouter un Token', 'supersede-css-jlg'); ?></button>
             </div>
 
             <div id="ssc-token-builder" class="ssc-token-builder" aria-live="polite">
@@ -82,23 +82,23 @@ if (function_exists('wp_localize_script')) {
 
             <hr>
 
-            <h3>📜 Code CSS généré (<code>:root</code>)</h3>
-            <p>Le code ci-dessous est synchronisé automatiquement avec la configuration JSON. Il est proposé en lecture seule pour vérification ou copie rapide.</p>
+            <h3><?php echo wp_kses_post(__('📜 Code CSS généré (<code>:root</code>)', 'supersede-css-jlg')); ?></h3>
+            <p><?php esc_html_e('Le code ci-dessous est synchronisé automatiquement avec la configuration JSON. Il est proposé en lecture seule pour vérification ou copie rapide.', 'supersede-css-jlg'); ?></p>
             <textarea id="ssc-tokens" rows="10" class="large-text" readonly><?php echo esc_textarea($tokens_css); ?></textarea>
             <div class="ssc-actions" style="margin-top:8px; display:flex; gap:8px; flex-wrap:wrap;">
-                <button id="ssc-tokens-save" class="button button-primary">Enregistrer les Tokens</button>
-                <button id="ssc-tokens-copy" class="button">Copier le CSS</button>
+                <button id="ssc-tokens-save" class="button button-primary"><?php esc_html_e('Enregistrer les Tokens', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-tokens-copy" class="button"><?php esc_html_e('Copier le CSS', 'supersede-css-jlg'); ?></button>
             </div>
         </div>
     </div>
 
     <div class="ssc-panel" style="margin-top:16px;">
-        <h3>👁️ Aperçu en Direct</h3>
-        <p>Voyez comment vos tokens affectent les éléments. Le style de cet aperçu est directement contrôlé par le code CSS ci-dessus.</p>
+        <h3><?php esc_html_e('👁️ Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
+        <p><?php esc_html_e('Voyez comment vos tokens affectent les éléments. Le style de cet aperçu est directement contrôlé par le code CSS ci-dessus.', 'supersede-css-jlg'); ?></p>
         <style id="ssc-tokens-preview-style"></style>
         <div id="ssc-tokens-preview" style="padding: 24px; border: 2px dashed var(--couleur-principale, #ccc); border-radius: var(--radius-moyen, 8px); background: #fff;">
-            <button class="button button-primary" style="background-color: var(--couleur-principale); border-radius: var(--radius-moyen);">Bouton Principal</button>
-            <a href="#" style="color: var(--couleur-principale); margin-left: 16px;">Lien Principal</a>
+            <button class="button button-primary" style="background-color: var(--couleur-principale); border-radius: var(--radius-moyen);"><?php esc_html_e('Bouton Principal', 'supersede-css-jlg'); ?></button>
+            <a href="#" style="color: var(--couleur-principale); margin-left: 16px;"><?php esc_html_e('Lien Principal', 'supersede-css-jlg'); ?></a>
         </div>
     </div>
 </div>

--- a/supersede-css-jlg-enhanced/views/tron-grid.php
+++ b/supersede-css-jlg-enhanced/views/tron-grid.php
@@ -4,58 +4,58 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <div class="ssc-app ssc-fullwidth">
-    <h2>🌐 Tron Grid Animator</h2>
-    <p>Générez un fond de grille animé et personnalisable. Idéal pour des bannières ou des fonds de section futuristes.</p>
+    <h2><?php esc_html_e('🌐 Tron Grid Animator', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e('Générez un fond de grille animé et personnalisable. Idéal pour des bannières ou des fonds de section futuristes.', 'supersede-css-jlg'); ?></p>
 
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Paramètres de la Grille</h3>
+            <h3><?php esc_html_e('Paramètres de la Grille', 'supersede-css-jlg'); ?></h3>
 
-            <label><strong>Couleur des lignes</strong></label>
+            <label><strong><?php esc_html_e('Couleur des lignes', 'supersede-css-jlg'); ?></strong></label>
             <input type="color" id="ssc-tron-line-color" value="#00ffff">
 
-            <label style="margin-top:16px; display:block;"><strong>Couleur de fond (Dégradé)</strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Couleur de fond (Dégradé)', 'supersede-css-jlg'); ?></strong></label>
             <div class="ssc-actions">
-                <span>Haut :</span> <input type="color" id="ssc-tron-bg1" value="#0a0a23">
-                <span>Bas :</span> <input type="color" id="ssc-tron-bg2" value="#000000">
+                <span><?php esc_html_e('Haut :', 'supersede-css-jlg'); ?></span> <input type="color" id="ssc-tron-bg1" value="#0a0a23">
+                <span><?php esc_html_e('Bas :', 'supersede-css-jlg'); ?></span> <input type="color" id="ssc-tron-bg2" value="#000000">
             </div>
 
-            <label style="margin-top:16px; display:block;"><strong>Taille de la grille (pixels)</strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Taille de la grille (pixels)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5">
             <span id="ssc-tron-size-val">50px</span>
 
-            <label style="margin-top:16px; display:block;"><strong>Épaisseur des lignes (pixels)</strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Épaisseur des lignes (pixels)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1">
             <span id="ssc-tron-thickness-val">1px</span>
 
-            <label style="margin-top:16px; display:block;"><strong>Vitesse de l'animation (secondes)</strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e("Vitesse de l'animation (secondes)", 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1">
             <span id="ssc-tron-speed-val">10s</span>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                <button id="ssc-tron-apply" class="button button-primary">Appliquer sur le site</button>
-                <button id="ssc-tron-copy" class="button">Copier le CSS</button>
+                <button id="ssc-tron-apply" class="button button-primary"><?php esc_html_e('Appliquer sur le site', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-tron-copy" class="button"><?php esc_html_e('Copier le CSS', 'supersede-css-jlg'); ?></button>
             </div>
 
-            <h3 style="margin-top:24px;">Comment utiliser cet effet ?</h3>
+            <h3 style="margin-top:24px;"><?php esc_html_e('Comment utiliser cet effet ?', 'supersede-css-jlg'); ?></h3>
             <p class="description">
-                Le bouton <strong>"Appliquer sur le site"</strong> ajoute le code CSS généré à la feuille de style globale de votre site. Vous pouvez ensuite utiliser la classe <code>.ssc-tron-grid-bg</code> sur n'importe quel élément (div, section, etc.) pour lui appliquer ce fond.
+                <?php echo wp_kses_post(__('Le bouton <strong>"Appliquer sur le site"</strong> ajoute le code CSS généré à la feuille de style globale de votre site. Vous pouvez ensuite utiliser la classe <code>.ssc-tron-grid-bg</code> sur n\'importe quel élément (div, section, etc.) pour lui appliquer ce fond.', 'supersede-css-jlg')); ?>
             </p>
             <p class="description">
-                <strong>Pour créer plusieurs grilles différentes :</strong>
+                <?php echo wp_kses_post(__('<strong>Pour créer plusieurs grilles différentes :</strong>', 'supersede-css-jlg')); ?>
             </p>
             <ol style="padding-left: 20px;" class="description">
-                <li>Personnalisez votre première grille ici.</li>
-                <li>Cliquez sur <strong>"Copier CSS"</strong>.</li>
-                <li>Allez dans le module <strong>"Utilities"</strong> (l'éditeur CSS principal).</li>
-                <li>Collez le code et renommez la classe principale, par exemple en <code>.ma-grille-bleue</code>.</li>
-                <li>Revenez ici, créez une autre variation, et répétez l'opération avec un nouveau nom de classe (ex: <code>.ma-grille-rouge</code>).</li>
+                <li><?php esc_html_e('Personnalisez votre première grille ici.', 'supersede-css-jlg'); ?></li>
+                <li><?php echo wp_kses_post(__('Cliquez sur <strong>"Copier CSS"</strong>.', 'supersede-css-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('Allez dans le module <strong>"Utilities"</strong> (l\'éditeur CSS principal).', 'supersede-css-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('Collez le code et renommez la classe principale, par exemple en <code>.ma-grille-bleue</code>.', 'supersede-css-jlg')); ?></li>
+                <li><?php echo wp_kses_post(__('Revenez ici, créez une autre variation, et répétez l\'opération avec un nouveau nom de classe (ex: <code>.ma-grille-rouge</code>).', 'supersede-css-jlg')); ?></li>
             </ol>
 
             <pre id="ssc-tron-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
-            <h3>Aperçu en Direct</h3>
+            <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
             <div id="ssc-tron-preview" style="height: 300px; border-radius: 12px; border: 1px solid var(--ssc-border); overflow: hidden;"></div>
         </div>
     </div>

--- a/supersede-css-jlg-enhanced/views/typography-editor.php
+++ b/supersede-css-jlg-enhanced/views/typography-editor.php
@@ -8,35 +8,35 @@ if (!defined('ABSPATH')) {
     .ssc-typo-vp-slider-container { width: 100%; background: var(--ssc-bg); padding: 10px; border-radius: 8px; margin-top: 10px; }
 </style>
 <div class="ssc-app ssc-fullwidth">
-    <h2>📏 Typographie Fluide (Clamp)</h2>
-    <p>Générez du texte qui s'adapte parfaitement à toutes les tailles d'écran, sans "sauts" disgracieux.</p>
+    <h2><?php esc_html_e('📏 Typographie Fluide (Clamp)', 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e("Générez du texte qui s'adapte parfaitement à toutes les tailles d'écran, sans \"sauts\" disgracieux.", 'supersede-css-jlg'); ?></p>
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
-            <h3>Paramètres de la Police (en pixels)</h3>
+            <h3><?php esc_html_e('Paramètres de la Police (en pixels)', 'supersede-css-jlg'); ?></h3>
             <div class="ssc-two">
-                <div><label>Taille min. police</label><input type="number" id="ssc-typo-min-fs" value="16" class="small-text"></div>
-                <div><label>Taille max. police</label><input type="number" id="ssc-typo-max-fs" value="48" class="small-text"></div>
+                <div><label><?php esc_html_e('Taille min. police', 'supersede-css-jlg'); ?></label><input type="number" id="ssc-typo-min-fs" value="16" class="small-text"></div>
+                <div><label><?php esc_html_e('Taille max. police', 'supersede-css-jlg'); ?></label><input type="number" id="ssc-typo-max-fs" value="48" class="small-text"></div>
             </div>
             <div class="ssc-two" style="margin-top: 12px;">
-                <div><label>Taille min. viewport (px)</label><input type="number" id="ssc-typo-min-vp" value="320" class="small-text"></div>
-                <div><label>Taille max. viewport (px)</label><input type="number" id="ssc-typo-max-vp" value="1280" class="small-text"></div>
+                <div><label><?php esc_html_e('Taille min. viewport (px)', 'supersede-css-jlg'); ?></label><input type="number" id="ssc-typo-min-vp" value="320" class="small-text"></div>
+                <div><label><?php esc_html_e('Taille max. viewport (px)', 'supersede-css-jlg'); ?></label><input type="number" id="ssc-typo-max-vp" value="1280" class="small-text"></div>
             </div>
-            <label style="margin-top: 16px;">Texte à prévisualiser</label>
-            <input type="text" id="ssc-typo-text" class="large-text" value="Design fluide, lecture parfaite.">
+            <label style="margin-top: 16px;"><?php esc_html_e('Texte à prévisualiser', 'supersede-css-jlg'); ?></label>
+            <input type="text" id="ssc-typo-text" class="large-text" value="<?php echo esc_attr__('Design fluide, lecture parfaite.', 'supersede-css-jlg'); ?>">
             <div class="ssc-actions" style="margin-top: 16px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
-                <button id="ssc-typo-generate" class="button button-primary">Générer</button>
-                <button id="ssc-typo-copy" class="button">Copier le CSS</button>
+                <button id="ssc-typo-generate" class="button button-primary"><?php esc_html_e('Générer', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-typo-copy" class="button"><?php esc_html_e('Copier le CSS', 'supersede-css-jlg'); ?></button>
             </div>
             <pre id="ssc-typo-css" class="ssc-code" style="margin-top: 16px;"></pre>
         </div>
         <div class="ssc-pane">
-            <h3>Aperçu</h3>
+            <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
             <div class="ssc-typo-vp-slider-container">
-                <label>Largeur du viewport (px)</label>
+                <label><?php esc_html_e('Largeur du viewport (px)', 'supersede-css-jlg'); ?></label>
                 <input type="range" id="ssc-typo-vp-slider" min="320" max="1280" value="960">
                 <span id="ssc-typo-vp-value">960px</span>
             </div>
-            <div id="ssc-typo-preview" style="margin-top: 16px; font-size: clamp(16px, 3vw, 48px);">Design fluide, lecture parfaite.</div>
+            <div id="ssc-typo-preview" style="margin-top: 16px; font-size: clamp(16px, 3vw, 48px);"><?php esc_html_e('Design fluide, lecture parfaite.', 'supersede-css-jlg'); ?></div>
         </div>
     </div>
 </div>

--- a/supersede-css-jlg-enhanced/views/utilities.php
+++ b/supersede-css-jlg-enhanced/views/utilities.php
@@ -28,38 +28,38 @@ if (!defined('ABSPATH')) {
                 </div>
             </div>
             <div class="ssc-editor-tabs">
-                <div class="ssc-editor-tab active" data-tab="desktop">🖥️ Desktop</div>
-                <div class="ssc-editor-tab" data-tab="tablet">📲 Tablette</div>
-                <div class="ssc-editor-tab" data-tab="mobile">📱 Mobile</div>
-                <div class="ssc-editor-tab" data-tab="tutorial">💡 Tutoriel @media queries</div>
+                <div class="ssc-editor-tab active" data-tab="desktop"><?php esc_html_e('🖥️ Desktop', 'supersede-css-jlg'); ?></div>
+                <div class="ssc-editor-tab" data-tab="tablet"><?php esc_html_e('📲 Tablette', 'supersede-css-jlg'); ?></div>
+                <div class="ssc-editor-tab" data-tab="mobile"><?php esc_html_e('📱 Mobile', 'supersede-css-jlg'); ?></div>
+                <div class="ssc-editor-tab" data-tab="tutorial"><?php esc_html_e('💡 Tutoriel @media queries', 'supersede-css-jlg'); ?></div>
             </div>
             <div class="ssc-editor-container">
                 <div id="ssc-editor-panel-desktop" class="ssc-editor-panel active"><textarea id="ssc-css-editor-desktop"><?php echo esc_textarea($css_desktop); ?></textarea></div>
                 <div id="ssc-editor-panel-tablet" class="ssc-editor-panel"><textarea id="ssc-css-editor-tablet"><?php echo esc_textarea($css_tablet); ?></textarea></div>
                 <div id="ssc-editor-panel-mobile" class="ssc-editor-panel"><textarea id="ssc-css-editor-mobile"><?php echo esc_textarea($css_mobile); ?></textarea></div>
                 <div id="ssc-editor-panel-tutorial" class="ssc-editor-panel ssc-tutorial-content">
-                    <h3>Le Principe : "Desktop First" Simplifié</h3>
-                    <p>Pensez à votre design comme à la construction d'une maison :</p>
+                    <h3><?php esc_html_e('Le Principe : "Desktop First" Simplifié', 'supersede-css-jlg'); ?></h3>
+                    <p><?php esc_html_e("Pensez à votre design comme à la construction d'une maison :", 'supersede-css-jlg'); ?></p>
                     <ol>
-                        <li><strong>L'onglet <code>Desktop</code> est le plan de base de la maison.</strong> C'est ici que vous définissez tous les styles fondamentaux (couleurs, polices, espacements). Ces styles s'appliquent par défaut à <strong>toutes les tailles d'écran</strong>.</li>
-                        <li><strong>L'onglet <code>Tablette</code> est l'aménagement pour les pièces moyennes.</strong> Vous ne redessinez pas tout, vous spécifiez uniquement les changements. Par exemple, réduire la taille d'un titre.</li>
-                        <li><strong>L'onglet <code>Mobile</code> est pour les plus petites pièces.</strong> Vous faites les derniers ajustements pour que tout soit parfait sur un petit écran.</li>
+                        <li><?php echo wp_kses_post(__("<strong>L'onglet <code>Desktop</code> est le plan de base de la maison.</strong> C'est ici que vous définissez tous les styles fondamentaux (couleurs, polices, espacements). Ces styles s'appliquent par défaut à <strong>toutes les tailles d'écran</strong>.", 'supersede-css-jlg')); ?></li>
+                        <li><?php echo wp_kses_post(__("<strong>L'onglet <code>Tablette</code> est l'aménagement pour les pièces moyennes.</strong> Vous ne redessinez pas tout, vous spécifiez uniquement les changements. Par exemple, réduire la taille d'un titre.", 'supersede-css-jlg')); ?></li>
+                        <li><?php echo wp_kses_post(__("<strong>L'onglet <code>Mobile</code> est pour les plus petites pièces.</strong> Vous faites les derniers ajustements pour que tout soit parfait sur un petit écran.", 'supersede-css-jlg')); ?></li>
                     </ol>
-                    <p>En coulisses, le plugin enveloppe automatiquement le code des onglets Tablette et Mobile dans des <strong>@media queries</strong>, vous faisant gagner du temps.</p>
+                    <p><?php echo wp_kses_post(__('En coulisses, le plugin enveloppe automatiquement le code des onglets Tablette et Mobile dans des <strong>@media queries</strong>, vous faisant gagner du temps.', 'supersede-css-jlg')); ?></p>
                     <hr>
-                    <h4>Exemple Concret : Un Titre Adaptatif</h4>
-                    <p><strong>Objectif :</strong> Un titre <code>.mon-titre</code> qui change de taille et d'alignement.</p>
-                    <p><strong>1. Onglet <code>Desktop</code> (la base) :</strong></p>
+                    <h4><?php esc_html_e('Exemple Concret : Un Titre Adaptatif', 'supersede-css-jlg'); ?></h4>
+                    <p><?php echo wp_kses_post(__('<strong>Objectif :</strong> Un titre <code>.mon-titre</code> qui change de taille et d\'alignement.', 'supersede-css-jlg')); ?></p>
+                    <p><?php echo wp_kses_post(__('<strong>1. Onglet <code>Desktop</code> (la base) :</strong>', 'supersede-css-jlg')); ?></p>
                     <pre class="ssc-code">.mon-titre {
   font-size: 48px;
   color: blue;
   font-weight: bold;
 }</pre>
-                    <p><strong>2. Onglet <code>Tablette</code> (premier ajustement) :</strong></p>
+                    <p><?php echo wp_kses_post(__('<strong>2. Onglet <code>Tablette</code> (premier ajustement) :</strong>', 'supersede-css-jlg')); ?></p>
                     <pre class="ssc-code">.mon-titre {
   font-size: 36px;
 }</pre>
-                    <p><strong>3. Onglet <code>Mobile</code> (ajustement final) :</strong></p>
+                    <p><?php echo wp_kses_post(__('<strong>3. Onglet <code>Mobile</code> (ajustement final) :</strong>', 'supersede-css-jlg')); ?></p>
                     <pre class="ssc-code">.mon-titre {
   font-size: 24px;
   text-align: center;
@@ -72,10 +72,10 @@ if (!defined('ABSPATH')) {
                 <div class="ssc-url-bar">
                     <input type="url" id="ssc-preview-url" value="<?php echo esc_url($preview_url); ?>">
                     <button class="button" id="ssc-preview-load"><?php echo esc_html__('Load', 'supersede-css-jlg'); ?></button>
-                    <button class="button" id="ssc-element-picker-toggle" title="Cibler un élément">🎯</button>
+                    <button class="button" id="ssc-element-picker-toggle" title="<?php echo esc_attr__('Cibler un élément', 'supersede-css-jlg'); ?>">🎯</button>
                 </div>
                 <div class="ssc-responsive-toggles">
-                    <button class="button button-primary" data-vp="desktop" title="Desktop">🖥️</button><button class="button" data-vp="tablet" title="Tablet">📲</button><button class="button" data-vp="mobile" title="Mobile">📱</button>
+                    <button class="button button-primary" data-vp="desktop" title="<?php echo esc_attr__('Desktop', 'supersede-css-jlg'); ?>">🖥️</button><button class="button" data-vp="tablet" title="<?php echo esc_attr__('Tablet', 'supersede-css-jlg'); ?>">📲</button><button class="button" data-vp="mobile" title="<?php echo esc_attr__('Mobile', 'supersede-css-jlg'); ?>">📱</button>
                 </div>
             </div>
             <div class="ssc-preview-frame-container">
@@ -84,8 +84,8 @@ if (!defined('ABSPATH')) {
                 <iframe id="ssc-preview-frame" sandbox="allow-same-origin allow-forms allow-scripts"></iframe>
             </div>
             <div style="padding-top: 8px;">
-                <label>Sélecteur Ciblé :</label>
-                <input type="text" id="ssc-picked-selector" readonly class="large-text" placeholder="Cliquez sur 🎯 puis sur un élément dans l'aperçu.">
+                <label><?php esc_html_e('Sélecteur Ciblé :', 'supersede-css-jlg'); ?></label>
+                <input type="text" id="ssc-picked-selector" readonly class="large-text" placeholder="<?php echo esc_attr__("Cliquez sur 🎯 puis sur un élément dans l'aperçu.", 'supersede-css-jlg'); ?>">
             </div>
         </div>
     </div>

--- a/supersede-css-jlg-enhanced/views/visual-effects.php
+++ b/supersede-css-jlg-enhanced/views/visual-effects.php
@@ -18,29 +18,29 @@ if (!defined('ABSPATH')) {
     .ssc-grid-three { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; }
 </style>
 <div class="ssc-app ssc-fullwidth">
-    <h2>🎬 Générateur d'Effets Visuels</h2>
-    <p>Une collection d'effets visuels avancés pour animer vos fonds, images et conteneurs.</p>
+    <h2><?php esc_html_e("🎬 Générateur d'Effets Visuels", 'supersede-css-jlg'); ?></h2>
+    <p><?php esc_html_e('Une collection d\'effets visuels avancés pour animer vos fonds, images et conteneurs.', 'supersede-css-jlg'); ?></p>
     <div class="ssc-ve-tabs">
-        <div class="ssc-ve-tab active" data-tab="backgrounds">🌌 Fonds Animés</div>
-        <div class="ssc-ve-tab" data-tab="ecg">❤️ ECG / Battement de Cœur</div>
-        <div class="ssc-ve-tab" data-tab="crt">📺 Effet CRT (Scanline)</div>
+        <div class="ssc-ve-tab active" data-tab="backgrounds"><?php esc_html_e('🌌 Fonds Animés', 'supersede-css-jlg'); ?></div>
+        <div class="ssc-ve-tab" data-tab="ecg"><?php esc_html_e('❤️ ECG / Battement de Cœur', 'supersede-css-jlg'); ?></div>
+        <div class="ssc-ve-tab" data-tab="crt"><?php esc_html_e('📺 Effet CRT (Scanline)', 'supersede-css-jlg'); ?></div>
     </div>
 
     <div id="ssc-ve-panel-crt" class="ssc-ve-panel">
         <div class="ssc-two" style="align-items: flex-start;">
             <div class="ssc-pane">
-                <h3>Paramètres de l'effet CRT</h3>
-                <p class="description">Cet effet est purement décoratif et ne génère pas de CSS à exporter.</p>
+                <h3><?php esc_html_e("Paramètres de l'effet CRT", 'supersede-css-jlg'); ?></h3>
+                <p class="description"><?php esc_html_e('Cet effet est purement décoratif et ne génère pas de CSS à exporter.', 'supersede-css-jlg'); ?></p>
                 <div class="ssc-grid-three">
-                    <div><label>Couleur Scanline</label><input type="color" class="ssc-crt-control" id="scanlineColor" value="#00ff00"></div>
-                    <div><label>Opacité Scanline</label><input type="range" class="ssc-crt-control" id="scanlineOpacity" min="0" max="1" value="0.4" step="0.05"></div>
-                    <div><label>Vitesse Scanline</label><input type="range" class="ssc-crt-control" id="scanlineSpeed" min="0.1" max="2" value="0.5" step="0.1"></div>
-                    <div><label>Intensité Bruit</label><input type="range" class="ssc-crt-control" id="noiseIntensity" min="0" max="0.5" value="0.1" step="0.02"></div>
-                    <div><label>Aberration Chromatique</label><input type="range" class="ssc-crt-control" id="chromaticAberration" min="0" max="5" value="1" step="0.5"></div>
+                    <div><label><?php esc_html_e('Couleur Scanline', 'supersede-css-jlg'); ?></label><input type="color" class="ssc-crt-control" id="scanlineColor" value="#00ff00"></div>
+                    <div><label><?php esc_html_e('Opacité Scanline', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-crt-control" id="scanlineOpacity" min="0" max="1" value="0.4" step="0.05"></div>
+                    <div><label><?php esc_html_e('Vitesse Scanline', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-crt-control" id="scanlineSpeed" min="0.1" max="2" value="0.5" step="0.1"></div>
+                    <div><label><?php esc_html_e('Intensité Bruit', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-crt-control" id="noiseIntensity" min="0" max="0.5" value="0.1" step="0.02"></div>
+                    <div><label><?php esc_html_e('Aberration Chromatique', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-crt-control" id="chromaticAberration" min="0" max="5" value="1" step="0.5"></div>
                 </div>
             </div>
             <div class="ssc-pane">
-                <h3>Aperçu</h3>
+                <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
                 <div class="ssc-ve-preview-box"><canvas id="ssc-crt-canvas"></canvas></div>
             </div>
         </div>
@@ -49,28 +49,28 @@ if (!defined('ABSPATH')) {
     <div id="ssc-ve-panel-ecg" class="ssc-ve-panel">
          <div class="ssc-two" style="align-items: flex-start;">
             <div class="ssc-pane">
-                <h3>Paramètres de l'ECG</h3>
-                <label><strong>Preset de Rythme</strong></label>
-                <select id="ssc-ecg-preset" class="regular-text"><option value="stable">Stable</option><option value="fast">Rapide</option><option value="critical">Critique</option></select>
-                <label style="margin-top:16px;"><strong>Couleur de la ligne</strong></label>
+                <h3><?php esc_html_e("Paramètres de l'ECG", 'supersede-css-jlg'); ?></h3>
+                <label><strong><?php esc_html_e('Preset de Rythme', 'supersede-css-jlg'); ?></strong></label>
+                <select id="ssc-ecg-preset" class="regular-text"><option value="stable"><?php esc_html_e('Stable', 'supersede-css-jlg'); ?></option><option value="fast"><?php esc_html_e('Rapide', 'supersede-css-jlg'); ?></option><option value="critical"><?php esc_html_e('Critique', 'supersede-css-jlg'); ?></option></select>
+                <label style="margin-top:16px;"><strong><?php esc_html_e('Couleur de la ligne', 'supersede-css-jlg'); ?></strong></label>
                 <input type="color" id="ssc-ecg-color" value="#00ff00">
-                <label style="margin-top:16px;"><strong>Positionnement (top)</strong></label>
+                <label style="margin-top:16px;"><strong><?php esc_html_e('Positionnement (top)', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-ecg-top" min="0" max="100" value="50" step="1"><span id="ssc-ecg-top-val">50%</span>
-                <label style="margin-top:16px;"><strong>Superposition (z-index)</strong></label>
+                <label style="margin-top:16px;"><strong><?php esc_html_e('Superposition (z-index)', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-ecg-z-index" min="-10" max="10" value="1" step="1"><span id="ssc-ecg-z-index-val">1</span>
                 <hr>
-                <label><strong>Logo/Image au centre</strong></label>
-                <button id="ssc-ecg-upload-btn" class="button">Choisir une image</button>
-                <label style="margin-top:16px;"><strong>Taille du logo</strong></label>
+                <label><strong><?php esc_html_e('Logo/Image au centre', 'supersede-css-jlg'); ?></strong></label>
+                <button id="ssc-ecg-upload-btn" class="button"><?php esc_html_e('Choisir une image', 'supersede-css-jlg'); ?></button>
+                <label style="margin-top:16px;"><strong><?php esc_html_e('Taille du logo', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-ecg-logo-size" min="20" max="200" value="100" step="1"><span id="ssc-ecg-logo-size-val">100px</span>
                 <hr>
                 <pre id="ssc-ecg-css" class="ssc-code ssc-code-small" style="margin-top:16px;"></pre>
-                <button id="ssc-ecg-apply" class="button button-primary" style="margin-top:8px;">Appliquer l'Effet</button>
+                <button id="ssc-ecg-apply" class="button button-primary" style="margin-top:8px;"><?php esc_html_e("Appliquer l'Effet", 'supersede-css-jlg'); ?></button>
             </div>
             <div class="ssc-pane">
-                <h3>Aperçu</h3>
+                <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
                 <div id="ssc-ecg-preview-container" class="ssc-ve-preview-box">
-                    <img id="ssc-ecg-logo-preview" src="" alt="Logo Preview" style="display:none;">
+                    <img id="ssc-ecg-logo-preview" src="" alt="<?php echo esc_attr__('Logo Preview', 'supersede-css-jlg'); ?>" style="display:none;">
                     <svg id="ssc-ecg-preview-svg" viewBox="0 0 400 60" preserveAspectRatio="none"><path id="ssc-ecg-preview-path" class="ssc-ecg-path" d="M0,30 L100,30 L110,18 L120,42 L130,26 L140,30 L240,30 L250,20 L260,40 L270,28 L280,30 L400,30"/></svg>
                 </div>
             </div>
@@ -80,15 +80,15 @@ if (!defined('ABSPATH')) {
     <div id="ssc-ve-panel-backgrounds" class="ssc-ve-panel">
          <div class="ssc-two" style="align-items: flex-start;">
             <div class="ssc-pane">
-                <h3>Paramètres du Fond</h3>
-                <select id="ssc-bg-type" class="regular-text"><option value="stars">Étoiles</option><option value="gradient">Dégradé</option></select>
-                <div id="ssc-bg-controls-stars"><label>Couleur</label><input type="color" id="starColor" value="#FFFFFF"><label>Nombre</label><input type="range" id="starCount" min="50" max="500" value="200" step="10"></div>
-                <div id="ssc-bg-controls-gradient" style="display:none;"><label>Vitesse</label><input type="range" id="gradientSpeed" min="2" max="20" value="10" step="1"></div>
+                <h3><?php esc_html_e('Paramètres du Fond', 'supersede-css-jlg'); ?></h3>
+                <select id="ssc-bg-type" class="regular-text"><option value="stars"><?php esc_html_e('Étoiles', 'supersede-css-jlg'); ?></option><option value="gradient"><?php esc_html_e('Dégradé', 'supersede-css-jlg'); ?></option></select>
+                <div id="ssc-bg-controls-stars"><label><?php esc_html_e('Couleur', 'supersede-css-jlg'); ?></label><input type="color" id="starColor" value="#FFFFFF"><label><?php esc_html_e('Nombre', 'supersede-css-jlg'); ?></label><input type="range" id="starCount" min="50" max="500" value="200" step="10"></div>
+                <div id="ssc-bg-controls-gradient" style="display:none;"><label><?php esc_html_e('Vitesse', 'supersede-css-jlg'); ?></label><input type="range" id="gradientSpeed" min="2" max="20" value="10" step="1"></div>
                  <pre id="ssc-bg-css" class="ssc-code"></pre>
-                <button id="ssc-bg-apply" class="button button-primary">Appliquer</button>
+                <button id="ssc-bg-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
             </div>
             <div class="ssc-pane">
-                <h3>Aperçu</h3>
+                <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
                 <div id="ssc-bg-preview" class="ssc-ve-preview-box"></div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- wrap all user-facing text in the Supersede CSS view templates with translation helpers using the `supersede-css-jlg` text domain
- update attribute placeholders and descriptions to keep appropriate escaping while allowing localized content

## Testing
- php -l supersede-css-jlg-enhanced/views/*.php

------
https://chatgpt.com/codex/tasks/task_e_68d6b5af1368832e8b1da1f3e99f5cb5