### PR TITLE
Improve internationalization in utilities script

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -1,10 +1,14 @@
 (function($) {
-    const wpPackages = typeof window !== 'undefined' && window.wp ? window.wp : {};
-    const i18n = wpPackages.i18n ? wpPackages.i18n : {};
-    const __ = typeof i18n.__ === 'function' ? i18n.__ : (text) => text;
-    const _x = typeof i18n._x === 'function' ? i18n._x : (text) => text;
-    const _n = typeof i18n._n === 'function' ? i18n._n : (single) => single;
-    const _nx = typeof i18n._nx === 'function' ? i18n._nx : (single) => single;
+    const i18n = (typeof window !== 'undefined' && window.wp && window.wp.i18n)
+        ? window.wp.i18n
+        : {
+            __: (text) => text,
+            _x: (text) => text,
+            _n: (single, plural, number) => (number === 1 ? single : plural),
+            _nx: (single, plural, number) => (number === 1 ? single : plural),
+        };
+
+    const { __, _x, _n, _nx } = i18n;
 
     let editors = {};
     let pickerActive = false;


### PR DESCRIPTION
## Summary
- import translation helpers from wp.i18n in the utilities admin script
- provide graceful fallbacks when wp.i18n is unavailable so messages still render

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6b5de1318832e9feb44c3c5319a07