### PR TITLE
Add wp-i18n support for utilities admin script

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -1,10 +1,13 @@
 (function($) {
     const wpPackages = typeof window !== 'undefined' && window.wp ? window.wp : {};
-    const i18n = wpPackages.i18n ? wpPackages.i18n : {};
-    const __ = typeof i18n.__ === 'function' ? i18n.__ : (text) => text;
-    const _x = typeof i18n._x === 'function' ? i18n._x : (text) => text;
-    const _n = typeof i18n._n === 'function' ? i18n._n : (single) => single;
-    const _nx = typeof i18n._nx === 'function' ? i18n._nx : (single) => single;
+    const i18n = wpPackages.i18n ? wpPackages.i18n : null;
+    const fallbacks = {
+        __: (text) => text,
+        _x: (text) => text,
+        _n: (single) => single,
+        _nx: (single) => single,
+    };
+    const { __, _x, _n, _nx } = i18n ? i18n : fallbacks;
 
     let editors = {};
     let pickerActive = false;

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -243,7 +243,7 @@ final class Admin
                     wp_enqueue_script($script_handle, SSC_PLUGIN_URL . $path, $dependencies, SSC_VERSION, true);
 
                     if ($handle === 'utilities' && function_exists('wp_set_script_translations')) {
-                        wp_set_script_translations($script_handle, 'supersede-css-jlg');
+                        wp_set_script_translations($script_handle, 'supersede-css-jlg', SSC_PLUGIN_DIR . 'languages');
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- ensure the utilities admin JavaScript reads translation helpers from `wp.i18n`
- enqueue the script with the `wp-i18n` dependency and register its text domain for translations

## Testing
- not run (WordPress environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6b5d82b70832e888ecc1623b07b1b