### PR TITLE
Localize literal UI defaults in views

### DIFF
--- a/supersede-css-jlg-enhanced/views/animation-studio.php
+++ b/supersede-css-jlg-enhanced/views/animation-studio.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
             </select>
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Durée (secondes)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-anim-duration" min="0.1" max="5" value="1.5" step="0.1">
-            <span id="ssc-anim-duration-val">1.5s</span>
+            <span id="ssc-anim-duration-val"><?php echo esc_html__('1.5s', 'supersede-css-jlg'); ?></span>
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
                 <button id="ssc-anim-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
                 <button id="ssc-anim-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button>

--- a/supersede-css-jlg-enhanced/views/avatar-glow.php
+++ b/supersede-css-jlg-enhanced/views/avatar-glow.php
@@ -34,10 +34,10 @@ if (!defined('ABSPATH')) {
                 </div>
                 <label style="margin-top:16px;"><strong><?php esc_html_e('Vitesse (secondes)', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-glow-speed" min="1" max="20" value="5" step="0.5">
-                <span id="ssc-glow-speed-val">5s</span>
+                <span id="ssc-glow-speed-val"><?php echo esc_html__('5s', 'supersede-css-jlg'); ?></span>
                 <label style="margin-top:16px;"><strong><?php esc_html_e('Épaisseur (pixels)', 'supersede-css-jlg'); ?></strong></label>
                 <input type="range" id="ssc-glow-thickness" min="2" max="12" value="4" step="1">
-                <span id="ssc-glow-thickness-val">4px</span>
+                <span id="ssc-glow-thickness-val"><?php echo esc_html__('4px', 'supersede-css-jlg'); ?></span>
             </div>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">

--- a/supersede-css-jlg-enhanced/views/clip-path-editor.php
+++ b/supersede-css-jlg-enhanced/views/clip-path-editor.php
@@ -36,7 +36,7 @@ if (!defined('ABSPATH')) {
                 <option value="polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)"><?php esc_html_e('Étoile', 'supersede-css-jlg'); ?></option>
                 <option value="polygon(0 15%, 15% 15%, 15% 0, 85% 0, 85% 15%, 100% 15%, 100% 85%, 85% 85%, 85% 100%, 15% 100%, 15% 85%, 0 85%)"><?php esc_html_e('Croix', 'supersede-css-jlg'); ?></option>
             </select>
-            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e("Taille de l'aperçu:", 'supersede-css-jlg'); ?> <span id="ssc-clip-size-val">300px</span></strong></label>
+            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e("Taille de l'aperçu:", 'supersede-css-jlg'); ?> <span id="ssc-clip-size-val"><?php echo esc_html__('300px', 'supersede-css-jlg'); ?></span></strong></label>
             <input type="range" id="ssc-clip-preview-size" min="100" max="500" value="300" step="10" style="width:100%;">
             <h3 style="margin-top:16px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
             <pre id="ssc-clip-css" class="ssc-code"></pre>

--- a/supersede-css-jlg-enhanced/views/debug-center.php
+++ b/supersede-css-jlg-enhanced/views/debug-center.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) {
 }
 /** @var array{plugin_version?:string,wordpress_version?:string,php_version?:string} $system_info */
 /** @var array<int,array<string,mixed>> $log_entries */
-$plugin_version    = $system_info['plugin_version'] ?? 'N/A';
+$plugin_version    = $system_info['plugin_version'] ?? __('N/A', 'supersede-css-jlg');
 $wordpress_version = $system_info['wordpress_version'] ?? '';
 $php_version       = $system_info['php_version'] ?? '';
 ?>

--- a/supersede-css-jlg-enhanced/views/filter-editor.php
+++ b/supersede-css-jlg-enhanced/views/filter-editor.php
@@ -41,12 +41,12 @@ if (!defined('ABSPATH')) {
         <div class="ssc-pane">
             <h3><?php printf(wp_kses_post(__('Filtres CSS (%s)', 'supersede-css-jlg')), '<code>filter</code>'); ?></h3>
             <div class="ssc-two">
-                <div><label><?php esc_html_e('Flou (Blur)', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="blur" min="0" max="20" value="0" step="1"> <span id="val-blur">0px</span></div>
-                <div><label><?php esc_html_e('Luminosité', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="brightness" min="0" max="200" value="100" step="5"> <span id="val-brightness">100%</span></div>
-                <div><label><?php esc_html_e('Contraste', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="contrast" min="0" max="200" value="100" step="5"> <span id="val-contrast">100%</span></div>
-                <div><label><?php esc_html_e('Niveaux de gris', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="grayscale" min="0" max="100" value="0" step="5"> <span id="val-grayscale">0%</span></div>
-                <div><label><?php esc_html_e('Rotation de teinte', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="hue-rotate" min="0" max="360" value="0" step="15"> <span id="val-hue-rotate">0deg</span></div>
-                <div><label><?php esc_html_e('Saturation', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="saturate" min="0" max="200" value="100" step="5"> <span id="val-saturate">100%</span></div>
+                <div><label><?php esc_html_e('Flou (Blur)', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="blur" min="0" max="20" value="0" step="1"> <span id="val-blur"><?php echo esc_html__('0px', 'supersede-css-jlg'); ?></span></div>
+                <div><label><?php esc_html_e('Luminosité', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="brightness" min="0" max="200" value="100" step="5"> <span id="val-brightness"><?php echo esc_html__('100%', 'supersede-css-jlg'); ?></span></div>
+                <div><label><?php esc_html_e('Contraste', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="contrast" min="0" max="200" value="100" step="5"> <span id="val-contrast"><?php echo esc_html__('100%', 'supersede-css-jlg'); ?></span></div>
+                <div><label><?php esc_html_e('Niveaux de gris', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="grayscale" min="0" max="100" value="0" step="5"> <span id="val-grayscale"><?php echo esc_html__('0%', 'supersede-css-jlg'); ?></span></div>
+                <div><label><?php esc_html_e('Rotation de teinte', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="hue-rotate" min="0" max="360" value="0" step="15"> <span id="val-hue-rotate"><?php echo esc_html__('0deg', 'supersede-css-jlg'); ?></span></div>
+                <div><label><?php esc_html_e('Saturation', 'supersede-css-jlg'); ?></label><input type="range" class="ssc-filter-prop" data-prop="saturate" min="0" max="200" value="100" step="5"> <span id="val-saturate"><?php echo esc_html__('100%', 'supersede-css-jlg'); ?></span></div>
             </div>
             <hr>
             <h3><?php printf(wp_kses_post(__('Effet Verre (%s)', 'supersede-css-jlg')), '<code>backdrop-filter</code>'); ?></h3>

--- a/supersede-css-jlg-enhanced/views/grid-editor.php
+++ b/supersede-css-jlg-enhanced/views/grid-editor.php
@@ -12,11 +12,11 @@ if (!defined('ABSPATH')) {
 
             <label><strong><?php esc_html_e('Nombre de colonnes', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
-            <span id="ssc-grid-cols-val">3</span>
+            <span id="ssc-grid-cols-val"><?php echo esc_html__('3', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Espacement (gap) en pixels', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
-            <span id="ssc-grid-gap-val">16px</span>
+            <span id="ssc-grid-gap-val"><?php echo esc_html__('16px', 'supersede-css-jlg'); ?></span>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
                 <button id="ssc-grid-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>

--- a/supersede-css-jlg-enhanced/views/tron-grid.php
+++ b/supersede-css-jlg-enhanced/views/tron-grid.php
@@ -22,15 +22,15 @@ if (!defined('ABSPATH')) {
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Taille de la grille (pixels)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5">
-            <span id="ssc-tron-size-val">50px</span>
+            <span id="ssc-tron-size-val"><?php echo esc_html__('50px', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Épaisseur des lignes (pixels)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1">
-            <span id="ssc-tron-thickness-val">1px</span>
+            <span id="ssc-tron-thickness-val"><?php echo esc_html__('1px', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Vitesse de l\'animation (secondes)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1">
-            <span id="ssc-tron-speed-val">10s</span>
+            <span id="ssc-tron-speed-val"><?php echo esc_html__('10s', 'supersede-css-jlg'); ?></span>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
                 <button id="ssc-tron-apply" class="button button-primary"><?php esc_html_e('Appliquer sur le site', 'supersede-css-jlg'); ?></button>

--- a/supersede-css-jlg-enhanced/views/typography-editor.php
+++ b/supersede-css-jlg-enhanced/views/typography-editor.php
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
             <div class="ssc-typo-vp-slider-container">
                 <label><?php esc_html_e('Largeur du viewport (px)', 'supersede-css-jlg'); ?></label>
                 <input type="range" id="ssc-typo-vp-slider" min="320" max="1280" value="960">
-                <span id="ssc-typo-vp-value">960px</span>
+                <span id="ssc-typo-vp-value"><?php echo esc_html__('960px', 'supersede-css-jlg'); ?></span>
             </div>
             <div id="ssc-typo-preview" style="margin-top: 16px; font-size: clamp(16px, 3vw, 48px);"><?php esc_html_e('Design fluide, lecture parfaite.', 'supersede-css-jlg'); ?></div>
         </div>

--- a/supersede-css-jlg-enhanced/views/visual-effects.php
+++ b/supersede-css-jlg-enhanced/views/visual-effects.php
@@ -55,14 +55,14 @@ if (!defined('ABSPATH')) {
                 <label style="margin-top:16px;"><strong><?php esc_html_e('Couleur de la ligne', 'supersede-css-jlg'); ?></strong></label>
                 <input type="color" id="ssc-ecg-color" value="#00ff00">
                 <label style="margin-top:16px;"><strong><?php esc_html_e('Positionnement (top)', 'supersede-css-jlg'); ?></strong></label>
-                <input type="range" id="ssc-ecg-top" min="0" max="100" value="50" step="1"><span id="ssc-ecg-top-val">50%</span>
+                <input type="range" id="ssc-ecg-top" min="0" max="100" value="50" step="1"><span id="ssc-ecg-top-val"><?php echo esc_html__('50%', 'supersede-css-jlg'); ?></span>
                 <label style="margin-top:16px;"><strong><?php esc_html_e('Superposition (z-index)', 'supersede-css-jlg'); ?></strong></label>
-                <input type="range" id="ssc-ecg-z-index" min="-10" max="10" value="1" step="1"><span id="ssc-ecg-z-index-val">1</span>
+                <input type="range" id="ssc-ecg-z-index" min="-10" max="10" value="1" step="1"><span id="ssc-ecg-z-index-val"><?php echo esc_html__('1', 'supersede-css-jlg'); ?></span>
                 <hr>
                 <label><strong><?php esc_html_e('Logo/Image au centre', 'supersede-css-jlg'); ?></strong></label>
                 <button id="ssc-ecg-upload-btn" class="button"><?php esc_html_e('Choisir une image', 'supersede-css-jlg'); ?></button>
                 <label style="margin-top:16px;"><strong><?php esc_html_e('Taille du logo', 'supersede-css-jlg'); ?></strong></label>
-                <input type="range" id="ssc-ecg-logo-size" min="20" max="200" value="100" step="1"><span id="ssc-ecg-logo-size-val">100px</span>
+                <input type="range" id="ssc-ecg-logo-size" min="20" max="200" value="100" step="1"><span id="ssc-ecg-logo-size-val"><?php echo esc_html__('100px', 'supersede-css-jlg'); ?></span>
                 <hr>
                 <pre id="ssc-ecg-css" class="ssc-code ssc-code-small" style="margin-top:16px;"></pre>
                 <button id="ssc-ecg-apply" class="button button-primary" style="margin-top:8px;"><?php esc_html_e('Appliquer l\'Effet', 'supersede-css-jlg'); ?></button>


### PR DESCRIPTION
## Summary
- wrap remaining literal default values in view templates with translation helpers
- translate the Debug Center fallback plugin version label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d707a3dee4832ea893613e29c5fab6