### PR TITLE
Add i18n integration for utilities editor

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/utilities.js
+++ b/supersede-css-jlg-enhanced/assets/js/utilities.js
@@ -1,14 +1,18 @@
 (function($) {
-    const i18n = (typeof window !== 'undefined' && window.wp && window.wp.i18n)
-        ? window.wp.i18n
-        : {
-            __: (text) => text,
-            _x: (text) => text,
-            _n: (single, plural, number) => (number === 1 ? single : plural),
-            _nx: (single, plural, number) => (number === 1 ? single : plural),
-        };
+    const fallbackI18n = {
+        __: (text) => text,
+        _x: (text) => text,
+        _n: (single, plural, number) => (number === 1 ? single : plural),
+        _nx: (single, plural, number) => (number === 1 ? single : plural),
+    };
 
-    const { __, _x, _n, _nx } = i18n;
+    const hasI18n = typeof window !== 'undefined' && window.wp && window.wp.i18n;
+    const { __, _x, _n, _nx } = hasI18n ? window.wp.i18n : fallbackI18n;
+
+    if (!hasI18n) {
+        // eslint-disable-next-line no-console
+        console.warn(__('wp.i18n is not available. Falling back to untranslated strings.', 'supersede-css-jlg'));
+    }
 
     let editors = {};
     let pickerActive = false;

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -243,7 +243,11 @@ final class Admin
                     wp_enqueue_script($script_handle, SSC_PLUGIN_URL . $path, $dependencies, SSC_VERSION, true);
 
                     if ($handle === 'utilities' && function_exists('wp_set_script_translations')) {
-                        wp_set_script_translations($script_handle, 'supersede-css-jlg');
+                        wp_set_script_translations(
+                            $script_handle,
+                            'supersede-css-jlg',
+                            SSC_PLUGIN_DIR . 'languages'
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- update the utilities editor script to rely on WordPress `wp.i18n` helpers while keeping a safe fallback when the package is missing
- link the script handle to the plugin text domain and languages directory so JavaScript translations can be loaded

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70feb332c832ebddccdfae6aa6b19