### PR TITLE
Wrap scope builder pseudo-class labels with translation helpers

### DIFF
--- a/supersede-css-jlg-enhanced/views/scope-builder.php
+++ b/supersede-css-jlg-enhanced/views/scope-builder.php
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
     <div class="ssc-two" style="align-items: flex-start;">
         <div class="ssc-pane">
             <label><?php esc_html_e('Sélecteur(s)', 'supersede-css-jlg'); ?></label><input type="text" id="ssc-sel" class="large-text" placeholder="<?php echo esc_attr__('.btn, .card > a', 'supersede-css-jlg'); ?>">
-            <label><?php esc_html_e('Pseudo-classe', 'supersede-css-jlg'); ?></label><select id="ssc-pseudo"><option value=""><?php esc_html_e('(aucune)', 'supersede-css-jlg'); ?></option><option value=":hover">:hover</option><option value=":focus">:focus</option></select>
+            <label><?php esc_html_e('Pseudo-classe', 'supersede-css-jlg'); ?></label><select id="ssc-pseudo"><option value=""><?php esc_html_e('(aucune)', 'supersede-css-jlg'); ?></option><option value=":hover"><?php esc_html_e(':hover', 'supersede-css-jlg'); ?></option><option value=":focus"><?php esc_html_e(':focus', 'supersede-css-jlg'); ?></option></select>
             <label><?php esc_html_e('Propriétés CSS', 'supersede-css-jlg'); ?></label><textarea id="ssc-css" rows="12" class="code"></textarea>
             <div class="ssc-actions"><button id="ssc-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button><button id="ssc-copy" class="button"><?php esc_html_e('Copier', 'supersede-css-jlg'); ?></button></div>
         </div>


### PR DESCRIPTION
## Summary
- ensure the scope builder pseudo-class dropdown options use `esc_html_e()` with the `supersede-css-jlg` textdomain
- allow the `:hover` and `:focus` labels to be translated like the rest of the interface

## Testing
- php -l supersede-css-jlg-enhanced/views/scope-builder.php

------
https://chatgpt.com/codex/tasks/task_e_68d717f797cc832ebfe27f8e2dc4c58d