### PR TITLE
Preserve underscores in token registry normalization

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -149,7 +149,7 @@ final class TokenRegistry
                 $rawName = '--' . ltrim($rawName, '-');
             }
 
-            $normalizedName = '--' . preg_replace('/[^a-z0-9\-]+/i', '-', ltrim($rawName, '-'));
+            $normalizedName = '--' . preg_replace('/[^a-z0-9_-]+/i', '-', ltrim($rawName, '-'));
             if ($normalizedName === '--') {
                 continue;
             }

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -178,3 +178,53 @@ if ($mergedTokens[1]['type'] !== 'text' || $mergedTokens[1]['group'] !== 'Legacy
     fwrite(STDERR, 'mergeMetadata should leave unmatched tokens untouched.' . PHP_EOL);
     exit(1);
 }
+
+$ssc_options_store = [];
+
+$underscoredTokens = [
+    [
+        'name' => '--spacing_small',
+        'value' => '8px',
+        'type' => 'text',
+        'description' => 'Spacing token with underscore.',
+        'group' => 'Spacing',
+    ],
+];
+
+$savedRegistry = TokenRegistry::saveRegistry($underscoredTokens);
+
+if ($savedRegistry === [] || $savedRegistry[0]['name'] !== '--spacing_small') {
+    fwrite(STDERR, 'saveRegistry should preserve underscores in token names.' . PHP_EOL);
+    exit(1);
+}
+
+if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
+    fwrite(STDERR, 'saveRegistry should persist the registry with the underscored token.' . PHP_EOL);
+    exit(1);
+}
+
+$storedRegistry = $ssc_options_store['ssc_tokens_registry'];
+
+if ($storedRegistry === [] || $storedRegistry[0]['name'] !== '--spacing_small') {
+    fwrite(STDERR, 'Persisted registry should keep underscores in token names.' . PHP_EOL);
+    exit(1);
+}
+
+if (!isset($ssc_options_store['ssc_tokens_css']) || strpos($ssc_options_store['ssc_tokens_css'], '--spacing_small') === false) {
+    fwrite(STDERR, 'Persisted CSS should include the underscored token name.' . PHP_EOL);
+    exit(1);
+}
+
+$roundTrip = TokenRegistry::getRegistry();
+
+if ($roundTrip === [] || $roundTrip[0]['name'] !== '--spacing_small') {
+    fwrite(STDERR, 'getRegistry should return tokens with underscores intact.' . PHP_EOL);
+    exit(1);
+}
+
+$roundTripCss = TokenRegistry::tokensToCss($roundTrip);
+
+if (strpos($roundTripCss, '--spacing_small') === false) {
+    fwrite(STDERR, 'tokensToCss should keep underscores after round-trip.' . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- update token normalization to keep underscores while filtering unsafe characters
- add a regression test covering saving, persisting, and reloading underscored tokens

## Testing
- php tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d723d8da3c832eb0d18115893a04aa