### PR TITLE
Prevent token reload from overwriting local edits

### DIFF
--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -22,6 +22,7 @@ if (function_exists('wp_localize_script')) {
             'deleteLabel' => __('Supprimer', 'supersede-css-jlg'),
             'saveSuccess' => __('Tokens enregistrés', 'supersede-css-jlg'),
             'saveError' => __('Impossible d’enregistrer les tokens.', 'supersede-css-jlg'),
+            'reloadConfirm' => __('Des modifications locales non enregistrées seront perdues. Continuer ?', 'supersede-css-jlg'),
         ],
     ]);
 }
@@ -88,6 +89,7 @@ if (function_exists('wp_localize_script')) {
             <div class="ssc-actions" style="margin-top:8px; display:flex; gap:8px; flex-wrap:wrap;">
                 <button id="ssc-tokens-save" class="button button-primary"><?php esc_html_e('Enregistrer les Tokens', 'supersede-css-jlg'); ?></button>
                 <button id="ssc-tokens-copy" class="button"><?php esc_html_e('Copier le CSS', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-tokens-reload" class="button" type="button"><?php esc_html_e('Recharger', 'supersede-css-jlg'); ?></button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- track unsaved token edits with a local change flag and skip remote overwrites while editing
- add a manual "Recharger" action that confirms before discarding local changes and re-syncing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d0080140832eaba7da07bb743936