### PR TITLE
Allow underscores in token names and extend UI test coverage

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/tokens.js
+++ b/supersede-css-jlg-enhanced/assets/js/tokens.js
@@ -73,7 +73,7 @@
         if (name.indexOf('--') !== 0) {
             name = '--' + name.replace(/^-+/, '');
         }
-        return name.replace(/[^a-zA-Z0-9\-]/g, '-');
+        return name.replace(/[^a-zA-Z0-9_\-]/g, '-');
     }
 
     function ensureGroupDatalist(groups) {


### PR DESCRIPTION
## Summary
- allow underscores when normalizing token names in the admin UI
- adjust the Playwright UI scenario to preload data, ensure CORS headers, and assert underscore preservation through save/delete cycles

## Testing
- npm run test:ui

------
https://chatgpt.com/codex/tasks/task_e_68d7d2a312e4832eb207d28b801f6046