### PR TITLE
Ensure export filtering applies to explicit module selections

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesExportFilterTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesExportFilterTest.php
@@ -251,6 +251,34 @@ if (!is_array($allData) || !array_key_exists('ssc_custom_extra', $allData)) {
     exit(1);
 }
 
+$exportExplicitAll = $routes->exportConfig(new WP_REST_Request(['modules' => ['all']]));
+
+if (!$exportExplicitAll instanceof WP_REST_Response) {
+    fwrite(STDERR, 'Exporting with an explicit "all" module selection should return a WP_REST_Response.' . PHP_EOL);
+    exit(1);
+}
+
+$explicitAllData = $exportExplicitAll->get_data();
+
+if (!is_array($explicitAllData) || array_key_exists('ssc_custom_extra', $explicitAllData)) {
+    fwrite(STDERR, 'Explicit "all" module selection should filter out options that are not part of any module.' . PHP_EOL);
+    exit(1);
+}
+
+$expectedAllKeys = [
+    'ssc_settings',
+    'ssc_presets',
+    'ssc_tokens_css',
+    'ssc_tokens_registry',
+];
+
+foreach ($expectedAllKeys as $expectedKey) {
+    if (!array_key_exists($expectedKey, $explicitAllData)) {
+        fwrite(STDERR, 'Explicit "all" module selection should keep whitelisted option ' . $expectedKey . '.' . PHP_EOL);
+        exit(1);
+    }
+}
+
 $exportTokens = $routes->exportConfig(new WP_REST_Request(['modules' => ['tokens']]));
 
 if (!$exportTokens instanceof WP_REST_Response) {


### PR DESCRIPTION
## Summary
- ensure module filtering always uses the whitelist when a module selection is provided while keeping default exports unchanged
- add coverage verifying explicit "all" module exports omit unmapped options

## Testing
- php tests/Infra/RoutesExportFilterTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d83672ee80832e915bda9c070a50d6