### PR TITLE
Translate supported token labels

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -123,7 +123,13 @@ final class TokenRegistry
      */
     public static function getSupportedTypes(): array
     {
-        return self::SUPPORTED_TYPES;
+        $types = self::SUPPORTED_TYPES;
+
+        foreach ($types as $key => $type) {
+            $types[$key]['label'] = __($type['label'], 'supersede-css-jlg');
+        }
+
+        return $types;
     }
 
     /**

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -41,6 +41,13 @@ if (!function_exists('wp_allowed_protocols')) {
     }
 }
 
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return sprintf('[%s] %s', $domain, $text);
+    }
+}
+
 /** @var array<string, mixed> $ssc_options_store */
 $ssc_options_store = [];
 
@@ -195,6 +202,13 @@ $savedRegistry = TokenRegistry::saveRegistry($underscoredTokens);
 
 if ($savedRegistry === [] || $savedRegistry[0]['name'] !== '--spacing_small') {
     fwrite(STDERR, 'saveRegistry should preserve underscores in token names.' . PHP_EOL);
+    exit(1);
+}
+
+$supportedTypes = TokenRegistry::getSupportedTypes();
+
+if (!isset($supportedTypes['color']['label']) || $supportedTypes['color']['label'] !== '[supersede-css-jlg] Couleur') {
+    fwrite(STDERR, 'getSupportedTypes should return translated labels.' . PHP_EOL);
     exit(1);
 }
 


### PR DESCRIPTION
## Summary
- translate supported token labels at runtime
- update token registry tests to account for translated labels

## Testing
- php supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d83b3925b0832e916d1d4dcc1df507