### PR TITLE
Revoke temporary object URLs after downloads

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/import-export.js
+++ b/supersede-css-jlg-enhanced/assets/js/import-export.js
@@ -2,12 +2,19 @@
     // Fonction pour déclencher le téléchargement d'un fichier
     function downloadFile(filename, content, mimeType) {
         const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
+        a.href = url;
         a.download = filename;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
+        const revoke = () => URL.revokeObjectURL(url);
+        if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(revoke);
+        } else {
+            setTimeout(revoke, 0);
+        }
     }
 
     $(document).ready(function() {


### PR DESCRIPTION
## Summary
- update downloadFile helper to cache the generated object URL before using it
- revoke the object URL after triggering the download to avoid leaking blobs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d91e27594c832e98eccb44d49c7610