### PR TITLE
Ensure exported downloads revoke object URLs

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/import-export.js
+++ b/supersede-css-jlg-enhanced/assets/js/import-export.js
@@ -7,13 +7,19 @@
         a.href = url;
         a.download = filename;
         document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
         const revoke = () => URL.revokeObjectURL(url);
-        if (typeof requestAnimationFrame === 'function') {
-            requestAnimationFrame(revoke);
-        } else {
-            setTimeout(revoke, 0);
+
+        try {
+            a.click();
+        } finally {
+            if (a.parentNode) {
+                a.parentNode.removeChild(a);
+            }
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(revoke);
+            } else {
+                setTimeout(revoke, 0);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- wrap the temporary download link in a try/finally block to guarantee cleanup
- schedule URL.revokeObjectURL after triggering the download so blob URLs do not leak

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92107c8b4832ebea0dbf816956616