### PR TITLE
Allow customizing Supersede CSS capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Supersede CSS JLG (Enhanced) is a visual toolkit for building CSS effects in Wor
 4. Use the **Token Manager** to add or edit CSS tokens; reference tokens within your custom styles.
 5. Export or import presets as needed from the built‑in tools.
 
+## Hooks
+
+### `ssc_required_capability`
+
+Filter the capability required to access the Supersede CSS admin pages and REST API endpoints. By default the plugin uses
+`manage_options`, but site administrators can delegate access with a simple filter:
+
+```php
+add_filter('ssc_required_capability', function () {
+    return 'edit_theme_options';
+});
+```
+
 ## License
 
 Supersede CSS JLG (Enhanced) is released under the [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html).

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -10,7 +10,7 @@ final class Admin
 
     public function __construct() {
         $this->slug = 'supersede-css-jlg';
-        $this->cap  = 'manage_options';
+        $this->cap  = \ssc_get_required_capability();
 
         add_action('admin_menu', [$this, 'menu']);
         add_action('admin_enqueue_scripts', [$this, 'assets']);

--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -1164,7 +1164,9 @@ final class Routes {
             );
         }
 
-        if (!current_user_can('manage_options')) {
+        $required_capability = \ssc_get_required_capability();
+
+        if (!current_user_can($required_capability)) {
             return new \WP_Error(
                 'rest_forbidden',
                 __('You are not allowed to access this endpoint.', 'supersede-css-jlg'),

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -32,6 +32,27 @@ spl_autoload_register(function($class){
     }
 });
 
+if (!function_exists('ssc_get_required_capability')) {
+    /**
+     * Returns the capability required to access Supersede CSS features.
+     *
+     * Developers can override the default capability (`manage_options`) by
+     * hooking into the `ssc_required_capability` filter.
+     *
+     * @return string
+     */
+    function ssc_get_required_capability(): string
+    {
+        $capability = apply_filters('ssc_required_capability', 'manage_options');
+
+        if (!is_string($capability) || $capability === '') {
+            $capability = 'manage_options';
+        }
+
+        return $capability;
+    }
+}
+
 if (!function_exists('ssc_get_cached_css')) {
     function ssc_get_cached_css(): string
     {


### PR DESCRIPTION
## Summary
- add a helper function that filters the required capability for Supersede CSS
- reuse the helper for the admin menu and REST route authorization
- document the new `ssc_required_capability` filter in the README

## Testing
- php -l supersede-css-jlg-enhanced/supersede-css-jlg.php
- php -l supersede-css-jlg-enhanced/src/Admin/Admin.php
- php -l supersede-css-jlg-enhanced/src/Infra/Routes.php

------
https://chatgpt.com/codex/tasks/task_e_68d99f843c90832ea2ff8c9f5f562221