### PR TITLE
Sanitize CSS viewer options

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Pages/CssViewer.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/CssViewer.php
@@ -14,9 +14,19 @@ class CssViewer extends AbstractPage
 
     public function render(): void
     {
+        $active_css = get_option('ssc_active_css', self::EMPTY_MESSAGE);
+        if (!is_string($active_css)) {
+            $active_css = self::EMPTY_MESSAGE;
+        }
+
+        $tokens_css = get_option('ssc_tokens_css', self::EMPTY_MESSAGE);
+        if (!is_string($tokens_css)) {
+            $tokens_css = self::EMPTY_MESSAGE;
+        }
+
         $this->render_view('css-viewer', [
-            'active_css' => get_option('ssc_active_css', self::EMPTY_MESSAGE),
-            'tokens_css' => get_option('ssc_tokens_css', self::EMPTY_MESSAGE),
+            'active_css' => $active_css,
+            'tokens_css' => $tokens_css,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the CSS viewer options are sanitized before rendering
- use the sanitized values to avoid passing unexpected types to the view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da573c5770832e902a8ffc71222306