### PR TITLE
Sanitize raw token JSON payload before decoding

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -410,7 +410,8 @@ final class Routes {
         if (!is_array($payload)) {
             $rawTokens = $request->get_param('tokens');
             if (is_string($rawTokens)) {
-                $decoded = json_decode($rawTokens, true);
+                // Mirror savePresets() by unslashing the raw payload before decoding JSON.
+                $decoded = json_decode(wp_unslash($rawTokens), true);
                 $payload = ['tokens' => $decoded];
             } elseif (is_array($rawTokens)) {
                 $payload = ['tokens' => $rawTokens];


### PR DESCRIPTION
## Summary
- mirror the presets handler by unslashing raw token payloads before JSON decoding
- document the behavior so future changes keep parity between handlers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da628b383c832eb4ab8a420c399c85