### PR TITLE
Localize import/export admin script strings

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -234,7 +234,7 @@ final class Admin
                 $path = 'assets/js/' . $handle . '.js';
                 if (is_file(SSC_PLUGIN_DIR . $path)) {
                     $dependencies = ['jquery'];
-                    if ($handle === 'utilities') {
+                    if (in_array($handle, ['utilities', 'import-export'], true)) {
                         $dependencies[] = 'wp-i18n';
                     }
 
@@ -242,7 +242,7 @@ final class Admin
 
                     wp_enqueue_script($script_handle, SSC_PLUGIN_URL . $path, $dependencies, SSC_VERSION, true);
 
-                    if ($handle === 'utilities' && function_exists('wp_set_script_translations')) {
+                    if (in_array($handle, ['utilities', 'import-export'], true) && function_exists('wp_set_script_translations')) {
                         wp_set_script_translations(
                             $script_handle,
                             'supersede-css-jlg',

--- a/supersede-css-jlg-enhanced/views/import-export.php
+++ b/supersede-css-jlg-enhanced/views/import-export.php
@@ -6,6 +6,10 @@ if (!defined('ABSPATH')) {
 }
 
 $modules = Routes::getConfigModules();
+
+if (function_exists('wp_set_script_translations')) {
+    wp_set_script_translations('ssc-import-export', 'supersede-css-jlg', SSC_PLUGIN_DIR . 'languages');
+}
 ?>
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('Import / Export', 'supersede-css-jlg'); ?></h2>


### PR DESCRIPTION
## Summary
- add a wp.i18n fallback to the import/export script and translate all UI strings
- load wp-i18n for the import/export bundle and register its translations
- ensure the import/export view wires up script translations when rendered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da7a3eb420832eba56c2a89e85a37f