### PR TITLE
Propagate import context into JSON string sanitization

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -882,7 +882,7 @@ final class Routes {
             }
 
             if (is_string($item)) {
-                $sanitized[$sanitizedKey] = $this->sanitizeImportStringValue($item);
+                $sanitized[$sanitizedKey] = $this->sanitizeImportStringValue($item, $depth, $objectStack, $itemBudget);
                 continue;
             }
 
@@ -917,11 +917,11 @@ final class Routes {
                     $encoded = '';
                 }
 
-                $sanitized[$sanitizedKey] = $this->sanitizeImportStringValue($encoded);
+                $sanitized[$sanitizedKey] = $this->sanitizeImportStringValue($encoded, $depth, $objectStack, $itemBudget);
                 continue;
             }
 
-            $sanitized[$sanitizedKey] = $this->sanitizeImportStringValue((string) $item);
+            $sanitized[$sanitizedKey] = $this->sanitizeImportStringValue((string) $item, $depth, $objectStack, $itemBudget);
         }
 
         return $sanitized;
@@ -964,7 +964,7 @@ final class Routes {
         return $sanitized !== '' ? $sanitized : null;
     }
 
-    private function sanitizeImportStringValue(string $value): string
+    private function sanitizeImportStringValue(string $value, int $depth = 0, ?\SplObjectStorage $objectStack = null, ?int &$itemBudget = null): string
     {
         if (function_exists('wp_check_invalid_utf8')) {
             $value = wp_check_invalid_utf8($value);
@@ -982,7 +982,7 @@ final class Routes {
             $decoded = json_decode($trimmed, true);
 
             if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
-                $sanitized = $this->sanitizeImportArray($decoded);
+                $sanitized = $this->sanitizeImportArray($decoded, $depth + 1, $objectStack, $itemBudget);
 
                 if ($sanitized !== null) {
                     $jsonOptions = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
@@ -998,6 +998,8 @@ final class Routes {
                     if (is_string($encoded)) {
                         $value = $encoded;
                     }
+                } else {
+                    $value = '';
                 }
             }
         }

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesImportJsonLimitTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesImportJsonLimitTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+use SSC\Infra\Routes;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key)
+    {
+        $key = strtolower((string) $key);
+
+        return preg_replace('/[^a-z0-9_]/', '', $key);
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($value, $options = 0, $depth = 512)
+    {
+        return json_encode($value, $options, $depth);
+    }
+}
+
+if (!function_exists('wp_check_invalid_utf8')) {
+    function wp_check_invalid_utf8($string)
+    {
+        return (string) $string;
+    }
+}
+
+if (!function_exists('wp_kses')) {
+    function wp_kses($string, $allowed_html)
+    {
+        unset($allowed_html);
+
+        return strip_tags((string) $string);
+    }
+}
+
+require_once __DIR__ . '/../../src/Support/CssSanitizer.php';
+require_once __DIR__ . '/../../src/Support/TokenRegistry.php';
+require_once __DIR__ . '/../../src/Infra/Logger.php';
+require_once __DIR__ . '/../../src/Infra/Routes.php';
+
+$routesReflection = new ReflectionClass(Routes::class);
+$routes = $routesReflection->newInstanceWithoutConstructor();
+
+$sanitizeImportArray = $routesReflection->getMethod('sanitizeImportArray');
+$sanitizeImportArray->setAccessible(true);
+
+$maxDepthConst = $routesReflection->getReflectionConstant('IMPORT_MAX_DEPTH');
+
+if ($maxDepthConst === false) {
+    fwrite(STDERR, 'Unable to read import depth limit from Routes class.' . PHP_EOL);
+    exit(1);
+}
+
+$maxDepth = (int) $maxDepthConst->getValue();
+
+$payload = [];
+$cursor = &$payload;
+
+for ($i = 0; $i < $maxDepth; $i++) {
+    $key = 'layer_' . $i;
+    $cursor[$key] = [];
+    $cursor = &$cursor[$key];
+}
+
+$cursor['encoded'] = json_encode(['should' => 'fail'], JSON_UNESCAPED_SLASHES);
+
+$sanitized = $sanitizeImportArray->invoke($routes, $payload);
+
+if (!is_array($sanitized)) {
+    fwrite(STDERR, 'Sanitized payload should remain an array.' . PHP_EOL);
+    exit(1);
+}
+
+$cursor = $sanitized;
+
+for ($i = 0; $i < $maxDepth; $i++) {
+    $key = 'layer_' . $i;
+
+    if (!isset($cursor[$key]) || !is_array($cursor[$key])) {
+        fwrite(STDERR, 'Expected nested layers to be preserved during sanitization.' . PHP_EOL);
+        exit(1);
+    }
+
+    $cursor = $cursor[$key];
+}
+
+if (($cursor['encoded'] ?? null) !== '') {
+    fwrite(STDERR, 'JSON strings exceeding depth limit should be rejected when sanitizing imports.' . PHP_EOL);
+    exit(1);
+}
+


### PR DESCRIPTION
## Summary
- propagate the depth, object stack, and shared budget when sanitizing string values within imported arrays
- discard JSON string payloads when their decoded structure violates depth/item constraints
- add a regression test that ensures deeply nested JSON strings are rejected during import sanitization

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/RoutesImportJsonLimitTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dac81b5e44832eb0993294e2e04f48