### PR TITLE
Ensure CSS cache meta option removed during uninstall

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php
@@ -48,3 +48,4 @@ if (!function_exists('assertOptionDeleted')) {
 }
 
 assertOptionDeleted('ssc_css_cache', $ssc_deleted_options);
+assertOptionDeleted('ssc_css_cache_meta', $ssc_deleted_options);

--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -19,6 +19,7 @@ $ssc_options_to_delete = [
     'ssc_css_tablet', // Ajouté
     'ssc_css_mobile', // Ajouté
     'ssc_css_cache', // Ajouté
+    'ssc_css_cache_meta', // Ajouté
     'ssc_avatar_glow_presets', // Ajouté
     'ssc_optimization_settings', // Ajouté
 ];


### PR DESCRIPTION
## Summary
- include the ssc_css_cache_meta option in the uninstall cleanup list so it is removed from all sites
- extend the uninstall QA test to verify that the ssc_css_cache_meta option is deleted

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dad6b7c9f4832e8734631c4d6cb658