### PR TITLE
Fix parsing of comment-prefixed CSS tokens

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -214,8 +214,30 @@ final class TokenRegistry
             }
 
             $before = $declarationStart - 1;
-            while ($before >= 0 && ctype_space($css[$before])) {
-                $before--;
+            while ($before >= 0) {
+                $character = $css[$before];
+
+                if (ctype_space($character)) {
+                    $before--;
+                    continue;
+                }
+
+                if ($character === '/' && $before > 0 && $css[$before - 1] === '*') {
+                    $before -= 2;
+
+                    while ($before >= 0) {
+                        if ($css[$before] === '/' && ($before + 1) < $length && $css[$before + 1] === '*') {
+                            $before--;
+                            break;
+                        }
+
+                        $before--;
+                    }
+
+                    continue;
+                }
+
+                break;
             }
 
             if ($before >= 0 && !in_array($css[$before], ['{', ';'], true)) {

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -242,3 +242,25 @@ if (strpos($roundTripCss, '--spacing_small') === false) {
     fwrite(STDERR, 'tokensToCss should keep underscores after round-trip.' . PHP_EOL);
     exit(1);
 }
+
+$ssc_options_store = [];
+
+$cssWithLeadingComment = '/* initial token */ --comment-prefixed: 24px;';
+$registryFromCommentedCss = TokenRegistry::convertCssToRegistry($cssWithLeadingComment);
+
+if ($registryFromCommentedCss === [] || $registryFromCommentedCss[0]['name'] !== '--comment-prefixed') {
+    fwrite(STDERR, 'convertCssToRegistry should parse tokens after comment delimiters.' . PHP_EOL);
+    exit(1);
+}
+
+TokenRegistry::saveRegistry($registryFromCommentedCss);
+
+if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
+    fwrite(STDERR, 'saveRegistry should persist tokens parsed after leading comments.' . PHP_EOL);
+    exit(1);
+}
+
+if (!isset($ssc_options_store['ssc_tokens_css']) || strpos($ssc_options_store['ssc_tokens_css'], '--comment-prefixed') === false) {
+    fwrite(STDERR, 'Persisted CSS should include tokens parsed after leading comments.' . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- skip CSS block comments when validating the prefix before a custom property declaration
- cover comment-prefixed tokens with a regression test to ensure they are imported and saved

## Testing
- php supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dbe8d76100832ea6c10375595307fc