### PR TITLE
Handle CSS comments before tokens

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -213,14 +213,21 @@ final class TokenRegistry
                 break;
             }
 
-            $before = $declarationStart - 1;
-            while ($before >= 0 && ctype_space($css[$before])) {
-                $before--;
+            $prefix = substr($css, 0, $declarationStart);
+            $prefixWithoutComments = preg_replace('#/\*[^*]*\*+(?:[^/*][^*]*\*+)*/#', ' ', $prefix);
+
+            if (!is_string($prefixWithoutComments)) {
+                $prefixWithoutComments = $prefix;
             }
 
-            if ($before >= 0 && !in_array($css[$before], ['{', ';'], true)) {
-                $cursor = $declarationStart + 2;
-                continue;
+            $prefixWithoutComments = rtrim($prefixWithoutComments);
+
+            if ($prefixWithoutComments !== '') {
+                $lastCharacter = substr($prefixWithoutComments, -1);
+                if ($lastCharacter !== '{' && $lastCharacter !== ';') {
+                    $cursor = $declarationStart + 2;
+                    continue;
+                }
             }
 
             $name = '--';

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -186,6 +186,36 @@ if ($mergedTokens[1]['type'] !== 'text' || $mergedTokens[1]['group'] !== 'Legacy
     exit(1);
 }
 
+$ssc_options_store = [
+    'ssc_tokens_css' => <<<'CSS'
+:root {
+    /* note */ --commented-token: 42px;
+}
+CSS
+];
+
+$importedWithComment = TokenRegistry::getRegistry();
+
+if ($importedWithComment === [] || $importedWithComment[0]['name'] !== '--commented-token') {
+    fwrite(STDERR, 'getRegistry should import tokens that follow a CSS comment.' . PHP_EOL);
+    exit(1);
+}
+
+if ($importedWithComment[0]['value'] !== '42px') {
+    fwrite(STDERR, 'Imported token values should be preserved when comments precede declarations.' . PHP_EOL);
+    exit(1);
+}
+
+if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
+    fwrite(STDERR, 'Imported tokens should be persisted to the registry option when comments are present.' . PHP_EOL);
+    exit(1);
+}
+
+if (strpos((string) ($ssc_options_store['ssc_tokens_css'] ?? ''), '--commented-token') === false) {
+    fwrite(STDERR, 'Imported tokens should be persisted back to CSS even when comments precede them.' . PHP_EOL);
+    exit(1);
+}
+
 $ssc_options_store = [];
 
 $underscoredTokens = [


### PR DESCRIPTION
## Summary
- ignore CSS comments when validating the prefix of custom property declarations during CSS registry import
- add a regression test ensuring commented custom properties are imported and persisted correctly

## Testing
- php supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dbe8d53930832ea0d6050017b0f086