### PR TITLE
Handle comment-prefixed CSS tokens

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -237,12 +237,30 @@ final class TokenRegistry
                     continue;
                 }
 
+                if ($character === '/' && ($before + 1) < $length && $css[$before + 1] === '*') {
+                    $before--;
+                    continue;
+                }
+
+                if ($character === '*' && $before > 0 && $css[$before - 1] === '/') {
+                    $before -= 2;
+                    continue;
+                }
+
+                if ($character === '*' && ($before + 1) < $length && $css[$before + 1] === '/') {
+                    $before--;
+                    continue;
+                }
+
                 break;
             }
 
-            if ($before >= 0 && !in_array($css[$before], ['{', ';'], true)) {
-                $cursor = $declarationStart + 2;
-                continue;
+            if ($before >= 0) {
+                $prefixCharacter = $css[$before];
+                if ($prefixCharacter !== '{' && $prefixCharacter !== ';') {
+                    $cursor = $declarationStart + 2;
+                    continue;
+                }
             }
 
             $name = '--';

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -264,3 +264,25 @@ if (!isset($ssc_options_store['ssc_tokens_css']) || strpos($ssc_options_store['s
     fwrite(STDERR, 'Persisted CSS should include tokens parsed after leading comments.' . PHP_EOL);
     exit(1);
 }
+
+$ssc_options_store = [];
+
+$annotatedCss = '/* note */ --my-token: value;';
+$annotatedRegistry = TokenRegistry::convertCssToRegistry($annotatedCss);
+
+if ($annotatedRegistry === [] || $annotatedRegistry[0]['name'] !== '--my-token') {
+    fwrite(STDERR, 'convertCssToRegistry should capture tokens defined after annotated comments.' . PHP_EOL);
+    exit(1);
+}
+
+TokenRegistry::saveRegistry($annotatedRegistry);
+
+if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
+    fwrite(STDERR, 'saveRegistry should persist tokens that follow annotated comments.' . PHP_EOL);
+    exit(1);
+}
+
+if (!isset($ssc_options_store['ssc_tokens_css']) || strpos($ssc_options_store['ssc_tokens_css'], '--my-token:value') === false) {
+    fwrite(STDERR, 'Persisted CSS should retain tokens declared after annotated comments.' . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- update `TokenRegistry::convertCssToRegistry()` to ignore block comment delimiters when locating token declarations
- add a regression test verifying comment-prefixed tokens are parsed and persisted

## Testing
- php supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
- php supersede-css-jlg-enhanced/tests/Infra/RoutesSaveCssTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dbf7540cd8832e884ec6215c469455