### PR TITLE
Preserve token metadata during CSS option imports

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -793,7 +793,12 @@ final class Routes {
 
             if ($optionName === 'ssc_tokens_css') {
                 $tokens = TokenRegistry::convertCssToRegistry($sanitizedValue);
-                TokenRegistry::saveRegistry($tokens);
+                $existingRegistry = get_option('ssc_tokens_registry', []);
+                if (!is_array($existingRegistry)) {
+                    $existingRegistry = [];
+                }
+                $tokensWithMetadata = TokenRegistry::mergeMetadata($tokens, $existingRegistry);
+                TokenRegistry::saveRegistry($tokensWithMetadata);
                 if (function_exists('\ssc_invalidate_css_cache')) {
                     \ssc_invalidate_css_cache();
                 }


### PR DESCRIPTION
## Summary
- merge imported CSS tokens with the existing registry metadata before persisting
- add regression coverage ensuring combined registry and CSS imports keep their metadata and CSS-only imports preserve existing details

## Testing
- php supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dc03cfe280832e8508b6305e1f9fa2