### PR TITLE
Invalidate CSS cache when token CSS is regenerated

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -111,10 +111,6 @@ final class TokenRegistry
 
         self::persistCss($normalized);
 
-        if (function_exists('\ssc_invalidate_css_cache')) {
-            \ssc_invalidate_css_cache();
-        }
-
         return $normalized;
     }
 
@@ -463,6 +459,10 @@ final class TokenRegistry
     {
         $css = self::tokensToCss($tokens);
         update_option(self::OPTION_CSS, $css, false);
+
+        if (function_exists('\ssc_invalidate_css_cache')) {
+            \ssc_invalidate_css_cache();
+        }
     }
 
     private static function guessTypeFromValue(string $value): string


### PR DESCRIPTION
## Summary
- ensure token CSS persistence invalidates the supersede-css cache when CSS is regenerated
- avoid duplicate cache invalidations in `saveRegistry()` by delegating to `persistCss()`
- extend the TokenRegistry test to cover cache invalidation and CSS regeneration when CSS is missing

## Testing
- php tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dc22718260832e8ab42e4564e09053