### PR TITLE
Move inline admin styles to dedicated assets

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/clip-path-editor.css
+++ b/supersede-css-jlg-enhanced/assets/css/clip-path-editor.css
@@ -1,0 +1,15 @@
+#ssc-clip-preview-wrapper {
+    display: grid;
+    place-items: center;
+    padding: 24px;
+    background: var(--ssc-bg);
+    border-radius: 8px;
+}
+
+#ssc-clip-preview {
+    background-size: cover;
+    background-position: center;
+    height: 300px;
+    width: 300px;
+    transition: all 0.3s ease;
+}

--- a/supersede-css-jlg-enhanced/assets/css/filter-editor.css
+++ b/supersede-css-jlg-enhanced/assets/css/filter-editor.css
@@ -1,0 +1,28 @@
+#ssc-filter-preview-bg {
+    background-size: cover;
+    border-radius: 12px;
+    padding: 24px;
+    display: grid;
+    place-items: center;
+}
+
+#ssc-filter-preview-box {
+    transition: all 0.2s ease-in-out;
+    width: 80%;
+    height: 250px;
+    color: white;
+    font-size: 24px;
+    font-weight: bold;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+    display: grid;
+    place-items: center;
+    border-radius: 16px;
+}
+
+.ssc-glassmorphism-preview {
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+}

--- a/supersede-css-jlg-enhanced/assets/css/page-layout-builder.css
+++ b/supersede-css-jlg-enhanced/assets/css/page-layout-builder.css
@@ -1,0 +1,33 @@
+.ssc-layout-grid {
+    display: grid;
+    height: 400px;
+    border: 2px dashed var(--ssc-accent);
+    padding: 10px;
+    border-radius: 8px;
+    background: var(--ssc-bg);
+}
+
+.ssc-layout-block {
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+    border-radius: 4px;
+    display: grid;
+    place-items: center;
+    font-weight: bold;
+}
+
+.ssc-layout-preview-mobile {
+    width: 375px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.ssc-tutorial-panel h4 {
+    margin-top: 1.2em;
+    margin-bottom: 0.5em;
+}
+
+.ssc-tutorial-panel ul,
+.ssc-tutorial-panel ol {
+    margin-left: 20px;
+}

--- a/supersede-css-jlg-enhanced/assets/css/tokens.css
+++ b/supersede-css-jlg-enhanced/assets/css/tokens.css
@@ -1,0 +1,49 @@
+.ssc-token-builder {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.ssc-token-group {
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 12px;
+    background: #fff;
+}
+
+.ssc-token-group h4 {
+    margin: 0 0 8px;
+}
+
+.ssc-token-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+}
+
+.ssc-token-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1 1 180px;
+    min-width: 180px;
+}
+
+.ssc-token-field__label {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.ssc-token-field-input {
+    width: 100%;
+}
+
+.ssc-token-field textarea {
+    resize: vertical;
+}
+
+.ssc-token-empty {
+    margin: 0;
+    font-style: italic;
+}

--- a/supersede-css-jlg-enhanced/assets/css/typography-editor.css
+++ b/supersede-css-jlg-enhanced/assets/css/typography-editor.css
@@ -1,0 +1,11 @@
+#ssc-typo-preview {
+    transition: font-size 0.1s linear;
+}
+
+.ssc-typo-vp-slider-container {
+    width: 100%;
+    background: var(--ssc-bg);
+    padding: 10px;
+    border-radius: 8px;
+    margin-top: 10px;
+}

--- a/supersede-css-jlg-enhanced/assets/css/utilities.css
+++ b/supersede-css-jlg-enhanced/assets/css/utilities.css
@@ -1,0 +1,56 @@
+.ssc-editor-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--ssc-border);
+}
+
+.ssc-editor-tab {
+    padding: 8px 16px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+}
+
+.ssc-editor-tab.active {
+    color: var(--ssc-accent);
+    border-bottom-color: var(--ssc-accent);
+    font-weight: 600;
+}
+
+.ssc-editor-panel {
+    display: none;
+    height: 100%;
+}
+
+.ssc-editor-panel.active {
+    display: block;
+}
+
+.ssc-tutorial-content {
+    padding: 16px;
+}
+
+.ssc-tutorial-content code {
+    background: var(--ssc-bg);
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+#ssc-picker-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(79, 70, 229, 0.2);
+    z-index: 9998;
+    display: none;
+    cursor: crosshair;
+}
+
+#ssc-picker-tooltip {
+    position: fixed;
+    background: #0f172a;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    z-index: 9999;
+    white-space: nowrap;
+    display: none;
+}

--- a/supersede-css-jlg-enhanced/assets/css/visual-effects.css
+++ b/supersede-css-jlg-enhanced/assets/css/visual-effects.css
@@ -1,0 +1,72 @@
+.ssc-ve-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--ssc-border);
+    margin-bottom: 16px;
+}
+
+.ssc-ve-tab {
+    padding: 10px 16px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+}
+
+.ssc-ve-tab.active {
+    color: var(--ssc-accent);
+    border-bottom-color: var(--ssc-accent);
+    font-weight: 600;
+}
+
+.ssc-ve-panel {
+    display: none;
+}
+
+.ssc-ve-panel.active {
+    display: block;
+}
+
+.ssc-ve-preview-box {
+    height: 300px;
+    border-radius: 12px;
+    border: 1px solid var(--ssc-border);
+    overflow: hidden;
+    position: relative;
+    background: #000;
+}
+
+#ssc-crt-canvas {
+    width: 100%;
+    height: 100%;
+}
+
+.ssc-ecg-path {
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    transition: all 0.3s;
+}
+
+#ssc-ecg-preview-container {
+    position: relative;
+    background: #0b1020;
+    display: grid;
+    place-items: center;
+}
+
+#ssc-ecg-preview-svg {
+    position: absolute;
+    width: 100%;
+    height: auto;
+}
+
+#ssc-ecg-logo-preview {
+    max-width: 100px;
+    max-height: 100px;
+    z-index: 5;
+}
+
+.ssc-grid-three {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 16px;
+}

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -229,6 +229,16 @@ final class Admin
             $this->slug.'-typography'       => ['typography-editor'],
         ];
 
+        $styles_by_page = [
+            $this->slug.'-utilities'        => ['utilities'],
+            $this->slug.'-layout-builder'   => ['page-layout-builder'],
+            $this->slug.'-tokens'           => ['tokens'],
+            $this->slug.'-effects'          => ['visual-effects'],
+            $this->slug.'-filters'          => ['filter-editor'],
+            $this->slug.'-clip-path'        => ['clip-path-editor'],
+            $this->slug.'-typography'       => ['typography-editor'],
+        ];
+
         if (isset($scripts_by_page[$page])) {
             foreach ($scripts_by_page[$page] as $handle) {
                 $path = 'assets/js/' . $handle . '.js';
@@ -249,6 +259,15 @@ final class Admin
                             SSC_PLUGIN_DIR . 'languages'
                         );
                     }
+                }
+            }
+        }
+
+        if (isset($styles_by_page[$page])) {
+            foreach ($styles_by_page[$page] as $handle) {
+                $path = 'assets/css/' . $handle . '.css';
+                if (is_file(SSC_PLUGIN_DIR . $path)) {
+                    wp_enqueue_style('ssc-' . $handle . '-style', SSC_PLUGIN_URL . $path, [], SSC_VERSION);
                 }
             }
         }

--- a/supersede-css-jlg-enhanced/views/clip-path-editor.php
+++ b/supersede-css-jlg-enhanced/views/clip-path-editor.php
@@ -4,23 +4,6 @@ if (!defined('ABSPATH')) {
 }
 /** @var string $preview_background */
 ?>
-<style>
-    #ssc-clip-preview-wrapper {
-        display: grid;
-        place-items: center;
-        padding: 24px;
-        background: var(--ssc-bg);
-        border-radius: 8px;
-    }
-    #ssc-clip-preview {
-        background-image: url('<?php echo esc_url($preview_background); ?>');
-        background-size: cover;
-        background-position: center;
-        height: 300px;
-        width: 300px;
-        transition: all 0.3s ease;
-    }
-</style>
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('✂️ Générateur de Formes (Clip-Path)', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Découpez vos conteneurs et images dans des formes géométriques pour des designs plus dynamiques.', 'supersede-css-jlg'); ?></p>
@@ -45,7 +28,7 @@ if (!defined('ABSPATH')) {
         <div class="ssc-pane">
              <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
              <div id="ssc-clip-preview-wrapper">
-                <div id="ssc-clip-preview"></div>
+                <div id="ssc-clip-preview" style="background-image: url('<?php echo esc_url($preview_background); ?>');"></div>
              </div>
         </div>
     </div>

--- a/supersede-css-jlg-enhanced/views/filter-editor.php
+++ b/supersede-css-jlg-enhanced/views/filter-editor.php
@@ -4,35 +4,6 @@ if (!defined('ABSPATH')) {
 }
 /** @var string $preview_background */
 ?>
-<style>
-    #ssc-filter-preview-bg {
-        background-image: url('<?php echo esc_url($preview_background); ?>');
-        background-size: cover;
-        border-radius: 12px;
-        padding: 24px;
-        display: grid;
-        place-items: center;
-    }
-    #ssc-filter-preview-box {
-        transition: all 0.2s ease-in-out;
-        width: 80%;
-        height: 250px;
-        color: white;
-        font-size: 24px;
-        font-weight: bold;
-        text-shadow: 0 2px 4px rgba(0,0,0,0.5);
-        display: grid;
-        place-items: center;
-        border-radius: 16px;
-    }
-    .ssc-glassmorphism-preview {
-        background: rgba(255, 255, 255, 0.2);
-        box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-        backdrop-filter: blur(5px);
-        -webkit-backdrop-filter: blur(5px);
-        border: 1px solid rgba(255, 255, 255, 0.3);
-    }
-</style>
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('🎨 Éditeur de Filtres & Effets de Verre', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Appliquez des filtres visuels à vos images et conteneurs, ou créez un effet "Glassmorphism" tendance.', 'supersede-css-jlg'); ?></p>
@@ -56,7 +27,7 @@ if (!defined('ABSPATH')) {
         </div>
         <div class="ssc-pane">
             <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
-            <div id="ssc-filter-preview-bg">
+            <div id="ssc-filter-preview-bg" style="background-image: url('<?php echo esc_url($preview_background); ?>');">
                 <div id="ssc-filter-preview-box">
                     <?php esc_html_e('Votre Contenu Ici', 'supersede-css-jlg'); ?>
                 </div>

--- a/supersede-css-jlg-enhanced/views/page-layout-builder.php
+++ b/supersede-css-jlg-enhanced/views/page-layout-builder.php
@@ -4,13 +4,6 @@ if (!defined('ABSPATH')) {
 }
 /** @var string $tokens_page_url */
 ?>
-<style>
-    .ssc-layout-grid { display: grid; height: 400px; border: 2px dashed var(--ssc-accent); padding: 10px; border-radius: 8px; background: var(--ssc-bg); }
-    .ssc-layout-block { background: var(--ssc-card); border: 1px solid var(--ssc-border); border-radius: 4px; display: grid; place-items: center; font-weight: bold; }
-    .ssc-layout-preview-mobile { width: 375px; margin-left: auto; margin-right: auto; }
-    .ssc-tutorial-panel h4 { margin-top: 1.2em; margin-bottom: 0.5em; }
-    .ssc-tutorial-panel ul, .ssc-tutorial-panel ol { margin-left: 20px; }
-</style>
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('📐 Maquettage de Page (CSS Grid)', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Préparez des mises en page complexes pour vos thèmes ou des sections spécifiques de vos pages.', 'supersede-css-jlg'); ?></p>

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -61,18 +61,6 @@ if (function_exists('wp_localize_script')) {
             <h3><?php esc_html_e('🎨 Éditeur Visuel de Tokens', 'supersede-css-jlg'); ?></h3>
             <p><?php esc_html_e('Gérez vos tokens sous forme de fiches structurées : nom technique, valeur, type de champ, description et groupe d\'appartenance. Chaque catégorie est listée séparément pour garder une vision claire de votre système de design.', 'supersede-css-jlg'); ?></p>
 
-            <style>
-                .ssc-token-builder { display: flex; flex-direction: column; gap: 16px; }
-                .ssc-token-group { border: 1px solid #e2e8f0; border-radius: 6px; padding: 12px; background: #fff; }
-                .ssc-token-group h4 { margin: 0 0 8px; }
-                .ssc-token-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; }
-                .ssc-token-field { display: flex; flex-direction: column; gap: 4px; flex: 1 1 180px; min-width: 180px; }
-                .ssc-token-field__label { font-weight: 600; font-size: 13px; }
-                .ssc-token-field-input { width: 100%; }
-                .ssc-token-field textarea { resize: vertical; }
-                .ssc-token-empty { margin: 0; font-style: italic; }
-            </style>
-
             <div class="ssc-token-toolbar" style="margin-bottom:12px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
                 <button id="ssc-token-add" class="button"><?php esc_html_e('+ Ajouter un Token', 'supersede-css-jlg'); ?></button>
             </div>

--- a/supersede-css-jlg-enhanced/views/typography-editor.php
+++ b/supersede-css-jlg-enhanced/views/typography-editor.php
@@ -3,10 +3,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<style>
-    #ssc-typo-preview { transition: font-size 0.1s linear; }
-    .ssc-typo-vp-slider-container { width: 100%; background: var(--ssc-bg); padding: 10px; border-radius: 8px; margin-top: 10px; }
-</style>
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('📏 Typographie Fluide (Clamp)', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Générez du texte qui s\'adapte parfaitement à toutes les tailles d\'écran, sans "sauts" disgracieux.', 'supersede-css-jlg'); ?></p>

--- a/supersede-css-jlg-enhanced/views/utilities.php
+++ b/supersede-css-jlg-enhanced/views/utilities.php
@@ -7,17 +7,6 @@ if (!defined('ABSPATH')) {
 /** @var string $css_mobile */
 /** @var string $preview_url */
 ?>
-<style>
-    .ssc-editor-tabs { display: flex; border-bottom: 1px solid var(--ssc-border); }
-    .ssc-editor-tab { padding: 8px 16px; cursor: pointer; border-bottom: 2px solid transparent; }
-    .ssc-editor-tab.active { color: var(--ssc-accent); border-bottom-color: var(--ssc-accent); font-weight: 600; }
-    .ssc-editor-panel { display: none; height: 100%; }
-    .ssc-editor-panel.active { display: block; }
-    .ssc-tutorial-content { padding: 16px; }
-    .ssc-tutorial-content code { background: var(--ssc-bg); padding: 2px 6px; border-radius: 4px; }
-    #ssc-picker-overlay { position: absolute; inset: 0; background: rgba(79, 70, 229, 0.2); z-index: 9998; display: none; cursor: crosshair; }
-    #ssc-picker-tooltip { position: fixed; background: #0f172a; color: white; padding: 4px 8px; border-radius: 4px; font-size: 12px; z-index: 9999; white-space: nowrap; display: none; }
-</style>
 <div class="ssc-wrap ssc-utilities-wrap">
     <div class="ssc-editor-layout">
         <div class="ssc-editor-column">

--- a/supersede-css-jlg-enhanced/views/visual-effects.php
+++ b/supersede-css-jlg-enhanced/views/visual-effects.php
@@ -3,20 +3,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<style>
-    .ssc-ve-tabs { display: flex; border-bottom: 1px solid var(--ssc-border); margin-bottom: 16px; }
-    .ssc-ve-tab { padding: 10px 16px; cursor: pointer; border-bottom: 2px solid transparent; }
-    .ssc-ve-tab.active { color: var(--ssc-accent); border-bottom-color: var(--ssc-accent); font-weight: 600; }
-    .ssc-ve-panel { display: none; }
-    .ssc-ve-panel.active { display: block; }
-    .ssc-ve-preview-box { height: 300px; border-radius: 12px; border: 1px solid var(--ssc-border); overflow: hidden; position: relative; background: #000; }
-    #ssc-crt-canvas { width: 100%; height: 100%; }
-    .ssc-ecg-path { fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; transition: all 0.3s; }
-    #ssc-ecg-preview-container { position: relative; background: #0b1020; display: grid; place-items: center; }
-    #ssc-ecg-preview-svg { position: absolute; width: 100%; height: auto; }
-    #ssc-ecg-logo-preview { max-width: 100px; max-height: 100px; z-index: 5; }
-    .ssc-grid-three { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; }
-</style>
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('🎬 Générateur d\'Effets Visuels', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Une collection d\'effets visuels avancés pour animer vos fonds, images et conteneurs.', 'supersede-css-jlg'); ?></p>


### PR DESCRIPTION
## Summary
- extract inline styles from the admin views into dedicated CSS files under assets/css
- clean the affected PHP views so they only output markup and dynamic data
- enqueue the new styles on their respective admin pages via the Admin assets loader

## Testing
- not run (WordPress admin verification recommended)


------
https://chatgpt.com/codex/tasks/task_e_68dc351f24d8832e8e9afb3754c0948a