### PR TITLE
Set up Composer-based PHPUnit suite and migrate tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+
+      - name: Install Composer dependencies
+        working-directory: supersede-css-jlg-enhanced
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Node dependencies
+        working-directory: supersede-css-jlg-enhanced
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: supersede-css-jlg-enhanced
+        run: npx playwright install --with-deps
+
+      - name: Run PHP unit tests
+        working-directory: supersede-css-jlg-enhanced
+        run: composer test
+
+      - name: Run UI tests
+        working-directory: supersede-css-jlg-enhanced
+        run: npm run test:ui

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ playwright-report/
 supersede-css-jlg-enhanced/playwright-report/
 test-results/
 supersede-css-jlg-enhanced/test-results/
+vendor/
+supersede-css-jlg-enhanced/vendor/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ Supersede CSS JLG (Enhanced) is released under the [GPLv2 or later](https://www.
 
 Contributions are welcome! Fork the project, create a branch with your feature or fix, then submit a pull request. For major changes, please open an issue first to discuss what you'd like to change.
 
+## Tests
+
+1. Install PHP dependencies with `composer install` inside `supersede-css-jlg-enhanced/`.
+2. Install front-end tooling with `npm install` inside `supersede-css-jlg-enhanced/`.
+3. Run the PHPUnit suite via `composer test`.
+4. Execute the UI regression tests with `npm run test:ui`.
+

--- a/supersede-css-jlg-enhanced/composer.json
+++ b/supersede-css-jlg-enhanced/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "supersede-css-jlg/enhanced",
+    "description": "Enhanced Supersede CSS plugin development dependencies",
+    "type": "project",
+    "require": {
+        "php": ">=8.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "SSC\\": "src/"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    }
+}

--- a/supersede-css-jlg-enhanced/composer.lock
+++ b/supersede-css-jlg-enhanced/composer.lock
@@ -1,0 +1,1690 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6caad7afd775dac0791157bafc52d25c",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.58",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:04:46+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:36:25+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.1"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/supersede-css-jlg-enhanced/package.json
+++ b/supersede-css-jlg-enhanced/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
+    "test:php": "composer test",
     "test:ui": "playwright test"
   },
   "devDependencies": {

--- a/supersede-css-jlg-enhanced/phpunit.xml.dist
+++ b/supersede-css-jlg-enhanced/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>tests/Support</directory>
+            <directory>tests/Infra</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
 use SSC\Infra\Routes;
+use SSC\Support\CssSanitizer;
+use SSC\Support\TokenRegistry;
 
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__);
@@ -162,16 +165,7 @@ if (!function_exists('absint')) {
 }
 
 /** @var array<string, mixed> $ssc_options_store */
-$ssc_options_store = [
-    'ssc_admin_log' => [
-        [
-            't' => '2024-01-01T00:00:00Z',
-            'user' => 'alice',
-            'action' => 'existing',
-            'data' => ['note' => 'original'],
-        ],
-    ],
-];
+$ssc_options_store = [];
 
 global $ssc_options_store;
 
@@ -187,6 +181,7 @@ if (!function_exists('get_option')) {
 if (!function_exists('update_option')) {
     function update_option($name, $value, $autoload = false)
     {
+        unset($autoload);
         global $ssc_options_store;
 
         $ssc_options_store[$name] = $value;
@@ -195,459 +190,356 @@ if (!function_exists('update_option')) {
     }
 }
 
-require_once __DIR__ . '/../../src/Support/CssSanitizer.php';
-require_once __DIR__ . '/../../src/Support/TokenRegistry.php';
-require_once __DIR__ . '/../../src/Infra/Logger.php';
-require_once __DIR__ . '/../../src/Infra/Routes.php';
+final class RoutesImportTest extends TestCase
+{
+    private Routes $routes;
 
-$originalLog = $ssc_options_store['ssc_admin_log'];
+    private ReflectionMethod $applyImportedOptions;
 
-$routesReflection = new ReflectionClass(Routes::class);
-$routes = $routesReflection->newInstanceWithoutConstructor();
+    private ReflectionMethod $sanitizeTokens;
 
-$applyMethod = $routesReflection->getMethod('applyImportedOptions');
-$applyMethod->setAccessible(true);
-
-$result = $applyMethod->invoke($routes, [
-    'ssc_admin_log' => 'not-an-array',
-]);
-
-if ($ssc_options_store['ssc_admin_log'] !== $originalLog) {
-    fwrite(STDERR, "Existing admin log should remain unchanged when import is invalid." . PHP_EOL);
-    exit(1);
-}
-
-if (!is_array($result) || !isset($result['skipped']) || !in_array('ssc_admin_log', $result['skipped'], true)) {
-    fwrite(STDERR, "Invalid admin log import should be reported as skipped." . PHP_EOL);
-    exit(1);
-}
-
-$ssc_options_store['ssc_tokens_css'] = '';
-$ssc_options_store['ssc_tokens_registry'] = [];
-
-$tokensCss = ":root {\n    --primary-color: #123456;\n    --spacing-md: 16px;\n}";
-$tokensResult = $applyMethod->invoke($routes, [
-    'ssc_tokens_css' => $tokensCss,
-]);
-
-$sanitizedCss = \SSC\Support\CssSanitizer::sanitize($tokensCss);
-$expectedTokens = \SSC\Support\TokenRegistry::convertCssToRegistry($sanitizedCss);
-
-if ($expectedTokens === []) {
-    fwrite(STDERR, "Expected tokens should not be empty for the provided CSS." . PHP_EOL);
-    exit(1);
-}
-
-$singleTokenCss = ":root {\n    --solitary-token: #bada55\n}";
-$singleTokenSanitized = \SSC\Support\CssSanitizer::sanitize($singleTokenCss);
-$singleTokenRegistry = \SSC\Support\TokenRegistry::convertCssToRegistry($singleTokenSanitized);
-
-if (count($singleTokenRegistry) !== 1) {
-    fwrite(STDERR, "A sanitized CSS payload with a single token should yield exactly one registry entry." . PHP_EOL);
-    exit(1);
-}
-
-$singleToken = $singleTokenRegistry[0];
-if ($singleToken['name'] !== '--solitary-token' || $singleToken['value'] !== '#bada55') {
-    fwrite(STDERR, "Single token CSS without trailing semicolon should preserve the token name and value." . PHP_EOL);
-    exit(1);
-}
-
-$noSemicolonCss = ":root {\n    --first-token: 10px;\n    --last-token: 1rem\n}";
-$noSemicolonSanitized = \SSC\Support\CssSanitizer::sanitize($noSemicolonCss);
-$noSemicolonRegistry = \SSC\Support\TokenRegistry::convertCssToRegistry($noSemicolonSanitized);
-
-if (count($noSemicolonRegistry) !== 2) {
-    fwrite(STDERR, "CSS without a trailing semicolon on the last declaration should still return all tokens." . PHP_EOL);
-    exit(1);
-}
-
-if ($noSemicolonRegistry[0]['name'] !== '--first-token' || $noSemicolonRegistry[0]['value'] !== '10px') {
-    fwrite(STDERR, "First token should remain unchanged when converting CSS with missing trailing semicolon." . PHP_EOL);
-    exit(1);
-}
-
-if ($noSemicolonRegistry[1]['name'] !== '--last-token' || $noSemicolonRegistry[1]['value'] !== '1rem') {
-    fwrite(STDERR, "Last token without a trailing semicolon should be preserved during CSS conversion." . PHP_EOL);
-    exit(1);
-}
-
-$expectedCss = \SSC\Support\TokenRegistry::tokensToCss($expectedTokens);
-
-if (!is_array($tokensResult) || !in_array('ssc_tokens_css', $tokensResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "Token CSS import should be reported as applied." . PHP_EOL);
-    exit(1);
-}
-
-if ($ssc_options_store['ssc_tokens_registry'] !== $expectedTokens) {
-    fwrite(STDERR, "Imported token CSS should update the token registry." . PHP_EOL);
-    exit(1);
-}
-
-if ($ssc_options_store['ssc_tokens_css'] !== $expectedCss) {
-    fwrite(STDERR, "Imported token CSS should be persisted with normalized formatting." . PHP_EOL);
-    exit(1);
-}
-
-$duplicateTokensCss = ":root {\n    --duplicate-token: 4px;\n    --duplicate-token: 8px;\n}";
-$duplicateSanitized = \SSC\Support\CssSanitizer::sanitize($duplicateTokensCss);
-$duplicateRegistry = \SSC\Support\TokenRegistry::convertCssToRegistry($duplicateSanitized);
-
-if (count($duplicateRegistry) !== 1) {
-    fwrite(STDERR, "Duplicate CSS tokens should be collapsed into a single registry entry." . PHP_EOL);
-    exit(1);
-}
-
-$duplicateToken = $duplicateRegistry[0];
-
-if ($duplicateToken['name'] !== '--duplicate-token' || $duplicateToken['value'] !== '8px') {
-    fwrite(STDERR, "Duplicate token conversion should keep the last value encountered." . PHP_EOL);
-    exit(1);
-}
-
-$ssc_options_store['ssc_tokens_css'] = '';
-$ssc_options_store['ssc_tokens_registry'] = [];
-
-$duplicateImportResult = $applyMethod->invoke($routes, [
-    'ssc_tokens_css' => $duplicateTokensCss,
-]);
-
-if (!is_array($duplicateImportResult) || !in_array('ssc_tokens_css', $duplicateImportResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "Duplicate token CSS import should still be reported as applied." . PHP_EOL);
-    exit(1);
-}
-
-$storedRegistry = $ssc_options_store['ssc_tokens_registry'];
-
-if (!is_array($storedRegistry) || count($storedRegistry) !== 1) {
-    fwrite(STDERR, "Token registry should contain a single entry after importing duplicate CSS tokens." . PHP_EOL);
-    exit(1);
-}
-
-$storedToken = $storedRegistry[0];
-
-if ($storedToken['name'] !== '--duplicate-token' || $storedToken['value'] !== '8px') {
-    fwrite(STDERR, "Token registry should preserve the last duplicate token value after import." . PHP_EOL);
-    exit(1);
-}
-
-$storedCss = $ssc_options_store['ssc_tokens_css'];
-$expectedStoredCss = \SSC\Support\TokenRegistry::tokensToCss($storedRegistry);
-
-if ($storedCss !== $expectedStoredCss) {
-    fwrite(STDERR, "Persisted CSS should only contain the deduplicated token definition." . PHP_EOL);
-    exit(1);
-}
-
-$sanitizeTokensMethod = $routesReflection->getMethod('sanitizeImportTokens');
-$sanitizeTokensMethod->setAccessible(true);
-
-$ssc_options_store['ssc_tokens_css'] = '__original_css__';
-$ssc_options_store['ssc_tokens_registry'] = '__original_registry__';
-
-$rawRegistryPayload = [
-    [
-        'name' => 'Primary Color',
-        'value' => '#FFFFFF',
-        'type' => 'color',
-        'description' => '<strong>Important</strong>',
-        'group' => 'Colors',
-    ],
-    [
-        'name' => '',
-        'value' => 'should-be-ignored',
-        'type' => 'text',
-        'description' => 'Unused',
-        'group' => '',
-    ],
-];
-
-$sanitizedRegistryPayload = $sanitizeTokensMethod->invoke($routes, $rawRegistryPayload);
-
-if (!is_array($sanitizedRegistryPayload) || count($sanitizedRegistryPayload) !== 1) {
-    fwrite(STDERR, "Token registry imports should normalize entries without persisting side effects." . PHP_EOL);
-    exit(1);
-}
-
-if ($ssc_options_store['ssc_tokens_registry'] !== '__original_registry__' || $ssc_options_store['ssc_tokens_css'] !== '__original_css__') {
-    fwrite(STDERR, "Sanitizing token registry imports should not modify stored options before apply." . PHP_EOL);
-    exit(1);
-}
-
-$registryImportResult = $applyMethod->invoke($routes, [
-    'ssc_tokens_registry' => $rawRegistryPayload,
-]);
-
-if (!is_array($registryImportResult) || !in_array('ssc_tokens_registry', $registryImportResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "Token registry array imports should be reported as applied." . PHP_EOL);
-    exit(1);
-}
-
-$storedRegistryAfterDirectImport = $ssc_options_store['ssc_tokens_registry'];
-
-if (!is_array($storedRegistryAfterDirectImport) || count($storedRegistryAfterDirectImport) !== 1) {
-    fwrite(STDERR, "Direct token registry imports should persist normalized entries." . PHP_EOL);
-    exit(1);
-}
-
-$storedDirectToken = $storedRegistryAfterDirectImport[0];
-
-if ($storedDirectToken['name'] !== '--Primary-Color' || $storedDirectToken['value'] !== '#FFFFFF') {
-    fwrite(STDERR, "Token registry imports should normalize token names and values." . PHP_EOL);
-    exit(1);
-}
-
-if ($storedDirectToken['group'] !== 'Colors' || $storedDirectToken['description'] !== 'Important') {
-    fwrite(STDERR, "Token registry imports should sanitize metadata fields." . PHP_EOL);
-    exit(1);
-}
-
-$expectedRegistryCss = \SSC\Support\TokenRegistry::tokensToCss($storedRegistryAfterDirectImport);
-
-if ($ssc_options_store['ssc_tokens_css'] !== $expectedRegistryCss) {
-    fwrite(STDERR, "Token registry imports should regenerate the CSS representation once applied." . PHP_EOL);
-    exit(1);
-}
-
-$ssc_options_store['ssc_tokens_registry'] = [];
-$ssc_options_store['ssc_tokens_css'] = '';
-
-$registryWithMetadata = [
-    [
-        'name' => '--brand-primary',
-        'value' => '#112233',
-        'type' => 'color',
-        'description' => 'Primary brand color',
-        'group' => 'Brand',
-    ],
-];
-
-$combinedImportResult = $applyMethod->invoke($routes, [
-    'ssc_tokens_registry' => $registryWithMetadata,
-    'ssc_tokens_css' => ":root {\n    --brand-primary: #112233;\n}",
-]);
-
-if (!is_array($combinedImportResult) || !in_array('ssc_tokens_registry', $combinedImportResult['applied'] ?? [], true) || !in_array('ssc_tokens_css', $combinedImportResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "Combined registry and CSS imports should report both options as applied." . PHP_EOL);
-    exit(1);
-}
-
-$storedCombinedRegistry = $ssc_options_store['ssc_tokens_registry'];
-
-if (!is_array($storedCombinedRegistry) || count($storedCombinedRegistry) !== 1) {
-    fwrite(STDERR, "Combined registry and CSS imports should persist a single normalized token." . PHP_EOL);
-    exit(1);
-}
-
-$storedCombinedToken = $storedCombinedRegistry[0];
-
-if ($storedCombinedToken['type'] !== 'color' || $storedCombinedToken['group'] !== 'Brand' || $storedCombinedToken['description'] !== 'Primary brand color') {
-    fwrite(STDERR, "Registry metadata should survive subsequent CSS imports processed in the same payload." . PHP_EOL);
-    exit(1);
-}
-
-$ssc_options_store['ssc_tokens_registry'] = \SSC\Support\TokenRegistry::saveRegistry([
-    [
-        'name' => '--spacing-large',
-        'value' => '32px',
-        'type' => 'number',
-        'description' => 'Large spacing token',
-        'group' => 'Spacing',
-    ],
-]);
-
-$cssOnlyResult = $applyMethod->invoke($routes, [
-    'ssc_tokens_css' => ":root {\n    --spacing-large: 40px;\n}",
-]);
-
-if (!is_array($cssOnlyResult) || !in_array('ssc_tokens_css', $cssOnlyResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "CSS-only imports should report the tokens CSS option as applied." . PHP_EOL);
-    exit(1);
-}
-
-$storedCssOnlyRegistry = $ssc_options_store['ssc_tokens_registry'];
-
-if (!is_array($storedCssOnlyRegistry) || count($storedCssOnlyRegistry) !== 1) {
-    fwrite(STDERR, "CSS-only imports should preserve the registry structure." . PHP_EOL);
-    exit(1);
-}
-
-$storedCssOnlyToken = $storedCssOnlyRegistry[0];
-
-if ($storedCssOnlyToken['value'] !== '40px') {
-    fwrite(STDERR, "CSS-only imports should update the token value from the CSS payload." . PHP_EOL);
-    exit(1);
-}
-
-if ($storedCssOnlyToken['type'] !== 'number' || $storedCssOnlyToken['group'] !== 'Spacing' || $storedCssOnlyToken['description'] !== 'Large spacing token') {
-    fwrite(STDERR, "CSS-only imports should retain metadata from the existing registry after merging." . PHP_EOL);
-    exit(1);
-}
-
-\SSC\Support\TokenRegistry::saveRegistry([
-    [
-        'name' => '--existing-token',
-        'value' => '#abcdef',
-        'type' => 'color',
-        'description' => '',
-        'group' => 'Legacy',
-    ],
-]);
-
-$emptyTokensResult = $applyMethod->invoke($routes, [
-    'ssc_tokens_css' => '',
-]);
-
-if (!is_array($emptyTokensResult) || !in_array('ssc_tokens_css', $emptyTokensResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "Empty token CSS import should be reported as applied." . PHP_EOL);
-    exit(1);
-}
-
-if ($ssc_options_store['ssc_tokens_registry'] !== []) {
-    fwrite(STDERR, "Empty token CSS import should reset the token registry." . PHP_EOL);
-    exit(1);
-}
-
-$expectedEmptyCss = \SSC\Support\TokenRegistry::tokensToCss([]);
-
-if ($ssc_options_store['ssc_tokens_css'] !== $expectedEmptyCss) {
-    fwrite(STDERR, "Empty token CSS import should persist an empty CSS template." . PHP_EOL);
-    exit(1);
-}
-
-$objectPayload = new stdClass();
-$objectPayload->title = '<strong>Title</strong>';
-$objectPayload->count = 5;
-$objectPayload->nested = new stdClass();
-$objectPayload->nested->note = '<em>Nested</em>';
-
-$jsonOnlyObject = new class() implements JsonSerializable {
-    public function jsonSerialize(): mixed
+    protected function setUp(): void
     {
-        return ['danger' => '<script>alert(1)</script>'];
+        parent::setUp();
+
+        global $ssc_options_store;
+        $ssc_options_store = [
+            'ssc_admin_log' => [
+                [
+                    't' => '2024-01-01T00:00:00Z',
+                    'user' => 'alice',
+                    'action' => 'existing',
+                    'data' => ['note' => 'original'],
+                ],
+            ],
+        ];
+
+        $reflection = new \ReflectionClass(Routes::class);
+        $this->routes = $reflection->newInstanceWithoutConstructor();
+
+        $this->applyImportedOptions = $reflection->getMethod('applyImportedOptions');
+        $this->applyImportedOptions->setAccessible(true);
+
+        $this->sanitizeTokens = $reflection->getMethod('sanitizeImportTokens');
+        $this->sanitizeTokens->setAccessible(true);
     }
-};
 
-$ssc_options_store['ssc_settings'] = [];
+    public function testInvalidAdminLogImportIsSkipped(): void
+    {
+        global $ssc_options_store;
+        $originalLog = $ssc_options_store['ssc_admin_log'];
 
-$objectImportResult = $applyMethod->invoke($routes, [
-    'ssc_settings' => [
-        'object_payload' => $objectPayload,
-        'json_only_object' => $jsonOnlyObject,
-    ],
-]);
+        $result = $this->apply(['ssc_admin_log' => 'not-an-array']);
 
-$expectedSettings = [
-    'object_payload' => [
-        'title' => 'Title',
-        'count' => 5,
-        'nested' => [
-            'note' => 'Nested',
-        ],
-    ],
-    'json_only_object' => '{"danger":"alert(1)"}',
-];
+        $this->assertSame($originalLog, $ssc_options_store['ssc_admin_log']);
+        $this->assertContains('ssc_admin_log', $result['skipped']);
+    }
 
-if ($ssc_options_store['ssc_settings'] !== $expectedSettings) {
-    fwrite(STDERR, "Object payloads should be sanitized recursively or serialized when needed." . PHP_EOL);
-    fwrite(STDERR, 'Actual settings: ' . json_encode($ssc_options_store['ssc_settings']) . PHP_EOL);
-    exit(1);
-}
+    public function testTokenCssImportUpdatesRegistryAndCss(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_tokens_css'] = '';
+        $ssc_options_store['ssc_tokens_registry'] = [];
 
-if (!is_array($objectImportResult) || !in_array('ssc_settings', $objectImportResult['applied'] ?? [], true)) {
-    fwrite(STDERR, "Object payload import should be reported as applied." . PHP_EOL);
-    exit(1);
-}
+        $tokensCss = ":root {\n    --primary-color: #123456;\n    --spacing-md: 16px;\n}";
+        $result = $this->apply(['ssc_tokens_css' => $tokensCss]);
 
-$ssc_options_store['ssc_settings'] = [];
+        $sanitizedCss = CssSanitizer::sanitize($tokensCss);
+        $expectedTokens = TokenRegistry::convertCssToRegistry($sanitizedCss);
+        $expectedCss = TokenRegistry::tokensToCss($expectedTokens);
 
-$duplicateKeyPayload = [
-    'options' => [
-        'ssc_settings' => [
-            'Name One' => 'First Value',
-            'name-one' => 'Second Value',
-        ],
-    ],
-];
+        $this->assertNotEmpty($expectedTokens);
+        $this->assertContains('ssc_tokens_css', $result['applied']);
+        $this->assertSame($expectedTokens, $ssc_options_store['ssc_tokens_registry']);
+        $this->assertSame($expectedCss, $ssc_options_store['ssc_tokens_css']);
+    }
 
-$duplicateKeyResponse = $routes->importConfig(new WP_REST_Request([], $duplicateKeyPayload));
+    public function testTokenRegistryConversionHandlesSingleAndMissingSemicolons(): void
+    {
+        $singleTokenCss = ":root {\n    --solitary-token: #bada55\n}";
+        $singleTokenRegistry = TokenRegistry::convertCssToRegistry(CssSanitizer::sanitize($singleTokenCss));
 
-if (!$duplicateKeyResponse instanceof WP_REST_Response) {
-    fwrite(STDERR, "Duplicate key import should return a REST response." . PHP_EOL);
-    exit(1);
-}
+        $this->assertCount(1, $singleTokenRegistry);
+        $this->assertSame('--solitary-token', $singleTokenRegistry[0]['name']);
+        $this->assertSame('#bada55', $singleTokenRegistry[0]['value']);
 
-$duplicateKeyData = $duplicateKeyResponse->get_data();
+        $noSemicolonCss = ":root {\n    --first-token: 10px;\n    --last-token: 1rem\n}";
+        $noSemicolonRegistry = TokenRegistry::convertCssToRegistry(CssSanitizer::sanitize($noSemicolonCss));
 
-if (!is_array($duplicateKeyData) || ($duplicateKeyData['ok'] ?? null) !== true) {
-    fwrite(STDERR, "Duplicate key import should succeed with ok=true." . PHP_EOL);
-    exit(1);
-}
+        $this->assertCount(2, $noSemicolonRegistry);
+        $this->assertSame('--first-token', $noSemicolonRegistry[0]['name']);
+        $this->assertSame('10px', $noSemicolonRegistry[0]['value']);
+        $this->assertSame('--last-token', $noSemicolonRegistry[1]['name']);
+        $this->assertSame('1rem', $noSemicolonRegistry[1]['value']);
+    }
 
-if (!in_array('ssc_settings', $duplicateKeyData['applied'] ?? [], true)) {
-    fwrite(STDERR, "Duplicate key import should still apply the settings option." . PHP_EOL);
-    exit(1);
-}
+    public function testDuplicateTokenCssIsDeduplicatedDuringImport(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_tokens_css'] = '';
+        $ssc_options_store['ssc_tokens_registry'] = [];
 
-$expectedDuplicateMessage = 'ssc_settings (duplicate key: nameone)';
+        $duplicateTokensCss = ":root {\n    --duplicate-token: 4px;\n    --duplicate-token: 8px;\n}";
 
-if (!in_array($expectedDuplicateMessage, $duplicateKeyData['skipped'] ?? [], true)) {
-    fwrite(STDERR, "Duplicate key import should report the normalized key in the skipped list." . PHP_EOL);
-    exit(1);
-}
+        $duplicateRegistry = TokenRegistry::convertCssToRegistry(CssSanitizer::sanitize($duplicateTokensCss));
+        $this->assertCount(1, $duplicateRegistry);
+        $this->assertSame('8px', $duplicateRegistry[0]['value']);
 
-$storedSettings = $ssc_options_store['ssc_settings'] ?? null;
+        $result = $this->apply(['ssc_tokens_css' => $duplicateTokensCss]);
+        $this->assertContains('ssc_tokens_css', $result['applied']);
 
-if (!is_array($storedSettings) || $storedSettings !== ['nameone' => 'First Value']) {
-    fwrite(STDERR, "Duplicate key import should keep the first occurrence of the normalized key." . PHP_EOL);
-    fwrite(STDERR, 'Actual settings: ' . json_encode($storedSettings) . PHP_EOL);
-    exit(1);
-}
+        $storedRegistry = $ssc_options_store['ssc_tokens_registry'];
+        $this->assertIsArray($storedRegistry);
+        $this->assertCount(1, $storedRegistry);
+        $this->assertSame('8px', $storedRegistry[0]['value']);
+        $this->assertSame(TokenRegistry::tokensToCss($storedRegistry), $ssc_options_store['ssc_tokens_css']);
+    }
 
-$ssc_options_store['ssc_active_css'] = 'original-css';
+    public function testSanitizeImportTokensNormalizesPayloadWithoutSideEffects(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_tokens_css'] = '__original_css__';
+        $ssc_options_store['ssc_tokens_registry'] = '__original_registry__';
 
-$unknownModulesRequest = new WP_REST_Request(
-    ['modules' => ['totally-unknown']],
-    [
-        'modules' => ['totally-unknown'],
-        'options' => [
-            'ssc_active_css' => 'body { color: red; }',
-        ],
-    ]
-);
+        $rawRegistryPayload = [
+            [
+                'name' => 'Primary Color',
+                'value' => '#FFFFFF',
+                'type' => 'color',
+                'description' => '<strong>Important</strong>',
+                'group' => 'Colors',
+            ],
+            [
+                'name' => '',
+                'value' => 'should-be-ignored',
+                'type' => 'text',
+                'description' => 'Unused',
+                'group' => '',
+            ],
+        ];
 
-$unknownModulesResponse = $routes->importConfig($unknownModulesRequest);
+        $sanitizedRegistryPayload = $this->sanitizeTokens->invoke($this->routes, $rawRegistryPayload);
 
-if (!$unknownModulesResponse instanceof WP_REST_Response) {
-    fwrite(STDERR, "Import with unknown modules should return a REST response." . PHP_EOL);
-    exit(1);
-}
+        $this->assertIsArray($sanitizedRegistryPayload);
+        $this->assertCount(1, $sanitizedRegistryPayload);
+        $this->assertSame('__original_registry__', $ssc_options_store['ssc_tokens_registry']);
+        $this->assertSame('__original_css__', $ssc_options_store['ssc_tokens_css']);
+    }
 
-if ($unknownModulesResponse->get_status() !== 400) {
-    fwrite(STDERR, "Import with unknown modules should fail with a 400 status." . PHP_EOL);
-    exit(1);
-}
+    public function testTokenRegistryImportsRegenerateCss(): void
+    {
+        global $ssc_options_store;
+        $rawRegistryPayload = [
+            [
+                'name' => 'Primary Color',
+                'value' => '#FFFFFF',
+                'type' => 'color',
+                'description' => '<strong>Important</strong>',
+                'group' => 'Colors',
+            ],
+        ];
 
-$unknownModulesData = $unknownModulesResponse->get_data();
+        $result = $this->apply(['ssc_tokens_registry' => $rawRegistryPayload]);
+        $this->assertContains('ssc_tokens_registry', $result['applied']);
 
-if (!is_array($unknownModulesData) || ($unknownModulesData['ok'] ?? null) !== false) {
-    fwrite(STDERR, "Import with unknown modules should report failure with ok=false." . PHP_EOL);
-    exit(1);
-}
+        $storedRegistry = $ssc_options_store['ssc_tokens_registry'];
+        $this->assertIsArray($storedRegistry);
+        $this->assertCount(1, $storedRegistry);
+        $storedToken = $storedRegistry[0];
 
-$expectedMessage = 'No valid Supersede CSS modules were selected for import.';
+        $this->assertSame('--Primary-Color', $storedToken['name']);
+        $this->assertSame('#FFFFFF', $storedToken['value']);
+        $this->assertSame('Colors', $storedToken['group']);
+        $this->assertSame('Important', $storedToken['description']);
 
-if (($unknownModulesData['message'] ?? '') !== $expectedMessage) {
-    fwrite(STDERR, "Import with unknown modules should return an explicit error message." . PHP_EOL);
-    exit(1);
-}
+        $expectedRegistryCss = TokenRegistry::tokensToCss($storedRegistry);
+        $this->assertSame($expectedRegistryCss, $ssc_options_store['ssc_tokens_css']);
+    }
 
-if (($unknownModulesData['skipped'] ?? []) !== ['ssc_active_css']) {
-    fwrite(STDERR, "Import with unknown modules should report skipped options." . PHP_EOL);
-    exit(1);
-}
+    public function testCombinedRegistryAndCssImportPreservesMetadata(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_tokens_registry'] = [];
+        $ssc_options_store['ssc_tokens_css'] = '';
 
-if ($ssc_options_store['ssc_active_css'] !== 'original-css') {
-    fwrite(STDERR, "Import with unknown modules should not change any stored options." . PHP_EOL);
-    exit(1);
+        $registryWithMetadata = [
+            [
+                'name' => '--brand-primary',
+                'value' => '#112233',
+                'type' => 'color',
+                'description' => 'Primary brand color',
+                'group' => 'Brand',
+            ],
+        ];
+
+        $result = $this->apply([
+            'ssc_tokens_registry' => $registryWithMetadata,
+            'ssc_tokens_css' => ":root {\n    --brand-primary: #112233;\n}",
+        ]);
+
+        $this->assertContains('ssc_tokens_registry', $result['applied']);
+        $this->assertContains('ssc_tokens_css', $result['applied']);
+
+        $storedCombinedRegistry = $ssc_options_store['ssc_tokens_registry'];
+        $this->assertIsArray($storedCombinedRegistry);
+        $this->assertCount(1, $storedCombinedRegistry);
+
+        $storedCombinedToken = $storedCombinedRegistry[0];
+        $this->assertSame('color', $storedCombinedToken['type']);
+        $this->assertSame('Brand', $storedCombinedToken['group']);
+        $this->assertSame('Primary brand color', $storedCombinedToken['description']);
+    }
+
+    public function testCssOnlyImportsMergeWithExistingRegistry(): void
+    {
+        global $ssc_options_store;
+        $existingRegistry = TokenRegistry::saveRegistry([
+            [
+                'name' => '--spacing-large',
+                'value' => '32px',
+                'type' => 'number',
+                'description' => 'Large spacing token',
+                'group' => 'Spacing',
+            ],
+        ]);
+        $ssc_options_store['ssc_tokens_registry'] = $existingRegistry;
+
+        $result = $this->apply(['ssc_tokens_css' => ":root {\n    --spacing-large: 40px;\n}"]);
+
+        $this->assertContains('ssc_tokens_css', $result['applied']);
+        $storedRegistry = $ssc_options_store['ssc_tokens_registry'];
+
+        $this->assertIsArray($storedRegistry);
+        $this->assertCount(1, $storedRegistry);
+
+        $storedToken = $storedRegistry[0];
+        $this->assertSame('40px', $storedToken['value']);
+        $this->assertSame('number', $storedToken['type']);
+        $this->assertSame('Spacing', $storedToken['group']);
+        $this->assertSame('Large spacing token', $storedToken['description']);
+    }
+
+    public function testEmptyTokenCssImportResetsRegistry(): void
+    {
+        global $ssc_options_store;
+        TokenRegistry::saveRegistry([
+            [
+                'name' => '--existing-token',
+                'value' => '#abcdef',
+                'type' => 'color',
+                'description' => '',
+                'group' => 'Legacy',
+            ],
+        ]);
+
+        $result = $this->apply(['ssc_tokens_css' => '']);
+
+        $this->assertContains('ssc_tokens_css', $result['applied']);
+        $this->assertSame([], $ssc_options_store['ssc_tokens_registry']);
+        $this->assertSame(TokenRegistry::tokensToCss([]), $ssc_options_store['ssc_tokens_css']);
+    }
+
+    public function testObjectPayloadsAreSanitized(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_settings'] = [];
+
+        $objectPayload = new stdClass();
+        $objectPayload->title = '<strong>Title</strong>';
+        $objectPayload->count = 5;
+        $objectPayload->nested = new stdClass();
+        $objectPayload->nested->note = '<em>Nested</em>';
+
+        $jsonOnlyObject = new class() implements \JsonSerializable {
+            public function jsonSerialize(): mixed
+            {
+                return ['danger' => '<script>alert(1)</script>'];
+            }
+        };
+
+        $result = $this->apply([
+            'ssc_settings' => [
+                'object_payload' => $objectPayload,
+                'json_only_object' => $jsonOnlyObject,
+            ],
+        ]);
+
+        $expectedSettings = [
+            'object_payload' => [
+                'title' => 'Title',
+                'count' => 5,
+                'nested' => [
+                    'note' => 'Nested',
+                ],
+            ],
+            'json_only_object' => '{"danger":"alert(1)"}',
+        ];
+
+        $this->assertSame($expectedSettings, $ssc_options_store['ssc_settings']);
+        $this->assertContains('ssc_settings', $result['applied']);
+    }
+
+    public function testDuplicateKeysAreReportedAndFirstValueIsKept(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_settings'] = [];
+
+        $payload = [
+            'options' => [
+                'ssc_settings' => [
+                    'Name One' => 'First Value',
+                    'name-one' => 'Second Value',
+                ],
+            ],
+        ];
+
+        $response = $this->routes->importConfig(new WP_REST_Request([], [], $payload));
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $data = $response->get_data();
+
+        $this->assertTrue($data['ok']);
+        $this->assertContains('ssc_settings', $data['applied']);
+        $this->assertContains('ssc_settings (duplicate key: nameone)', $data['skipped']);
+        $this->assertSame(['nameone' => 'First Value'], $ssc_options_store['ssc_settings']);
+    }
+
+    public function testImportConfigRejectsUnknownModules(): void
+    {
+        global $ssc_options_store;
+        $ssc_options_store['ssc_active_css'] = 'original-css';
+
+        $request = new WP_REST_Request(
+            ['modules' => ['totally-unknown']],
+            [],
+            [
+                'modules' => ['totally-unknown'],
+                'options' => [
+                    'ssc_active_css' => 'body { color: red; }',
+                ],
+            ]
+        );
+
+        $response = $this->routes->importConfig($request);
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(400, $response->get_status());
+
+        $data = $response->get_data();
+        $this->assertFalse($data['ok']);
+        $this->assertSame('No valid Supersede CSS modules were selected for import.', $data['message']);
+        $this->assertSame(['ssc_active_css'], $data['skipped']);
+        $this->assertSame('original-css', $ssc_options_store['ssc_active_css']);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array{applied: array<int, string>, skipped: array<int, string>} 
+     */
+    private function apply(array $options): array
+    {
+        /** @var array{applied: array<int, string>, skipped: array<int, string>} $result */
+        $result = $this->applyImportedOptions->invoke($this->routes, $options);
+
+        return $result;
+    }
 }

--- a/supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/UninstallCleanupTest.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+
 if (!defined('WP_UNINSTALL_PLUGIN')) {
     define('WP_UNINSTALL_PLUGIN', true);
 }
@@ -10,6 +12,8 @@ if (!defined('ABSPATH')) {
 
 /** @var list<string> $ssc_deleted_options */
 $ssc_deleted_options = [];
+
+global $ssc_deleted_options;
 
 if (!function_exists('delete_option')) {
     function delete_option(string $option_name): void
@@ -27,25 +31,21 @@ if (!function_exists('is_multisite')) {
     }
 }
 
-require __DIR__ . '/../../uninstall.php';
-
-if (!function_exists('assertOptionDeleted')) {
-    function assertOptionDeleted(string $option_name, array $deleted_options): void
+final class UninstallCleanupTest extends TestCase
+{
+    protected function setUp(): void
     {
-        if (!in_array($option_name, $deleted_options, true)) {
-            fwrite(
-                STDERR,
-                sprintf(
-                    'Failed asserting that option "%s" was deleted. Deleted options: %s' . PHP_EOL,
-                    $option_name,
-                    implode(', ', $deleted_options)
-                )
-            );
+        parent::setUp();
+        global $ssc_deleted_options;
+        $ssc_deleted_options = [];
+    }
 
-            exit(1);
-        }
+    public function testUninstallRemovesCachedOptions(): void
+    {
+        require __DIR__ . '/../../uninstall.php';
+
+        global $ssc_deleted_options;
+        $this->assertContains('ssc_css_cache', $ssc_deleted_options);
+        $this->assertContains('ssc_css_cache_meta', $ssc_deleted_options);
     }
 }
-
-assertOptionDeleted('ssc_css_cache', $ssc_deleted_options);
-assertOptionDeleted('ssc_css_cache_meta', $ssc_deleted_options);

--- a/supersede-css-jlg-enhanced/tests/bootstrap.php
+++ b/supersede-css-jlg-enhanced/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+error_reporting(E_ALL);
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
+
+if (!function_exists('ssc_get_required_capability')) {
+    function ssc_get_required_capability(): string
+    {
+        return 'manage_options';
+    }
+}


### PR DESCRIPTION
## Summary
- add a Composer configuration with PHPUnit, PSR-4 autoloading, a phpunit.xml.dist file, and a shared bootstrap
- convert the Support and Infra PHP scripts in tests/ into PHPUnit TestCase classes with native assertions
- expose composer test through npm, document the workflow in the README, and add a CI job that runs composer test and npm run test:ui

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dc351c9640832e95dc68a153d21d47