### PR TITLE
Add responsive mobile sidebar experience

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -2,8 +2,17 @@
 /* Thème sombre avec contraste encore amélioré */
 .ssc-dark:root,.ssc-dark{--ssc-bg:#030712;--ssc-card:#111827;--ssc-border:#374151;--ssc-text:#e5e7eb;--ssc-muted:#d1d5db;--ssc-accent:#a5b4fc;}
 .ssc-shell{position:relative}
-.ssc-topbar{position:sticky;top:0;z-index:1000;display:flex;align-items:center;gap:8px;background:var(--ssc-card);border-bottom:1px solid var(--ssc-border);padding:8px 16px;margin:0}
-.ssc-topbar .ssc-title{font-weight:700} .ssc-topbar .ssc-spacer{flex:1}
+.ssc-topbar{position:sticky;top:0;z-index:1300;display:flex;align-items:center;gap:8px;background:var(--ssc-card);border-bottom:1px solid var(--ssc-border);padding:8px 16px;margin:0}
+.ssc-topbar .ssc-title{font-weight:700}
+.ssc-topbar .ssc-spacer{flex:1}
+.ssc-topbar .ssc-topbar-label{margin-left:4px}
+.ssc-topbar .ssc-back-to-admin{display:inline-flex;align-items:center;gap:6px;text-decoration:none;padding:4px 8px}
+.ssc-topbar .ssc-back-to-admin .dashicons{font-size:18px;line-height:1}
+.ssc-topbar .button{display:inline-flex;align-items:center;gap:6px}
+.ssc-mobile-menu-toggle{display:none;align-items:center;justify-content:center;gap:4px}
+.ssc-mobile-menu-toggle .dashicons{font-size:18px;line-height:1}
+.ssc-shell-overlay{display:none}
+body.ssc-no-scroll{overflow:hidden}
 
 /* CORRECTION : La sidebar utilise maintenant les variables du thème */
 .ssc-sidebar{
@@ -22,12 +31,8 @@
 
 .ssc-sidebar a{display:flex;gap:8px;align-items:center;padding:8px;border-radius:8px;color:var(--ssc-text);text-decoration:none;border:1px solid transparent}
 .ssc-sidebar a.active{background:rgba(165, 180, 252, 0.1);border-color:var(--ssc-border); color: var(--ssc-accent); font-weight: 600;}
-.ssc-layout{display:grid;grid-template-columns:220px 1fr;gap:16px; align-items: flex-start;}
+.ssc-layout{display:grid;grid-template-columns:220px 1fr;gap:16px;align-items:flex-start;position:relative}
 .ssc-main-content { padding-left: 16px; }
-
-/* Nouveau bouton de retour */
-.ssc-topbar .ssc-back-to-admin { display: inline-flex; align-items: center; gap: 6px; text-decoration: none; padding: 4px 8px; }
-.ssc-topbar .ssc-back-to-admin .dashicons { font-size: 18px; line-height: 1; }
 
 /* Titres des groupes dans la sidebar */
 .ssc-sidebar-group { margin-bottom: 12px; }
@@ -38,6 +43,28 @@
     font-weight: 600;
     color: var(--ssc-muted);
     letter-spacing: 0.5px;
+}
+
+@media (max-width:960px){
+    .ssc-topbar{flex-wrap:wrap;row-gap:6px}
+    .ssc-topbar .ssc-title{flex:1 0 100%;margin-top:4px}
+    .ssc-topbar .ssc-spacer{display:none}
+    .ssc-mobile-menu-toggle{display:inline-flex}
+    .ssc-layout{grid-template-columns:1fr}
+    .ssc-layout aside{position:fixed;inset:0;background:var(--ssc-card);border:0;border-radius:0;padding:88px 16px 24px;max-width:100%;transform:translateY(-100%);transition:transform .3s ease,opacity .3s ease;z-index:1100;overflow-y:auto;box-shadow:0 20px 40px rgba(15,23,42,.4);pointer-events:none;opacity:0;visibility:hidden}
+    .ssc-layout aside .ssc-sidebar{width:100%;height:auto;max-width:640px;margin:0 auto}
+    .ssc-layout .ssc-main-content{padding-left:0}
+    .ssc-shell-overlay{position:fixed;inset:0;background:rgba(15,23,42,.45);z-index:1050;opacity:0;transition:opacity .3s ease}
+    .ssc-shell--menu-open .ssc-shell-overlay{display:block;opacity:1}
+    .ssc-shell--menu-open .ssc-layout aside{transform:translateY(0);pointer-events:auto;opacity:1;visibility:visible}
+    .ssc-shell--menu-open .ssc-shell-overlay{pointer-events:auto}
+    .ssc-shell-overlay{pointer-events:none}
+}
+
+@media (max-width:782px){
+    .ssc-topbar .ssc-topbar-label{display:none}
+    .ssc-topbar .ssc-back-to-admin{padding:4px}
+    .ssc-topbar .button{padding:4px 8px}
 }
 
 #ssc-cmdp{position:fixed;inset:0;display:none;align-items:flex-start;justify-content:center;background:rgba(2,6,23,.5);z-index:9999}

--- a/supersede-css-jlg-enhanced/assets/js/ux.js
+++ b/supersede-css-jlg-enhanced/assets/js/ux.js
@@ -91,6 +91,104 @@
             localStorage.setItem('ssc-theme', body.hasClass('ssc-dark') ? 'dark' : 'light');
         });
 
+        // --- Mobile Sidebar Toggle ---
+        const shell = $('.ssc-shell');
+        const sidebar = $('#ssc-sidebar');
+        const mobileMenuToggle = $('#ssc-mobile-menu');
+        const overlay = $('.ssc-shell-overlay');
+        const focusableSelectors = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+        let lastFocusedElement = null;
+
+        const isMobileViewport = () => window.matchMedia('(max-width: 960px)').matches;
+
+        const updateSidebarAria = () => {
+            if (isMobileViewport() && !shell.hasClass('ssc-shell--menu-open')) {
+                sidebar.attr('aria-hidden', 'true');
+            } else {
+                sidebar.removeAttr('aria-hidden');
+            }
+        };
+
+        const focusSidebar = () => {
+            const focusable = sidebar.find(focusableSelectors).filter(':visible');
+            if (focusable.length) {
+                focusable.first().trigger('focus');
+            } else {
+                sidebar.attr('tabindex', '-1');
+                sidebar.trigger('focus');
+            }
+        };
+
+        const openMobileMenu = () => {
+            if (!isMobileViewport() || shell.hasClass('ssc-shell--menu-open')) {
+                return;
+            }
+
+            lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            shell.addClass('ssc-shell--menu-open');
+            $('body').addClass('ssc-no-scroll');
+            overlay.removeAttr('hidden');
+            mobileMenuToggle.attr({
+                'aria-expanded': 'true',
+                'aria-label': 'Masquer le menu'
+            });
+            updateSidebarAria();
+            focusSidebar();
+        };
+
+        const closeMobileMenu = ({ restoreFocus = true } = {}) => {
+            if (!shell.hasClass('ssc-shell--menu-open')) {
+                updateSidebarAria();
+                return;
+            }
+
+            shell.removeClass('ssc-shell--menu-open');
+            $('body').removeClass('ssc-no-scroll');
+            overlay.attr('hidden', 'hidden');
+            mobileMenuToggle.attr({
+                'aria-expanded': 'false',
+                'aria-label': 'Afficher le menu'
+            });
+            sidebar.removeAttr('tabindex');
+            updateSidebarAria();
+
+            if (restoreFocus && lastFocusedElement) {
+                $(lastFocusedElement).trigger('focus');
+            }
+            lastFocusedElement = null;
+        };
+
+        updateSidebarAria();
+
+        mobileMenuToggle.on('click', function() {
+            if (shell.hasClass('ssc-shell--menu-open')) {
+                closeMobileMenu();
+            } else {
+                openMobileMenu();
+            }
+        });
+
+        overlay.on('click', function() {
+            closeMobileMenu();
+        });
+
+        shell.on('click', function(event) {
+            if (!shell.hasClass('ssc-shell--menu-open') || !isMobileViewport()) {
+                return;
+            }
+
+            if (!$(event.target).closest('aside, #ssc-mobile-menu').length) {
+                closeMobileMenu();
+            }
+        });
+
+        $(window).on('resize', function() {
+            if (!isMobileViewport()) {
+                closeMobileMenu({ restoreFocus: false });
+            }
+            updateSidebarAria();
+        });
+
         // --- Command Palette (⌘K) ---
         const cmdkButton = $('#ssc-cmdk');
         const cmdkPanelHtml = `
@@ -168,8 +266,43 @@
                 e.preventDefault();
                 cmdkButton.click();
             }
-            if (e.key === 'Escape' && cmdp.hasClass('active')) {
-                cmdp.removeClass('active');
+
+            if (e.key === 'Escape') {
+                if (cmdp.hasClass('active')) {
+                    cmdp.removeClass('active');
+                }
+                if (shell.hasClass('ssc-shell--menu-open')) {
+                    closeMobileMenu();
+                }
+            }
+
+            if (shell.hasClass('ssc-shell--menu-open') && e.key === 'Tab') {
+                const focusable = sidebar.find(focusableSelectors).filter(':visible');
+                if (!focusable.length) {
+                    return;
+                }
+
+                const first = focusable.get(0);
+                const last = focusable.get(focusable.length - 1);
+                const activeElement = document.activeElement;
+
+                if (!e.shiftKey && activeElement === last) {
+                    e.preventDefault();
+                    $(first).trigger('focus');
+                } else if (e.shiftKey && activeElement === first) {
+                    e.preventDefault();
+                    $(last).trigger('focus');
+                }
+            }
+        });
+
+        $(document).on('focusin', function(e) {
+            if (!shell.hasClass('ssc-shell--menu-open') || !isMobileViewport()) {
+                return;
+            }
+
+            if ($(e.target).closest('#ssc-sidebar, #ssc-mobile-menu').length === 0) {
+                focusSidebar();
             }
         });
     });

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -313,15 +313,27 @@ class Layout {
         ?>
         <div class="ssc-shell">
             <header class="ssc-topbar">
-                <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button">
-                    <span class="dashicons dashicons-arrow-left-alt"></span> WP Admin
+                <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="Retourner sur le tableau de bord WordPress">
+                    <span class="dashicons dashicons-arrow-left-alt" aria-hidden="true"></span>
+                    <span class="ssc-topbar-label">WP Admin</span>
                 </a>
                 <span class="ssc-title">Supersede CSS</span><span class="ssc-spacer"></span>
-                <button class="button" id="ssc-theme">🌓 Thème</button>
-                <button class="button button-primary" id="ssc-cmdk">⌘K Commande</button>
+                <button type="button" class="button" id="ssc-theme" aria-label="Basculer le thème clair ou sombre">
+                    <span aria-hidden="true">🌓</span>
+                    <span class="ssc-topbar-label">Thème</span>
+                </button>
+                <button type="button" class="button ssc-mobile-menu-toggle" id="ssc-mobile-menu" aria-expanded="false" aria-controls="ssc-sidebar" aria-label="Afficher le menu">
+                    <span class="dashicons dashicons-menu" aria-hidden="true"></span>
+                </button>
+                <button type="button" class="button button-primary" id="ssc-cmdk" aria-label="Ouvrir la palette de commandes">
+                    <span aria-hidden="true">⌘K</span>
+                    <span class="ssc-topbar-label">Commande</span>
+                </button>
             </header>
+            <div class="ssc-shell-overlay" hidden></div>
             <div class="ssc-layout">
-                <aside><nav class="ssc-sidebar">
+                <aside>
+                    <nav class="ssc-sidebar" id="ssc-sidebar">
                     <?php foreach ($menu_items as $group_label => $items): ?>
                         <div class="ssc-sidebar-group">
                             <h4 class="ssc-sidebar-heading"><?php echo esc_html($group_label); ?></h4>
@@ -332,7 +344,8 @@ class Layout {
                             <?php endforeach; ?>
                         </div>
                     <?php endforeach; ?>
-                </nav></aside>
+                    </nav>
+                </aside>
                 <main class="ssc-main-content">
                     <?php echo wp_kses( $page_content, self::allowed_tags() ); ?>
                 </main>


### PR DESCRIPTION
## Summary
- adjust the admin topbar markup to support compact labels and add a mobile menu toggle
- add responsive CSS breakpoints so the sidebar becomes a full-screen overlay on small viewports
- implement JavaScript to open and close the mobile sidebar with focus management and escape/outside-click support

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc5c8a0070832e9149540755f75ccb