### PR TITLE
Improve toast accessibility live region

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -70,6 +70,6 @@ body.ssc-no-scroll{overflow:hidden}
 #ssc-cmdp ul{max-height:50vh;overflow:auto;margin:0;padding:0;list-style:none}
 #ssc-cmdp li a{display:flex;padding:10px;text-decoration:none;color:var(--ssc-text);border-bottom:1px solid var(--ssc-border)}
 #ssc-cmdp li a:hover{background:rgba(165, 180, 252, 0.1)}
-#ssc-toasts{position:fixed;right:16px;bottom:16px;display:flex;flex-direction:column;gap:8px;z-index:99999}
-.ssc-toast{background:var(--ssc-card);border:1px solid var(--ssc-border);border-radius:10px;padding:10px 12px;box-shadow:0 10px 20px rgba(0,0,0,.12); opacity: 0; transform: translateY(10px); animation: ssc-toast-in 0.3s ease forwards;}
+#ssc-toasts{position:fixed;right:16px;bottom:16px;display:flex;flex-direction:column;gap:8px;z-index:99999;pointer-events:none}
+.ssc-toast{background:var(--ssc-card);border:1px solid var(--ssc-border);border-radius:10px;padding:10px 12px;box-shadow:0 10px 20px rgba(0,0,0,.12); opacity: 0; transform: translateY(10px); animation: ssc-toast-in 0.3s ease forwards;pointer-events:auto}
 @keyframes ssc-toast-in { to { opacity: 1; transform: translateY(0); } }

--- a/supersede-css-jlg-enhanced/assets/js/ux.js
+++ b/supersede-css-jlg-enhanced/assets/js/ux.js
@@ -1,10 +1,44 @@
 (function($) {
     // --- Toast Notifications ---
-    window.sscToast = function(message) {
-        const toast = $('<div class="ssc-toast"></div>').text(message);
-        const container = $('#ssc-toasts').length ? $('#ssc-toasts') : $('<div id="ssc-toasts"></div>').appendTo('body');
+    const TOAST_DEFAULT_TIMEOUT = 3000;
+    const TOAST_DEFAULT_POLITENESS = 'polite';
+
+    const getToastContainer = (politeness = TOAST_DEFAULT_POLITENESS) => {
+        let container = $('#ssc-toasts');
+
+        if (!container.length) {
+            container = $('<div id="ssc-toasts" role="status" aria-live="polite" aria-atomic="false"></div>');
+            container.appendTo('body');
+        }
+
+        const normalizedPoliteness = politeness === 'assertive' ? 'assertive' : TOAST_DEFAULT_POLITENESS;
+        if (container.attr('aria-live') !== normalizedPoliteness) {
+            container.attr('aria-live', normalizedPoliteness);
+        }
+
+        return container;
+    };
+
+    window.sscToast = function(message, {
+        politeness = TOAST_DEFAULT_POLITENESS,
+        role,
+        timeout = TOAST_DEFAULT_TIMEOUT
+    } = {}) {
+        const container = getToastContainer(politeness);
+        const toastRole = role || (politeness === 'assertive' ? 'alert' : 'status');
+        const toast = $('<div class="ssc-toast"></div>')
+            .attr('role', toastRole)
+            .text(message);
+
         container.append(toast);
-        setTimeout(() => toast.remove(), 3000);
+
+        setTimeout(() => {
+            toast.remove();
+
+            if (!container.children().length) {
+                container.attr('aria-live', TOAST_DEFAULT_POLITENESS);
+            }
+        }, timeout);
     };
 
     // --- Plugin Asset URL Helper ---

--- a/supersede-css-jlg-enhanced/manual-tests/import-config.md
+++ b/supersede-css-jlg-enhanced/manual-tests/import-config.md
@@ -21,6 +21,7 @@ Objectif : vérifier que le flux « Exporter → Importer » permet de restau
 4. **Importer le fichier exporté**
    1. Toujours dans l’onglet « Import / Export », sélectionner le fichier JSON précédemment exporté.
    2. Cliquer sur **Importer** et s’assurer que le toast « Configuration importée ! » et le message récapitulatif apparaissent.
+   3. Ouvrir les outils de développement et vérifier que le conteneur `#ssc-toasts` reste présent avec `role="status"` et l’attribut `aria-live` correspondant, et que chaque toast ajouté possède `role="alert"` (ou un rôle équivalent selon la criticité).
 5. **Valider la restauration**
    1. Revenir sur l’éditeur principal et vérifier que le CSS, les presets et les autres réglages sont de nouveau présents.
    2. En cas d’échec, relever le message affiché dans `#ssc-import-msg` ainsi que la réponse REST (onglet Réseau du navigateur) pour faciliter le diagnostic.


### PR DESCRIPTION
## Summary
- initialize the toast live region with the appropriate ARIA role and politeness handling while keeping notifications in place
- tweak toast container styling so it stays visually consistent without capturing pointer focus
- extend the import configuration manual test to confirm the toast container and items expose the required accessibility attributes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2020b66c832eb5ab4f90c88d56f2