### PR TITLE
Handle duplicate token names across registry and UI

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/tokens.css
+++ b/supersede-css-jlg-enhanced/assets/css/tokens.css
@@ -47,3 +47,18 @@
     margin: 0;
     font-style: italic;
 }
+
+.ssc-token-row--duplicate {
+    background-color: rgba(220, 38, 38, 0.08);
+    border-radius: 4px;
+    padding: 4px;
+}
+
+.token-field-input--duplicate {
+    border-color: #dc2626;
+    box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.35);
+}
+
+.token-field-input--duplicate:focus {
+    box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.35), 0 0 0 3px rgba(220, 38, 38, 0.2);
+}

--- a/supersede-css-jlg-enhanced/src/Support/CssRevisions.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssRevisions.php
@@ -115,7 +115,10 @@ final class CssRevisions
             $existingRegistry = TokenRegistry::getRegistry();
             $tokensWithMetadata = TokenRegistry::mergeMetadata($tokens, $existingRegistry);
             $savedTokens = TokenRegistry::saveRegistry($tokensWithMetadata);
-            $css = TokenRegistry::tokensToCss($savedTokens);
+            if ($savedTokens['duplicates'] !== []) {
+                return;
+            }
+            $css = TokenRegistry::tokensToCss($savedTokens['tokens']);
             update_option('ssc_tokens_css', $css, false);
         } else {
             update_option($option, $css, false);

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesImportTest.php
@@ -446,7 +446,7 @@ if ($storedCombinedToken['type'] !== 'color' || $storedCombinedToken['group'] !=
     exit(1);
 }
 
-$ssc_options_store['ssc_tokens_registry'] = \SSC\Support\TokenRegistry::saveRegistry([
+$saveResult = \SSC\Support\TokenRegistry::saveRegistry([
     [
         'name' => '--spacing-large',
         'value' => '32px',
@@ -455,6 +455,13 @@ $ssc_options_store['ssc_tokens_registry'] = \SSC\Support\TokenRegistry::saveRegi
         'group' => 'Spacing',
     ],
 ]);
+
+if ($saveResult['duplicates'] !== []) {
+    fwrite(STDERR, 'Initial registry setup should not report duplicates.' . PHP_EOL);
+    exit(1);
+}
+
+$ssc_options_store['ssc_tokens_registry'] = $saveResult['tokens'];
 
 $cssOnlyResult = $applyMethod->invoke($routes, [
     'ssc_tokens_css' => ":root {\n    --spacing-large: 40px;\n}",
@@ -484,7 +491,7 @@ if ($storedCssOnlyToken['type'] !== 'number' || $storedCssOnlyToken['group'] !==
     exit(1);
 }
 
-\SSC\Support\TokenRegistry::saveRegistry([
+$secondSave = \SSC\Support\TokenRegistry::saveRegistry([
     [
         'name' => '--existing-token',
         'value' => '#abcdef',
@@ -493,6 +500,11 @@ if ($storedCssOnlyToken['type'] !== 'number' || $storedCssOnlyToken['group'] !==
         'group' => 'Legacy',
     ],
 ]);
+
+if ($secondSave['duplicates'] !== []) {
+    fwrite(STDERR, 'Registry persistence should not report duplicates.' . PHP_EOL);
+    exit(1);
+}
 
 $emptyTokensResult = $applyMethod->invoke($routes, [
     'ssc_tokens_css' => '',

--- a/supersede-css-jlg-enhanced/tests/Infra/RoutesSaveCssTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/RoutesSaveCssTest.php
@@ -78,7 +78,8 @@ class RoutesSaveCssTest extends WP_UnitTestCase
             ],
         ];
 
-        TokenRegistry::saveRegistry($initialRegistry);
+        $initialSave = TokenRegistry::saveRegistry($initialRegistry);
+        $this->assertSame([], $initialSave['duplicates']);
 
         $tokenCss = ":root {\n    --first-token: #123456;\n    --second-token: 1.5rem;\n    --with-semicolon: 'foo;bar'\n}";
 
@@ -94,10 +95,14 @@ class RoutesSaveCssTest extends WP_UnitTestCase
 
         $sanitizedCss = CssSanitizer::sanitize($tokenCss);
         $convertedRegistry = TokenRegistry::convertCssToRegistry($sanitizedCss);
-        $normalizedInitial = TokenRegistry::normalizeRegistry($initialRegistry);
-        $expectedRegistry = TokenRegistry::normalizeRegistry(
+        $normalizedInitialResult = TokenRegistry::normalizeRegistry($initialRegistry);
+        $this->assertSame([], $normalizedInitialResult['duplicates']);
+        $normalizedInitial = $normalizedInitialResult['tokens'];
+        $expectedRegistryResult = TokenRegistry::normalizeRegistry(
             TokenRegistry::mergeMetadata($convertedRegistry, $normalizedInitial)
         );
+        $this->assertSame([], $expectedRegistryResult['duplicates']);
+        $expectedRegistry = $expectedRegistryResult['tokens'];
         $expectedRegistryCss = TokenRegistry::tokensToCss($expectedRegistry);
 
         $this->assertSame($expectedRegistry, get_option('ssc_tokens_registry'));

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -90,7 +90,7 @@ if (!function_exists('update_option')) {
 require_once __DIR__ . '/../../src/Support/CssSanitizer.php';
 require_once __DIR__ . '/../../src/Support/TokenRegistry.php';
 
-$normalized = TokenRegistry::normalizeRegistry([
+$normalizedResult = TokenRegistry::normalizeRegistry([
     [
         'name' => '--BrandPrimary',
         'value' => '#3366ff',
@@ -99,13 +99,20 @@ $normalized = TokenRegistry::normalizeRegistry([
         'group' => 'Brand',
     ],
 ]);
+
+$normalized = $normalizedResult['tokens'];
+
+if ($normalizedResult['duplicates'] !== []) {
+    fwrite(STDERR, 'TokenRegistry::normalizeRegistry should not report duplicates for unique tokens.' . PHP_EOL);
+    exit(1);
+}
 
 if ($normalized === [] || $normalized[0]['name'] !== '--BrandPrimary') {
     fwrite(STDERR, 'TokenRegistry::normalizeRegistry should preserve the original token casing.' . PHP_EOL);
     exit(1);
 }
 
-$registry = TokenRegistry::saveRegistry([
+$registryResult = TokenRegistry::saveRegistry([
     [
         'name' => '--BrandPrimary',
         'value' => '#3366ff',
@@ -114,6 +121,13 @@ $registry = TokenRegistry::saveRegistry([
         'group' => 'Brand',
     ],
 ]);
+
+$registry = $registryResult['tokens'];
+
+if ($registryResult['duplicates'] !== []) {
+    fwrite(STDERR, 'TokenRegistry::saveRegistry should not report duplicates for unique tokens.' . PHP_EOL);
+    exit(1);
+}
 
 if ($registry === [] || $registry[0]['name'] !== '--BrandPrimary') {
     fwrite(STDERR, 'TokenRegistry::saveRegistry should preserve the original token casing.' . PHP_EOL);
@@ -237,7 +251,13 @@ $underscoredTokens = [
     ],
 ];
 
-$savedRegistry = TokenRegistry::saveRegistry($underscoredTokens);
+$savedRegistryResult = TokenRegistry::saveRegistry($underscoredTokens);
+$savedRegistry = $savedRegistryResult['tokens'];
+
+if ($savedRegistryResult['duplicates'] !== []) {
+    fwrite(STDERR, 'saveRegistry should not report duplicates for unique underscored tokens.' . PHP_EOL);
+    exit(1);
+}
 
 if ($savedRegistry === [] || $savedRegistry[0]['name'] !== '--spacing_small') {
     fwrite(STDERR, 'saveRegistry should preserve underscores in token names.' . PHP_EOL);
@@ -292,7 +312,11 @@ if ($registryFromCommentedCss === [] || $registryFromCommentedCss[0]['name'] !==
     exit(1);
 }
 
-TokenRegistry::saveRegistry($registryFromCommentedCss);
+$commentedResult = TokenRegistry::saveRegistry($registryFromCommentedCss);
+if ($commentedResult['duplicates'] !== []) {
+    fwrite(STDERR, 'saveRegistry should not report duplicates when CSS comments are ignored.' . PHP_EOL);
+    exit(1);
+}
 
 if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
     fwrite(STDERR, 'saveRegistry should persist tokens parsed after leading comments.' . PHP_EOL);
@@ -314,7 +338,11 @@ if ($annotatedRegistry === [] || $annotatedRegistry[0]['name'] !== '--my-token')
     exit(1);
 }
 
-TokenRegistry::saveRegistry($annotatedRegistry);
+$annotatedResult = TokenRegistry::saveRegistry($annotatedRegistry);
+if ($annotatedResult['duplicates'] !== []) {
+    fwrite(STDERR, 'saveRegistry should not report duplicates when annotated comments are present.' . PHP_EOL);
+    exit(1);
+}
 
 if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
     fwrite(STDERR, 'saveRegistry should persist tokens that follow annotated comments.' . PHP_EOL);

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -22,6 +22,8 @@ if (function_exists('wp_localize_script')) {
             'deleteLabel' => __('Supprimer', 'supersede-css-jlg'),
             'saveSuccess' => __('Tokens enregistrés', 'supersede-css-jlg'),
             'saveError' => __('Impossible d’enregistrer les tokens.', 'supersede-css-jlg'),
+            'duplicateError' => __('Certains tokens utilisent le même nom. Corrigez les doublons avant d’enregistrer.', 'supersede-css-jlg'),
+            'duplicateListPrefix' => __('Doublons :', 'supersede-css-jlg'),
             'copySuccess' => __('Tokens copiés', 'supersede-css-jlg'),
             'reloadConfirm' => __('Des modifications locales non enregistrées seront perdues. Continuer ?', 'supersede-css-jlg'),
         ],


### PR DESCRIPTION
## Summary
- propagate duplicate detection information from the token registry and skip persistence when conflicts are present
- update REST routes, imports, and revision restore logic to return duplicate token errors instead of silently overwriting values
- enhance the admin tokens UI with duplicate highlighting, blocking, and toast messaging, and add Playwright coverage for the conflict scenario

## Testing
- composer test *(fails: WordPress database connection refused in wp_die())*

------
https://chatgpt.com/codex/tasks/task_e_68dd2e986760832eb7ec8ae2d5d63f21