### PR TITLE
Localize Debug Center client strings

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -244,7 +244,7 @@ final class Admin
                 $path = 'assets/js/' . $handle . '.js';
                 if (is_file(SSC_PLUGIN_DIR . $path)) {
                     $dependencies = ['jquery'];
-                    if (in_array($handle, ['utilities', 'import-export'], true)) {
+                    if (in_array($handle, ['utilities', 'import-export', 'debug-center'], true)) {
                         $dependencies[] = 'wp-i18n';
                     }
 
@@ -252,7 +252,7 @@ final class Admin
 
                     wp_enqueue_script($script_handle, SSC_PLUGIN_URL . $path, $dependencies, SSC_VERSION, true);
 
-                    if (in_array($handle, ['utilities', 'import-export'], true) && function_exists('wp_set_script_translations')) {
+                    if (in_array($handle, ['utilities', 'import-export', 'debug-center'], true) && function_exists('wp_set_script_translations')) {
                         wp_set_script_translations(
                             $script_handle,
                             'supersede-css-jlg',

--- a/supersede-css-jlg-enhanced/src/Admin/Pages/DebugCenter.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/DebugCenter.php
@@ -15,6 +15,39 @@ class DebugCenter extends AbstractPage
     {
         $log_entries = class_exists('\\SSC\\Infra\\Logger') ? \SSC\Infra\Logger::all() : [];
 
+        if (function_exists('wp_localize_script')) {
+            wp_localize_script(
+                'ssc-debug-center',
+                'sscDebugCenterL10n',
+                [
+                    'domain'  => 'supersede-css-jlg',
+                    'strings' => [
+                        'healthCheckCheckingLabel'       => __('Vérification...', 'supersede-css-jlg'),
+                        'healthCheckRunningMessage'      => __('Vérification en cours...', 'supersede-css-jlg'),
+                        'healthCheckSuccessMessage'      => __('Health Check terminé.', 'supersede-css-jlg'),
+                        'healthCheckErrorMessage'        => __('Erreur lors du Health Check. Vérifiez la console du navigateur pour plus de détails.', 'supersede-css-jlg'),
+                        'healthCheckRunLabel'            => __('Lancer Health Check', 'supersede-css-jlg'),
+                        'confirmClearLog'                => __('Voulez-vous vraiment effacer tout le journal d\'activité ? Cette action est irréversible.', 'supersede-css-jlg'),
+                        'clearLogSuccess'                => __('Journal effacé ! La page va se recharger.', 'supersede-css-jlg'),
+                        'clearLogError'                  => __('Erreur lors de la suppression du journal.', 'supersede-css-jlg'),
+                        'confirmResetAllCss'             => __("ATTENTION : Vous êtes sur le point de supprimer TOUT le CSS généré par Supersede. Cette action est irréversible.\n\nVoulez-vous vraiment continuer ?", 'supersede-css-jlg'),
+                        'resetAllCssWorking'             => __('Réinitialisation...', 'supersede-css-jlg'),
+                        'resetAllCssSuccess'             => __('Tout le CSS a été réinitialisé !', 'supersede-css-jlg'),
+                        'resetAllCssLabel'               => __('Réinitialiser tout le CSS', 'supersede-css-jlg'),
+                        'resetAllCssError'               => __('Erreur lors de la réinitialisation.', 'supersede-css-jlg'),
+                        'restUnavailable'                => __('L’API REST est indisponible.', 'supersede-css-jlg'),
+                        'revisionNotFound'               => __('Révision introuvable.', 'supersede-css-jlg'),
+                        /* translators: %s: Option name associated with the revision. */
+                        'confirmRestoreRevisionWithOption' => __('Restaurer la révision pour « %s » ?\nCette opération remplacera le CSS actuel.', 'supersede-css-jlg'),
+                        'confirmRestoreRevision'         => __('Restaurer cette révision ?\nCette opération remplacera le CSS actuel.', 'supersede-css-jlg'),
+                        'restoreWorking'                 => __('Restauration…', 'supersede-css-jlg'),
+                        'restoreSuccess'                 => __('Révision restaurée. Actualisation de la page…', 'supersede-css-jlg'),
+                        'restoreError'                   => __('Impossible de restaurer cette révision.', 'supersede-css-jlg'),
+                    ],
+                ]
+            );
+        }
+
         $this->render_view('debug-center', [
             'system_info' => [
                 'plugin_version'    => defined('SSC_VERSION') ? SSC_VERSION : 'N/A',


### PR DESCRIPTION
## Summary
- localize Debug Center script strings from PHP and register wp-i18n dependencies
- consume the localized messages in debug-center.js using wp.i18n translations
- extend the Playwright UI test suite to cover the localized health check messaging

## Testing
- not run (Playwright environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd424fbf94832ea6e338da02e15ccd