### PR TITLE
Add configurable responsive breakpoints

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -252,6 +252,12 @@ final class Admin
 
                     wp_enqueue_script($script_handle, SSC_PLUGIN_URL . $path, $dependencies, SSC_VERSION, true);
 
+                    if ($handle === 'utilities') {
+                        wp_localize_script($script_handle, 'SSC_UTILITIES_DATA', [
+                            'breakpoints' => \ssc_get_breakpoints(),
+                        ]);
+                    }
+
                     if (in_array($handle, ['utilities', 'import-export'], true) && function_exists('wp_set_script_translations')) {
                         wp_set_script_translations(
                             $script_handle,

--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -4,6 +4,7 @@ namespace SSC\Infra;
 use SSC\Support\CssRevisions;
 use SSC\Support\CssSanitizer;
 use SSC\Support\TokenRegistry;
+use function ssc_get_breakpoints;
 
 if (!class_exists('\\SSC\\Support\\CssRevisions') && is_readable(__DIR__ . '/../Support/CssRevisions.php')) {
     require_once __DIR__ . '/../Support/CssRevisions.php';
@@ -1328,12 +1329,16 @@ final class Routes {
             $parts[] = $desktop;
         }
 
+        $breakpoints = ssc_get_breakpoints();
+        $tabletMax = isset($breakpoints['tablet']) ? (int) $breakpoints['tablet'] : 782;
+        $mobileMax = isset($breakpoints['mobile']) ? (int) $breakpoints['mobile'] : 480;
+
         if (trim($tablet) !== '') {
-            $parts[] = "@media (max-width: 782px) {\n{$tablet}\n}";
+            $parts[] = "@media (max-width: {$tabletMax}px) {\n{$tablet}\n}";
         }
 
         if (trim($mobile) !== '') {
-            $parts[] = "@media (max-width: 480px) {\n{$mobile}\n}";
+            $parts[] = "@media (max-width: {$mobileMax}px) {\n{$mobile}\n}";
         }
 
         $combined = implode("\n\n", array_filter($parts, static function (string $part): bool {

--- a/supersede-css-jlg-enhanced/tests/ui/responsive-preview.spec.js
+++ b/supersede-css-jlg-enhanced/tests/ui/responsive-preview.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require('@playwright/test');
+const { runWpEnv } = require('./utils/wp-env');
+
+const ADMIN_PATH = '/wp-admin/admin.php?page=supersede-css-jlg-utilities';
+const DEFAULT_USERNAME = process.env.WP_USERNAME || 'admin';
+const DEFAULT_PASSWORD = process.env.WP_PASSWORD || 'password';
+
+function getAdminUtilitiesUrl(testInfo) {
+  const baseURL = testInfo.project.use.baseURL || 'http://localhost:8889';
+  return new URL(ADMIN_PATH, baseURL).toString();
+}
+
+async function authenticate(page, adminUrl, credentials) {
+  const loginUrl = `/wp-login.php?redirect_to=${encodeURIComponent(adminUrl)}`;
+  await page.goto(loginUrl, { waitUntil: 'domcontentloaded' });
+
+  const usernameInput = page.locator('#user_login');
+  if (await usernameInput.isVisible()) {
+    await usernameInput.fill(credentials.username);
+    await page.locator('#user_pass').fill(credentials.password);
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle' }),
+      page.locator('#wp-submit').click(),
+    ]);
+  }
+
+  await page.goto(adminUrl, { waitUntil: 'networkidle' });
+}
+
+test.describe('Responsive preview breakpoints', () => {
+  test.beforeAll(async () => {
+    await runWpEnv([
+      'run',
+      'cli',
+      'wp',
+      'eval',
+      "update_option('ssc_breakpoints', ['desktop' => 900, 'tablet' => 640, 'mobile' => 360], false);",
+    ]);
+  });
+
+  test.afterAll(async () => {
+    await runWpEnv(['run', 'cli', 'wp', 'option', 'delete', 'ssc_breakpoints']);
+  });
+
+  test('applies configured breakpoints to preview toggles', async ({ page }, testInfo) => {
+    const adminUrl = getAdminUtilitiesUrl(testInfo);
+
+    await authenticate(page, adminUrl, {
+      username: DEFAULT_USERNAME,
+      password: DEFAULT_PASSWORD,
+    });
+
+    await page.waitForSelector('.ssc-utilities-wrap');
+    await page.waitForFunction(() => {
+      return Boolean(
+        window.SSC_UTILITIES_DATA &&
+          window.SSC_UTILITIES_DATA.breakpoints &&
+          typeof window.SSC_UTILITIES_DATA.breakpoints === 'object'
+      );
+    });
+
+    const localizedBreakpoints = await page.evaluate(() => window.SSC_UTILITIES_DATA.breakpoints);
+    expect(localizedBreakpoints.tablet).toBe(640);
+    expect(localizedBreakpoints.mobile).toBe(360);
+
+    const previewFrame = page.locator('#ssc-preview-frame');
+    await expect(previewFrame).toHaveCSS('max-width', '900px');
+
+    const tabletToggle = page.locator('.ssc-responsive-toggles button[data-vp="tablet"]');
+    const mobileToggle = page.locator('.ssc-responsive-toggles button[data-vp="mobile"]');
+    const desktopToggle = page.locator('.ssc-responsive-toggles button[data-vp="desktop"]');
+
+    await tabletToggle.click();
+    await expect(previewFrame).toHaveCSS('max-width', '640px');
+
+    await mobileToggle.click();
+    await expect(previewFrame).toHaveCSS('max-width', '360px');
+
+    await desktopToggle.click();
+    await expect(previewFrame).toHaveCSS('max-width', '900px');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable helper that retrieves configurable desktop/tablet/mobile breakpoints with sanitization and filtering
- expose the breakpoints to the utilities script and update the responsive CSS/preview logic to consume them dynamically
- update REST handling and tests, including a new Playwright scenario, to cover custom breakpoint usage

## Testing
- composer test *(fails: WordPress test database not available in container)*
- npx playwright test tests/ui/responsive-preview.spec.js --project=chromium *(fails: Docker/wp-env unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd42522be4832e8a6c51cf2e322635