### PR TITLE
Handle save-css errors for Tron grid and visual effects

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/tron-grid.js
+++ b/supersede-css-jlg-enhanced/assets/js/tron-grid.js
@@ -1,4 +1,11 @@
 (function($) {
+    const fallbackI18n = {
+        __: (text) => text,
+    };
+
+    const hasI18n = typeof window !== 'undefined' && window.wp && window.wp.i18n;
+    const { __ } = hasI18n ? window.wp.i18n : fallbackI18n;
+
     function copyToClipboard(text) {
         if (navigator.clipboard && window.isSecureContext) {
             return navigator.clipboard.writeText(text);
@@ -88,7 +95,14 @@
                 method: 'POST',
                 data: { css: css, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-            }).done(() => window.sscToast('Grille animée appliquée !'));
+            }).done(() => window.sscToast('Grille animée appliquée !'))
+                .fail((jqXHR, textStatus, errorThrown) => {
+                    console.error('Échec de l\'enregistrement de la grille animée.', errorThrown || jqXHR);
+                    window.sscToast(
+                        __('Échec de l\'enregistrement de la grille animée.', 'supersede-css-jlg'),
+                        { politeness: 'assertive' }
+                    );
+                });
         });
 
         generateTronCSS();

--- a/supersede-css-jlg-enhanced/assets/js/visual-effects.js
+++ b/supersede-css-jlg-enhanced/assets/js/visual-effects.js
@@ -1,4 +1,11 @@
 (function($) {
+    const fallbackI18n = {
+        __: (text) => text,
+    };
+
+    const hasI18n = typeof window !== 'undefined' && window.wp && window.wp.i18n;
+    const { __ } = hasI18n ? window.wp.i18n : fallbackI18n;
+
     $(document).ready(function() {
         if (!$('.ssc-ve-tabs').length) return;
 
@@ -158,10 +165,22 @@
 
         // Attacher les écouteurs d'événements
         $('#ssc-bg-type, #starColor, #starCount, #gradientSpeed').on('input change', generateBackgroundCSS);
-        $('#ssc-bg-apply').on('click', () => {
+        const $applyButton = $('#ssc-bg-apply');
+        $applyButton.on('click', () => {
              const css = $('#ssc-bg-css').text();
+             $applyButton.prop('disabled', true).attr('aria-disabled', 'true');
              $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-             }).done(() => window.sscToast('Fond animé appliqué !'));
+             }).done(() => window.sscToast('Fond animé appliqué !'))
+             .fail((jqXHR, textStatus, errorThrown) => {
+                 console.error('Échec de l\'enregistrement du fond animé.', errorThrown || jqXHR);
+                 window.sscToast(
+                     __('Échec de l\'enregistrement du fond animé.', 'supersede-css-jlg'),
+                     { politeness: 'assertive' }
+                 );
+             })
+             .always(() => {
+                 $applyButton.prop('disabled', false).removeAttr('aria-disabled');
+             });
         });
         
         // Appel initial pour afficher l'aperçu par défaut


### PR DESCRIPTION
## Summary
- add wp.i18n fallbacks so Tron grid and animated backgrounds can localize failure toasts
- surface save-css AJAX failures with assertive toasts and console logging
- disable the animated background apply button during requests and restore it afterward

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd696f128c832eafe99da4c3d78379