### PR TITLE
Handle save-css failures for Tron grid and animated backgrounds

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/tron-grid.js
+++ b/supersede-css-jlg-enhanced/assets/js/tron-grid.js
@@ -90,6 +90,7 @@
         
         $('#ssc-tron-apply').on('click', () => {
             const css = $('#ssc-tron-css').text();
+            const errorMessage = __('Échec de l\'enregistrement de la grille animée.', 'supersede-css-jlg');
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
@@ -97,9 +98,9 @@
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => window.sscToast('Grille animée appliquée !'))
                 .fail((jqXHR, textStatus, errorThrown) => {
-                    console.error('Échec de l\'enregistrement de la grille animée.', errorThrown || jqXHR);
+                    console.error(errorMessage, { jqXHR, textStatus, errorThrown });
                     window.sscToast(
-                        __('Échec de l\'enregistrement de la grille animée.', 'supersede-css-jlg'),
+                        errorMessage,
                         { politeness: 'assertive' }
                     );
                 });

--- a/supersede-css-jlg-enhanced/assets/js/visual-effects.js
+++ b/supersede-css-jlg-enhanced/assets/js/visual-effects.js
@@ -168,13 +168,14 @@
         const $applyButton = $('#ssc-bg-apply');
         $applyButton.on('click', () => {
              const css = $('#ssc-bg-css').text();
+             const errorMessage = __('Échec de l\'enregistrement du fond animé.', 'supersede-css-jlg');
              $applyButton.prop('disabled', true).attr('aria-disabled', 'true');
              $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
              }).done(() => window.sscToast('Fond animé appliqué !'))
              .fail((jqXHR, textStatus, errorThrown) => {
-                 console.error('Échec de l\'enregistrement du fond animé.', errorThrown || jqXHR);
+                 console.error(errorMessage, { jqXHR, textStatus, errorThrown });
                  window.sscToast(
-                     __('Échec de l\'enregistrement du fond animé.', 'supersede-css-jlg'),
+                     errorMessage,
                      { politeness: 'assertive' }
                  );
              })


### PR DESCRIPTION
## Summary
- localize the Tron grid save-css failure message and log detailed error data
- reuse the localized failure message for animated backgrounds while keeping the apply button state consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7ee10884832ea16e18e892147287