### PR TITLE
Restore WordPress notices on Supersede CSS admin pages

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -121,43 +121,63 @@
 /*
  * App-Like Experience for Supersede CSS Pages
  */
-body[class*="page_supersede-css-jlg"] {
-    overflow: hidden;
-}
-body[class*="page_supersede-css-jlg"] #wpadminbar,
-body[class*="page_supersede-css-jlg"] #adminmenumain,
-body[class*="page_supersede-css-jlg"] #wpfooter,
-body[class*="page_supersede-css-jlg"] .update-nag,
-body[class*="page_supersede-css-jlg"] .notice,
-body[class*="page_supersede-css-jlg"] #screen-meta-links,
-body[class*="page_supersede-css-jlg"] #screen-meta {
-    display: none !important;
-}
-body[class*="page_supersede-css-jlg"] #wpcontent {
-    margin-left: 0;
-    padding-left: 0;
-}
-body[class*="page_supersede-css-jlg"] #wpbody {
-    height: 100vh;
-    overflow-y: auto;
-    overflow-x: hidden;
-    background-color: var(--ssc-bg);
-}
-body[class*="page_supersede-css-jlg"] #wpbody-content {
-    padding-bottom: 0;
-    height: 100%;
-}
-body[class*="page_supersede-css-jlg"] .ssc-shell {
-    height: 100%;
+body[class*="page_supersede-css-jlg"] .ssc-viewport {
+    position: relative;
     display: flex;
     flex-direction: column;
+    gap: 0;
+    min-height: 100vh;
+    overflow: hidden;
+    background-color: var(--ssc-bg);
+    border-radius: 16px;
+    margin-top: 16px;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+    width: 100%;
+}
+body[class*="page_supersede-css-jlg"] .ssc-shell {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    padding: 0 16px 16px;
+}
+body[class*="page_supersede-css-jlg"] .ssc-shell > .ssc-topbar {
+    margin: 16px -16px 0;
+    border-radius: 16px 16px 0 0;
 }
 body[class*="page_supersede-css-jlg"] .ssc-layout {
-    flex-grow: 1;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
+    margin-top: 16px;
+    align-items: stretch;
 }
-body[class*="page_supersede-css-jlg"] .ssc-main-content {
+body[class*="page_supersede-css-jlg"] .ssc-layout .ssc-main-content {
     overflow-y: auto;
-    height: calc(100vh - 70px);
     padding-right: 16px;
+    min-height: 0;
+}
+@media (max-width: 960px) {
+    body[class*="page_supersede-css-jlg"] .ssc-viewport {
+        margin-top: 12px;
+        border-radius: 12px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+    }
+
+    body[class*="page_supersede-css-jlg"] .ssc-shell {
+        padding: 0 12px 12px;
+    }
+
+    body[class*="page_supersede-css-jlg"] .ssc-shell > .ssc-topbar {
+        margin: 12px -12px 0;
+    }
+
+    body[class*="page_supersede-css-jlg"] .ssc-layout {
+        margin-top: 12px;
+    }
+
+    body[class*="page_supersede-css-jlg"] .ssc-layout .ssc-main-content {
+        padding-right: 0;
+    }
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -311,8 +311,9 @@ class Layout {
             ],
         ];
         ?>
-        <div class="ssc-shell">
-            <header class="ssc-topbar">
+        <div class="ssc-viewport">
+            <div class="ssc-shell">
+                <header class="ssc-topbar">
                 <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="Retourner sur le tableau de bord WordPress">
                     <span class="dashicons dashicons-arrow-left-alt" aria-hidden="true"></span>
                     <span class="ssc-topbar-label">WP Admin</span>
@@ -358,6 +359,7 @@ class Layout {
                 <main class="ssc-main-content">
                     <?php echo wp_kses( $page_content, self::allowed_tags() ); ?>
                 </main>
+            </div>
             </div>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- remove the global body overrides that hid core WordPress UI from Supersede CSS screens
- introduce an internal `.ssc-viewport` wrapper to control the full-height layout without suppressing notices
- tune shell spacing so admin notices remain readable while preserving the app-like presentation on desktop and mobile

## Testing
- php -l supersede-css-jlg-enhanced/src/Admin/Layout.php

------
https://chatgpt.com/codex/tasks/task_e_68dd916de8d8832eb81956df92de47d0