### PR TITLE
Add ARIA metadata to admin sidebar navigation

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -31,7 +31,8 @@ body.ssc-no-scroll{overflow:hidden}
 }
 
 .ssc-sidebar a{display:flex;gap:8px;align-items:center;padding:8px;border-radius:8px;color:var(--ssc-text);text-decoration:none;border:1px solid transparent}
-.ssc-sidebar a.active{background:rgba(165, 180, 252, 0.1);border-color:var(--ssc-border); color: var(--ssc-accent); font-weight: 600;}
+.ssc-sidebar a.active,
+.ssc-sidebar a[aria-current="page"]{background:rgba(165, 180, 252, 0.1);border-color:var(--ssc-border); color: var(--ssc-accent); font-weight: 600;}
 .ssc-layout{display:grid;grid-template-columns:220px minmax(0,1fr);gap:16px;align-items:flex-start;position:relative}
 .ssc-main-content { padding-left: 16px; }
 

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -342,12 +342,17 @@ class Layout {
             <div class="ssc-shell-overlay" hidden></div>
             <div class="ssc-layout">
                 <aside>
-                    <nav class="ssc-sidebar" id="ssc-sidebar">
+                    <nav class="ssc-sidebar" id="ssc-sidebar" aria-label="<?php echo esc_attr__('Navigation Supersede CSS', 'supersede-css-jlg'); ?>">
                     <?php foreach ($menu_items as $group_label => $items): ?>
                         <div class="ssc-sidebar-group">
                             <h4 class="ssc-sidebar-heading"><?php echo esc_html($group_label); ?></h4>
                             <?php foreach ($items as $slug => $label): ?>
-                                <a href="<?php echo esc_url(admin_url('admin.php?page=' . $slug)); ?>" class="<?php echo esc_attr( $current_page_slug === $slug ? 'active' : '' ); ?>">
+                                <?php $is_active = ($current_page_slug === $slug); ?>
+                                <a
+                                    href="<?php echo esc_url(admin_url('admin.php?page=' . $slug)); ?>"
+                                    class="<?php echo esc_attr( $is_active ? 'active' : '' ); ?>"
+                                    <?php if ($is_active): ?>aria-current="page"<?php endif; ?>
+                                >
                                     <?php echo esc_html($label); ?>
                                 </a>
                             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- add an explicit aria-label to the Supersede CSS admin sidebar navigation
- set aria-current="page" on the active sidebar entry while keeping the existing CSS class
- extend the highlight styling to cover links targeted via the aria-current attribute

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd916ff728832ea150e5c6125dce5d