### PR TITLE
Prevent double submissions when applying animations and effects

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/animation-studio.js
+++ b/supersede-css-jlg-enhanced/assets/js/animation-studio.js
@@ -80,14 +80,34 @@
             }).catch(() => {});
         });
 
-        $('#ssc-anim-apply').on('click', () => {
+        const $applyButton = $('#ssc-anim-apply');
+        $applyButton.on('click', () => {
             const css = $('#ssc-anim-css').text();
+            const originalText = $applyButton.text();
+
+            $applyButton
+                .prop('disabled', true)
+                .attr('aria-disabled', 'true')
+                .text('Application…');
+
             $.ajax({
                 url: SSC.rest.root + 'save-css',
                 method: 'POST',
                 data: { css, append: true, _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-            }).done(() => window.sscToast('Animation appliquée !'));
+            })
+                .done(() => window.sscToast('Animation appliquée !'))
+                .fail((jqXHR, textStatus, errorThrown) => {
+                    const errorMessage = 'Impossible d\'appliquer l\'animation.';
+                    console.error(errorMessage, { jqXHR, textStatus, errorThrown });
+                    window.sscToast(errorMessage, { politeness: 'assertive' });
+                })
+                .always(() => {
+                    $applyButton
+                        .prop('disabled', false)
+                        .removeAttr('aria-disabled')
+                        .text(originalText);
+                });
         });
 
         generateAnimationCSS();

--- a/supersede-css-jlg-enhanced/assets/js/visual-effects.js
+++ b/supersede-css-jlg-enhanced/assets/js/visual-effects.js
@@ -166,10 +166,15 @@
         // Attacher les écouteurs d'événements
         $('#ssc-bg-type, #starColor, #starCount, #gradientSpeed').on('input change', generateBackgroundCSS);
         const $applyButton = $('#ssc-bg-apply');
+        const applyingLabel = __('Application…', 'supersede-css-jlg');
         $applyButton.on('click', () => {
              const css = $('#ssc-bg-css').text();
              const errorMessage = __('Échec de l\'enregistrement du fond animé.', 'supersede-css-jlg');
-             $applyButton.prop('disabled', true).attr('aria-disabled', 'true');
+             const originalText = $applyButton.text();
+             $applyButton
+                 .prop('disabled', true)
+                 .attr('aria-disabled', 'true')
+                 .text(applyingLabel);
              $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
              }).done(() => window.sscToast('Fond animé appliqué !'))
              .fail((jqXHR, textStatus, errorThrown) => {
@@ -180,7 +185,10 @@
                  );
              })
              .always(() => {
-                 $applyButton.prop('disabled', false).removeAttr('aria-disabled');
+                 $applyButton
+                     .prop('disabled', false)
+                     .removeAttr('aria-disabled')
+                     .text(originalText);
              });
         });
         
@@ -300,10 +308,31 @@
         }
 
         $('#ssc-ecg-preset, #ssc-ecg-color, #ssc-ecg-top, #ssc-ecg-logo-size, #ssc-ecg-z-index').on('input', generateECGCSS);
-        $('#ssc-ecg-apply').on('click', () => {
+        const $ecgApplyButton = $('#ssc-ecg-apply');
+        const ecgApplyingLabel = __('Application…', 'supersede-css-jlg');
+        $ecgApplyButton.on('click', () => {
              const css = $('#ssc-ecg-css').text();
+             const errorMessage = __('Impossible d\'appliquer l\'effet ECG.', 'supersede-css-jlg');
+             const originalText = $ecgApplyButton.text();
+
+             $ecgApplyButton
+                 .prop('disabled', true)
+                 .attr('aria-disabled', 'true')
+                 .text(ecgApplyingLabel);
+
              $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-             }).done(() => window.sscToast('Effet ECG appliqué !'));
+             })
+             .done(() => window.sscToast('Effet ECG appliqué !'))
+             .fail((jqXHR, textStatus, errorThrown) => {
+                 console.error(errorMessage, { jqXHR, textStatus, errorThrown });
+                 window.sscToast(errorMessage, { politeness: 'assertive' });
+             })
+             .always(() => {
+                 $ecgApplyButton
+                     .prop('disabled', false)
+                     .removeAttr('aria-disabled')
+                     .text(originalText);
+             });
         });
         generateECGCSS();
     }


### PR DESCRIPTION
## Summary
- disable animation studio apply button while requests are in-flight and surface errors
- extend visual effects apply flows to show a loading label, prevent double clicks, and restore the UI state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda1c60190832e8d1a1dcc2249ba20