### PR TITLE
Handle token conflicts when restoring CSS revisions

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Routes.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Routes.php
@@ -317,6 +317,21 @@ final class Routes {
             ], 404);
         }
 
+        if (is_array($restored) && isset($restored['error'])) {
+            $duplicates = $restored['duplicates'] ?? [];
+
+            return new \WP_Error(
+                'ssc_tokens_conflict',
+                __('Some tokens use the same name. Please choose unique names before restoring.', 'supersede-css-jlg'),
+                [
+                    'status' => 409,
+                    'duplicates' => $duplicates,
+                    'revision' => $restored['revision']['id'] ?? $revisionId,
+                ]
+            );
+        }
+
+        /** @var array{id: string, option: string, css: string, timestamp: string, author: string, segments?: array<string, string>} $restored */
         $context = [];
         if (($restored['option'] ?? '') === 'ssc_active_css' && isset($restored['segments']) && is_array($restored['segments'])) {
             $context['segments'] = $restored['segments'];

--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -267,9 +267,9 @@ final class TokenRegistry
 
     /**
      * @param string $css
-     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     * @return array{tokens: array<int, array{name: string, value: string, type: string, description: string, group: string}>, duplicates: array<int, array{canonical: string, variants: array<int, string>, conflicts: array<int, array{name: string, value: string}>}>}
      */
-    public static function convertCssToRegistry(string $css): array
+    public static function convertCssToRegistryDetailed(string $css): array
     {
         $tokensByName = [];
         $length = strlen($css);
@@ -449,6 +449,17 @@ final class TokenRegistry
         }
 
         $result = self::normalizeRegistry(array_values($tokensByName));
+
+        return $result;
+    }
+
+    /**
+     * @param string $css
+     * @return array<int, array{name: string, value: string, type: string, description: string, group: string}>
+     */
+    public static function convertCssToRegistry(string $css): array
+    {
+        $result = self::convertCssToRegistryDetailed($css);
 
         return $result['tokens'];
     }


### PR DESCRIPTION
## Summary
- surface duplicate token conflicts when restoring CSS revisions and propagate the error back to callers
- return WP_Error responses with duplicate details from the restore route and display the message in the debug UI
- expose TokenRegistry::convertCssToRegistryDetailed to share duplicate data and extend the CssRevisions test coverage for conflict scenarios

## Testing
- php tests/Support/CssRevisionsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dda1cb20e8832ebb7c15498d4fac49