### PR TITLE
Add UI Playwright coverage for visual effects and import/export

### DIFF
--- a/supersede-css-jlg-enhanced/package.json
+++ b/supersede-css-jlg-enhanced/package.json
@@ -7,7 +7,11 @@
     "env:stop": "wp-env stop",
     "env:destroy": "wp-env destroy --yes",
     "test:ui": "playwright test",
-    "test:ui:shell": "playwright test tests/ui/shell-accessibility.spec.js"
+    "test:ui:accessibility": "playwright test --project=chromium-accessibility",
+    "test:ui:tokens": "playwright test --project=chromium-tokens",
+    "test:ui:visual-effects": "playwright test --project=chromium-visual-effects",
+    "test:ui:import-export": "playwright test --project=chromium-import-export",
+    "test:ui:css-utilities": "playwright test --project=chromium-css-utilities"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.1",

--- a/supersede-css-jlg-enhanced/playwright.config.js
+++ b/supersede-css-jlg-enhanced/playwright.config.js
@@ -17,9 +17,32 @@ module.exports = defineConfig({
     locale: 'en-US',
     baseURL,
   },
+  // Suite names double as CLI filters. Run a specific suite with:
+  // `npx playwright test --project=<suite-name>`
   projects: [
     {
-      name: 'chromium',
+      name: 'chromium-accessibility',
+      testMatch: /.*accessibility\.spec\.js$/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-tokens',
+      testMatch: /tokens\.spec\.js$/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-visual-effects',
+      testMatch: /visual-effects\.spec\.js$/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-import-export',
+      testMatch: /import-export\.spec\.js$/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-css-utilities',
+      testMatch: /css-utilities\.spec\.js$/,
       use: { ...devices['Desktop Chrome'] },
     },
   ],

--- a/supersede-css-jlg-enhanced/tests/ui/css-utilities.spec.js
+++ b/supersede-css-jlg-enhanced/tests/ui/css-utilities.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+const { authenticate, getAdminUrl } = require('./utils/auth');
+
+const ADMIN_PATH = '/wp-admin/admin.php?page=supersede-css-jlg-utilities';
+
+async function waitForUtilitiesReady(page) {
+  await page.waitForSelector('.ssc-editor-tabs');
+  await page.waitForFunction(() => {
+    return (
+      typeof window !== 'undefined' &&
+      window.SSC &&
+      window.SSC.rest &&
+      typeof window.SSC.rest.root === 'string' &&
+      typeof window.SSC.rest.nonce === 'string'
+    );
+  });
+}
+
+test.describe('CSS utilities workspace', () => {
+  test('supports CodeMirror editing and responsive preview controls', async ({ page }, testInfo) => {
+    const adminUrl = getAdminUrl(testInfo, ADMIN_PATH);
+    await authenticate(page, adminUrl);
+    await waitForUtilitiesReady(page);
+
+    const desktopEditor = page.locator('#ssc-editor-panel-desktop .CodeMirror');
+    await desktopEditor.click({ position: { x: 10, y: 10 } });
+    await page.keyboard.type('.hero { color: red; }');
+    await page.waitForFunction(() => {
+      const editor = document.querySelector('#ssc-editor-panel-desktop .CodeMirror');
+      return editor && editor.CodeMirror && editor.CodeMirror.getValue().includes('color: red');
+    });
+
+    const tabletTab = page.locator('#ssc-editor-tab-tablet');
+    await tabletTab.click();
+    await expect(tabletTab).toHaveAttribute('aria-selected', 'true');
+    const tabletEditor = page.locator('#ssc-editor-panel-tablet .CodeMirror');
+    await tabletEditor.click({ position: { x: 10, y: 10 } });
+    await page.keyboard.type('.hero { font-size: 24px; }');
+    await page.waitForFunction(() => {
+      const editor = document.querySelector('#ssc-editor-panel-tablet .CodeMirror');
+      return editor && editor.CodeMirror && editor.CodeMirror.getValue().includes('font-size: 24px');
+    });
+
+    const previewFrame = page.locator('#ssc-preview-frame');
+    await page.waitForFunction(() => {
+      const frame = document.getElementById('ssc-preview-frame');
+      return frame && typeof frame.getAttribute('src') === 'string' && frame.getAttribute('src') !== '';
+    });
+    const previewUrl = await previewFrame.getAttribute('src');
+    await expect(page.locator('#ssc-preview-url')).toHaveValue(previewUrl || '');
+
+    await page.locator('.ssc-responsive-toggles button[data-vp="mobile"]').click();
+    await expect(previewFrame).toHaveCSS('max-width', '375px');
+
+    await page.setViewportSize({ width: 900, height: 720 });
+    await page.waitForFunction(() => {
+      const toggle = document.getElementById('ssc-preview-toggle');
+      return toggle && toggle.getAttribute('aria-expanded') === 'false';
+    });
+
+    const previewColumn = page.locator('#ssc-preview-column');
+    await expect(previewColumn).toHaveClass(/is-hidden/);
+    await page.locator('#ssc-preview-toggle').click();
+    await expect(page.locator('#ssc-preview-toggle')).toHaveAttribute('aria-expanded', 'true');
+    await expect(previewColumn).not.toHaveClass(/is-hidden/);
+  });
+});

--- a/supersede-css-jlg-enhanced/tests/ui/fixtures/sample-config.json
+++ b/supersede-css-jlg-enhanced/tests/ui/fixtures/sample-config.json
@@ -1,0 +1,5 @@
+{
+  "tokens": {
+    "--primary-color": "#123456"
+  }
+}

--- a/supersede-css-jlg-enhanced/tests/ui/import-export.spec.js
+++ b/supersede-css-jlg-enhanced/tests/ui/import-export.spec.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+const { authenticate, getAdminUrl } = require('./utils/auth');
+
+const ADMIN_PATH = '/wp-admin/admin.php?page=supersede-css-jlg-import';
+const SAMPLE_CONFIG_PATH = path.resolve(__dirname, 'fixtures/sample-config.json');
+
+async function waitForImportExportReady(page) {
+  await page.waitForSelector('#ssc-export-config');
+  await page.waitForFunction(() => {
+    return (
+      typeof window !== 'undefined' &&
+      window.SSC &&
+      window.SSC.rest &&
+      typeof window.SSC.rest.root === 'string' &&
+      typeof window.SSC.rest.nonce === 'string'
+    );
+  });
+}
+
+test.describe('Import / Export workflow', () => {
+  test('exports a config, reimports it and surfaces notifications', async ({ page }, testInfo) => {
+    const adminUrl = getAdminUrl(testInfo, ADMIN_PATH);
+    await authenticate(page, adminUrl);
+    await waitForImportExportReady(page);
+
+    await page.route('**/wp-json/ssc/v1/export-config**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tokens: {}, utilities: {} }),
+      });
+    });
+
+    const downloadPromise = page.waitForEvent('download');
+    const exportToast = page.waitForSelector('.ssc-toast', { state: 'attached' });
+    await page.locator('#ssc-export-config').click();
+    await downloadPromise;
+    await exportToast;
+    await expect(page.locator('.ssc-toast').last()).toHaveText('Configuration exportée !');
+    await page.unroute('**/wp-json/ssc/v1/export-config**');
+    await page.waitForSelector('.ssc-toast', { state: 'detached' });
+
+    await page.route('**/wp-json/ssc/v1/import-config', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ applied: ['tokens', 'utilities'], skipped: [] }),
+      });
+    });
+
+    await page.setInputFiles('#ssc-import-file', SAMPLE_CONFIG_PATH);
+    const importToast = page.waitForSelector('.ssc-toast', { state: 'attached' });
+    await page.locator('#ssc-import-btn').click();
+    await importToast;
+
+    await expect(page.locator('#ssc-import-msg')).toHaveText('Import terminé : 2 option(s) appliquée(s).');
+    await expect(page.locator('.ssc-toast').last()).toHaveText('Configuration importée !');
+    await page.unroute('**/wp-json/ssc/v1/import-config');
+  });
+});

--- a/supersede-css-jlg-enhanced/tests/ui/tokens.spec.js
+++ b/supersede-css-jlg-enhanced/tests/ui/tokens.spec.js
@@ -1,29 +1,10 @@
 const { test, expect } = require('@playwright/test');
+const { authenticate, getAdminUrl } = require('./utils/auth');
 
 const ADMIN_PATH = '/wp-admin/admin.php?page=supersede-css-jlg-tokens';
-const DEFAULT_USERNAME = process.env.WP_USERNAME || 'admin';
-const DEFAULT_PASSWORD = process.env.WP_PASSWORD || 'password';
 
 function getAdminTokensUrl(testInfo) {
-  const baseURL = testInfo.project.use.baseURL || 'http://localhost:8889';
-  return new URL(ADMIN_PATH, baseURL).toString();
-}
-
-async function authenticate(page, adminUrl, credentials) {
-  const loginUrl = `/wp-login.php?redirect_to=${encodeURIComponent(adminUrl)}`;
-  await page.goto(loginUrl, { waitUntil: 'domcontentloaded' });
-
-  const usernameInput = page.locator('#user_login');
-  if (await usernameInput.isVisible()) {
-    await usernameInput.fill(credentials.username);
-    await page.locator('#user_pass').fill(credentials.password);
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'networkidle' }),
-      page.locator('#wp-submit').click(),
-    ]);
-  }
-
-  await page.goto(adminUrl, { waitUntil: 'networkidle' });
+  return getAdminUrl(testInfo, ADMIN_PATH);
 }
 
 async function waitForPluginReady(page) {
@@ -61,10 +42,7 @@ test.describe('Token manager admin UI', () => {
   test('adds, edits and deletes tokens with live CSS preview updates', async ({ page }, testInfo) => {
     const adminTokensUrl = getAdminTokensUrl(testInfo);
 
-    await authenticate(page, adminTokensUrl, {
-      username: DEFAULT_USERNAME,
-      password: DEFAULT_PASSWORD,
-    });
+    await authenticate(page, adminTokensUrl);
 
     let { restRoot, nonce } = await waitForPluginReady(page);
     let tokensEndpoint = new URL('tokens', restRoot).toString();
@@ -165,10 +143,7 @@ test.describe('Token manager admin UI', () => {
   test('shows localized toast message when copying tokens', async ({ page }, testInfo) => {
     const adminTokensUrl = getAdminTokensUrl(testInfo);
 
-    await authenticate(page, adminTokensUrl, {
-      username: DEFAULT_USERNAME,
-      password: DEFAULT_PASSWORD,
-    });
+    await authenticate(page, adminTokensUrl);
 
     await waitForPluginReady(page);
 
@@ -187,10 +162,7 @@ test.describe('Token manager admin UI', () => {
   test('prevents saving tokens with duplicate names', async ({ page }, testInfo) => {
     const adminTokensUrl = getAdminTokensUrl(testInfo);
 
-    await authenticate(page, adminTokensUrl, {
-      username: DEFAULT_USERNAME,
-      password: DEFAULT_PASSWORD,
-    });
+    await authenticate(page, adminTokensUrl);
 
     let { restRoot, nonce } = await waitForPluginReady(page);
     let tokensEndpoint = new URL('tokens', restRoot).toString();
@@ -315,10 +287,7 @@ test.describe('Token manager admin UI', () => {
   test('API surfaces duplicate conflicts when normalization detects collisions', async ({ page }, testInfo) => {
     const adminTokensUrl = getAdminTokensUrl(testInfo);
 
-    await authenticate(page, adminTokensUrl, {
-      username: DEFAULT_USERNAME,
-      password: DEFAULT_PASSWORD,
-    });
+    await authenticate(page, adminTokensUrl);
 
     let { restRoot, nonce } = await waitForPluginReady(page);
     let tokensEndpoint = new URL('tokens', restRoot).toString();

--- a/supersede-css-jlg-enhanced/tests/ui/utils/auth.js
+++ b/supersede-css-jlg-enhanced/tests/ui/utils/auth.js
@@ -1,0 +1,37 @@
+const DEFAULT_USERNAME = process.env.WP_USERNAME || 'admin';
+const DEFAULT_PASSWORD = process.env.WP_PASSWORD || 'password';
+
+function getAdminUrl(testInfo, adminPath) {
+  const baseURL = testInfo.project.use.baseURL || 'http://localhost:8889';
+  return new URL(adminPath, baseURL).toString();
+}
+
+function getDefaultCredentials() {
+  return {
+    username: DEFAULT_USERNAME,
+    password: DEFAULT_PASSWORD,
+  };
+}
+
+async function authenticate(page, adminUrl, credentials = getDefaultCredentials()) {
+  const loginUrl = `/wp-login.php?redirect_to=${encodeURIComponent(adminUrl)}`;
+  await page.goto(loginUrl, { waitUntil: 'domcontentloaded' });
+
+  const usernameInput = page.locator('#user_login');
+  if (await usernameInput.isVisible()) {
+    await usernameInput.fill(credentials.username);
+    await page.locator('#user_pass').fill(credentials.password);
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle' }),
+      page.locator('#wp-submit').click(),
+    ]);
+  }
+
+  await page.goto(adminUrl, { waitUntil: 'networkidle' });
+}
+
+module.exports = {
+  authenticate,
+  getAdminUrl,
+  getDefaultCredentials,
+};

--- a/supersede-css-jlg-enhanced/tests/ui/visual-effects.spec.js
+++ b/supersede-css-jlg-enhanced/tests/ui/visual-effects.spec.js
@@ -1,0 +1,73 @@
+const { test, expect } = require('@playwright/test');
+const { authenticate, getAdminUrl } = require('./utils/auth');
+
+const ADMIN_PATH = '/wp-admin/admin.php?page=supersede-css-jlg-effects';
+
+async function waitForVisualEffectsReady(page) {
+  await page.waitForSelector('.ssc-ve-tabs');
+  await page.waitForFunction(() => {
+    return (
+      typeof window !== 'undefined' &&
+      window.SSC &&
+      window.SSC.rest &&
+      typeof window.SSC.rest.root === 'string' &&
+      typeof window.SSC.rest.nonce === 'string'
+    );
+  });
+}
+
+test.describe('Visual effects studio', () => {
+  test('supports tab navigation, live previews and ECG preset application', async ({ page }, testInfo) => {
+    const adminUrl = getAdminUrl(testInfo, ADMIN_PATH);
+    await authenticate(page, adminUrl);
+    await waitForVisualEffectsReady(page);
+
+    const backgroundsTab = page.locator('#ssc-ve-tab-backgrounds');
+    const backgroundsPanel = page.locator('#ssc-ve-panel-backgrounds');
+    await expect(backgroundsTab).toHaveAttribute('aria-selected', 'true');
+    await expect(backgroundsPanel).toHaveClass(/active/);
+
+    const crtTab = page.locator('#ssc-ve-tab-crt');
+    await crtTab.click();
+    const crtPanel = page.locator('#ssc-ve-panel-crt');
+    await expect(crtTab).toHaveAttribute('aria-selected', 'true');
+    await expect(crtPanel).toBeVisible();
+    await page.waitForFunction(() => {
+      const canvas = document.getElementById('ssc-crt-canvas');
+      if (!canvas) {
+        return false;
+      }
+      const rect = canvas.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    });
+
+    const ecgTab = page.locator('#ssc-ve-tab-ecg');
+    await ecgTab.click();
+    const ecgPanel = page.locator('#ssc-ve-panel-ecg');
+    await expect(ecgTab).toHaveAttribute('aria-selected', 'true');
+    await expect(ecgPanel).toBeVisible();
+
+    const presetSelect = page.locator('#ssc-ecg-preset');
+    await presetSelect.selectOption('fast');
+    const cssOutput = page.locator('#ssc-ecg-css');
+    await expect(cssOutput).toContainText('animation:ssc-ecg-line 1.2s');
+
+    const previewPath = page.locator('#ssc-ecg-preview-path');
+    await expect(previewPath).toHaveAttribute('d', /L60,30/);
+
+    await page.route('**/wp-json/ssc/v1/save-css', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    const applyButton = page.locator('#ssc-ecg-apply');
+    const toastPromise = page.waitForSelector('.ssc-toast', { state: 'attached' });
+    await applyButton.click();
+    await toastPromise;
+    await expect(page.locator('.ssc-toast').last()).toHaveText('Effet ECG appliqué !');
+    await page.unroute('**/wp-json/ssc/v1/save-css');
+  });
+});


### PR DESCRIPTION
## Summary
- factor a shared authentication helper for UI specs
- add Playwright scenarios for visual effects, import/export, and CSS utilities admin pages
- extend Playwright projects and npm scripts so CI can target the new suites

## Testing
- npx playwright test --list

------
https://chatgpt.com/codex/tasks/task_e_68de3e64a784832ebbfefaca3d41ee00