### PR TITLE
Support advanced token types in registry and builder

### DIFF
--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) {
 }
 /** @var string $tokens_css */
 /** @var array<int, array{name: string, value: string, type: string, description: string, group: string}> $tokens_registry */
-/** @var array<string, array{label: string, input: string}> $token_types */
+/** @var array<string, array{label: string, input: string, placeholder?: string, rows?: int}> $token_types */
 
 if (function_exists('wp_localize_script')) {
     wp_localize_script('ssc-tokens', 'SSC_TOKENS_DATA', [


### PR DESCRIPTION
## Summary
- extend the token registry with spacing, font, shadow, and gradient definitions including input metadata
- normalize stored tokens based on the configured input type and keep multiline values intact when persisting CSS
- update the admin tokens view and builder script to localize the new metadata, render appropriate controls, and format generated CSS

## Testing
- php -l src/Support/TokenRegistry.php

------
https://chatgpt.com/codex/tasks/task_e_68de667354a0832e98347438d4c75114