### PR TITLE
Add advanced token types and contextual builder help

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/tokens.css
+++ b/supersede-css-jlg-enhanced/assets/css/tokens.css
@@ -35,6 +35,12 @@
     font-size: 13px;
 }
 
+.ssc-token-field__help {
+    font-size: 12px;
+    color: #475569;
+    line-height: 1.4;
+}
+
 .ssc-token-field-input {
     width: 100%;
 }

--- a/supersede-css-jlg-enhanced/assets/js/tokens.js
+++ b/supersede-css-jlg-enhanced/assets/js/tokens.js
@@ -3,13 +3,67 @@
     const restNonce = window.SSC && window.SSC.rest && window.SSC.rest.nonce ? window.SSC.rest.nonce : '';
     const localized = window.SSC_TOKENS_DATA || {};
     const defaultTokenTypes = {
-        color: { label: 'Couleur', input: 'color' },
-        text: { label: 'Texte', input: 'text', placeholder: 'Ex. 16px ou clamp(1rem, 2vw, 2rem)' },
-        number: { label: 'Nombre', input: 'number' },
-        spacing: { label: 'Espacement', input: 'text', placeholder: 'Ex. 16px 24px' },
-        font: { label: 'Typographie', input: 'text', placeholder: 'Ex. "Inter", sans-serif' },
-        shadow: { label: 'Ombre', input: 'textarea', placeholder: '0 2px 4px rgba(15, 23, 42, 0.25)', rows: 3 },
-        gradient: { label: 'Dégradé', input: 'textarea', placeholder: 'linear-gradient(135deg, #4f46e5, #7c3aed)', rows: 3 },
+        color: {
+            label: 'Couleur',
+            input: 'color',
+            help: 'Utilisez un code hexadécimal (ex. #4f46e5) ou une variable existante.',
+        },
+        text: {
+            label: 'Texte',
+            input: 'text',
+            placeholder: 'Ex. 16px ou clamp(1rem, 2vw, 2rem)',
+            help: 'Idéal pour les valeurs libres (unités CSS, fonctions, etc.).',
+        },
+        number: {
+            label: 'Nombre',
+            input: 'number',
+            help: 'Pour les valeurs strictement numériques (ex. 1.25).',
+        },
+        spacing: {
+            label: 'Espacement',
+            input: 'text',
+            placeholder: 'Ex. 16px 24px',
+            help: 'Convient aux marges/paddings ou aux espacements multiples.',
+        },
+        font: {
+            label: 'Typographie',
+            input: 'text',
+            placeholder: 'Ex. "Inter", sans-serif',
+            help: 'Définissez la pile de polices complète avec les guillemets requis.',
+        },
+        shadow: {
+            label: 'Ombre',
+            input: 'textarea',
+            placeholder: '0 2px 4px rgba(15, 23, 42, 0.25)',
+            rows: 3,
+            help: 'Accepte plusieurs valeurs box-shadow, une par ligne si nécessaire.',
+        },
+        gradient: {
+            label: 'Dégradé',
+            input: 'textarea',
+            placeholder: 'linear-gradient(135deg, #4f46e5, #7c3aed)',
+            rows: 3,
+            help: 'Pour les dégradés CSS complexes (linear-, radial-…).',
+        },
+        border: {
+            label: 'Bordure',
+            input: 'text',
+            placeholder: 'Ex. 1px solid currentColor',
+            help: 'Combinez largeur, style et couleur de bordure.',
+        },
+        dimension: {
+            label: 'Dimensions',
+            input: 'text',
+            placeholder: 'Ex. 320px ou clamp(280px, 50vw, 480px)',
+            help: 'Largeurs/hauteurs ou tailles maximales avec clamp/min/max.',
+        },
+        transition: {
+            label: 'Transition',
+            input: 'textarea',
+            placeholder: 'all 0.3s ease-in-out\ncolor 150ms ease',
+            rows: 2,
+            help: 'Définissez des transitions multi-propriétés, une par ligne.',
+        },
     };
 
     let tokens = Array.isArray(localized.tokens) ? localized.tokens.slice() : [];
@@ -387,10 +441,16 @@
         });
     }
 
-    function createField(label, input) {
+    function createField(label, input, helpText) {
         const field = $('<label>', { class: 'ssc-token-field' });
         field.append($('<span>', { class: 'ssc-token-field__label', text: label }));
         field.append(input);
+        if (helpText) {
+            field.append($('<span>', {
+                class: 'ssc-token-field__help',
+                text: helpText,
+            }));
+        }
         return field;
     }
 
@@ -452,6 +512,11 @@
                 valueInput.attr('placeholder', typeMeta.placeholder);
             }
         }
+        if (typeMeta.help && valueInput && valueInput.attr) {
+            const helpId = 'token-help-' + resolvedType + '-' + index;
+            valueInput.attr('aria-describedby', helpId);
+            valueInput.data('help-id', helpId);
+        }
 
         const typeSelect = $('<select>', { class: 'token-field-input token-type' });
         typeOptions.forEach(function(optionKey) {
@@ -484,11 +549,25 @@
             text: i18n.deleteLabel || 'Supprimer',
         });
 
-        row.append(createField(i18n.nameLabel || 'Nom', nameInput));
-        row.append(createField(i18n.valueLabel || 'Valeur', valueInput));
-        row.append(createField(i18n.typeLabel || 'Type', typeSelect));
-        row.append(createField(i18n.groupLabel || 'Groupe', groupInput));
-        row.append(createField(i18n.descriptionLabel || 'Description', descriptionInput));
+        const nameField = createField(i18n.nameLabel || 'Nom', nameInput);
+        const valueField = createField(i18n.valueLabel || 'Valeur', valueInput, typeMeta.help);
+        const typeField = createField(i18n.typeLabel || 'Type', typeSelect);
+        const groupField = createField(i18n.groupLabel || 'Groupe', groupInput);
+        const descriptionField = createField(i18n.descriptionLabel || 'Description', descriptionInput);
+
+        if (typeMeta.help && valueField) {
+            const helpElement = valueField.find('.ssc-token-field__help');
+            const helpId = valueInput.data('help-id');
+            if (helpElement.length && helpId) {
+                helpElement.attr('id', helpId);
+            }
+        }
+
+        row.append(nameField);
+        row.append(valueField);
+        row.append(typeField);
+        row.append(groupField);
+        row.append(descriptionField);
         row.append(deleteButton);
 
         return row;

--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -14,12 +14,17 @@ final class TokenRegistry
      * Supported token types exposed to the UI.
      *
      * The `input` key controls the form control rendered for the token value.
-     * Accepted values are `color`, `number`, `text` and `textarea`.
+     * Accepted values are:
+     *  - `color`: renders an `<input type="color">` (falls back to text if value is not a valid hex).
+     *  - `number`: renders an `<input type="number">`.
+     *  - `text`: renders an `<input type="text">`.
+     *  - `textarea`: renders a `<textarea>` and keeps multi-line values intact.
      *
      * @var array<string, array{
      *     label: string,
      *     input: 'color'|'number'|'text'|'textarea',
      *     placeholder?: string,
+     *     help?: string,
      *     rows?: positive-int
      * }>
      */
@@ -27,37 +32,63 @@ final class TokenRegistry
         'color' => [
             'label' => 'Couleur',
             'input' => 'color',
+            'help' => 'Utilisez un code hexadécimal (ex. #4f46e5) ou une variable existante.',
         ],
         'text' => [
             'label' => 'Texte',
             'input' => 'text',
             'placeholder' => 'Ex. 16px ou clamp(1rem, 2vw, 2rem)',
+            'help' => 'Idéal pour les valeurs libres (unités CSS, fonctions, etc.).',
         ],
         'number' => [
             'label' => 'Nombre',
             'input' => 'number',
+            'help' => 'Pour les valeurs strictement numériques (ex. 1.25).',
         ],
         'spacing' => [
             'label' => 'Espacement',
             'input' => 'text',
             'placeholder' => 'Ex. 16px 24px',
+            'help' => 'Convient aux marges/paddings ou aux espacements multiples.',
         ],
         'font' => [
             'label' => 'Typographie',
             'input' => 'text',
             'placeholder' => 'Ex. "Inter", sans-serif',
+            'help' => 'Définissez la pile de polices complète avec les guillemets requis.',
         ],
         'shadow' => [
             'label' => 'Ombre',
             'input' => 'textarea',
             'placeholder' => "0 2px 4px rgba(15, 23, 42, 0.25)",
             'rows' => 3,
+            'help' => 'Accepte plusieurs valeurs box-shadow, une par ligne si nécessaire.',
         ],
         'gradient' => [
             'label' => 'Dégradé',
             'input' => 'textarea',
             'placeholder' => 'linear-gradient(135deg, #4f46e5, #7c3aed)',
             'rows' => 3,
+            'help' => 'Pour les dégradés CSS complexes (linear-, radial-…).',
+        ],
+        'border' => [
+            'label' => 'Bordure',
+            'input' => 'text',
+            'placeholder' => 'Ex. 1px solid currentColor',
+            'help' => 'Combinez largeur, style et couleur de bordure.',
+        ],
+        'dimension' => [
+            'label' => 'Dimensions',
+            'input' => 'text',
+            'placeholder' => 'Ex. 320px ou clamp(280px, 50vw, 480px)',
+            'help' => 'Largeurs/hauteurs ou tailles maximales avec clamp/min/max.',
+        ],
+        'transition' => [
+            'label' => 'Transition',
+            'input' => 'textarea',
+            'placeholder' => "all 0.3s ease-in-out\ncolor 150ms ease", // multi-ligne possible
+            'rows' => 2,
+            'help' => 'Définissez des transitions multi-propriétés, une par ligne.',
         ],
     ];
 
@@ -167,6 +198,9 @@ final class TokenRegistry
             $types[$key]['label'] = __($type['label'], 'supersede-css-jlg');
             if (isset($type['placeholder'])) {
                 $types[$key]['placeholder'] = __($type['placeholder'], 'supersede-css-jlg');
+            }
+            if (isset($type['help'])) {
+                $types[$key]['help'] = __($type['help'], 'supersede-css-jlg');
             }
         }
 

--- a/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php
@@ -271,6 +271,18 @@ if (!isset($supportedTypes['color']['label']) || $supportedTypes['color']['label
     exit(1);
 }
 
+foreach (['spacing', 'font', 'shadow', 'gradient', 'border', 'dimension', 'transition'] as $expectedType) {
+    if (!isset($supportedTypes[$expectedType])) {
+        fwrite(STDERR, sprintf('getSupportedTypes should expose the "%s" type.', $expectedType) . PHP_EOL);
+        exit(1);
+    }
+}
+
+if (!isset($supportedTypes['shadow']['help']) || strpos($supportedTypes['shadow']['help'], 'box-shadow') === false) {
+    fwrite(STDERR, 'getSupportedTypes should provide contextual help for textarea-capable types.' . PHP_EOL);
+    exit(1);
+}
+
 if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_store['ssc_tokens_registry'])) {
     fwrite(STDERR, 'saveRegistry should persist the registry with the underscored token.' . PHP_EOL);
     exit(1);
@@ -351,5 +363,33 @@ if (!isset($ssc_options_store['ssc_tokens_registry']) || !is_array($ssc_options_
 
 if (!isset($ssc_options_store['ssc_tokens_css']) || strpos($ssc_options_store['ssc_tokens_css'], '--my-token:value') === false) {
     fwrite(STDERR, 'Persisted CSS should retain tokens declared after annotated comments.' . PHP_EOL);
+    exit(1);
+}
+
+$multilineTokens = [
+    [
+        'name' => '--shadow-card',
+        'value' => "0 2px 6px rgba(15, 23, 42, 0.12)\r\n0 12px 24px rgba(15, 23, 42, 0.16)",
+        'type' => 'shadow',
+        'description' => 'Shadow token with multiple lines.',
+        'group' => 'Surfaces',
+    ],
+];
+
+$multilineResult = TokenRegistry::normalizeRegistry($multilineTokens);
+$normalizedMultiline = $multilineResult['tokens'];
+
+if ($multilineResult['duplicates'] !== []) {
+    fwrite(STDERR, 'normalizeRegistry should not report duplicates for multi-line tokens.' . PHP_EOL);
+    exit(1);
+}
+
+if ($normalizedMultiline === [] || $normalizedMultiline[0]['type'] !== 'shadow') {
+    fwrite(STDERR, 'normalizeRegistry should keep the declared token type for textarea tokens.' . PHP_EOL);
+    exit(1);
+}
+
+if ($normalizedMultiline[0]['value'] !== "0 2px 6px rgba(15, 23, 42, 0.12)\n0 12px 24px rgba(15, 23, 42, 0.16)") {
+    fwrite(STDERR, 'normalizeRegistry should preserve multi-line textarea values.' . PHP_EOL);
     exit(1);
 }

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -4,12 +4,38 @@ if (!defined('ABSPATH')) {
 }
 /** @var string $tokens_css */
 /** @var array<int, array{name: string, value: string, type: string, description: string, group: string}> $tokens_registry */
-/** @var array<string, array{label: string, input: string, placeholder?: string, rows?: int}> $token_types */
+/** @var array<string, array{label: string, input: string, placeholder?: string, help?: string, rows?: int}> $token_types */
 
 if (function_exists('wp_localize_script')) {
+    $localized_types = [];
+    foreach ($token_types as $type_key => $meta) {
+        if (!is_string($type_key) || $type_key === '') {
+            continue;
+        }
+
+        $normalized_meta = [
+            'label' => $meta['label'],
+            'input' => $meta['input'],
+        ];
+
+        if (isset($meta['placeholder'])) {
+            $normalized_meta['placeholder'] = $meta['placeholder'];
+        }
+
+        if (isset($meta['help'])) {
+            $normalized_meta['help'] = $meta['help'];
+        }
+
+        if (isset($meta['rows'])) {
+            $normalized_meta['rows'] = (int) $meta['rows'];
+        }
+
+        $localized_types[$type_key] = $normalized_meta;
+    }
+
     wp_localize_script('ssc-tokens', 'SSC_TOKENS_DATA', [
         'tokens' => $tokens_registry,
-        'types' => $token_types,
+        'types' => $localized_types,
         'css' => $tokens_css,
         'i18n' => [
             'addToken' => __('Ajouter un token', 'supersede-css-jlg'),


### PR DESCRIPTION
## Summary
- extend the token registry with additional design token presets and contextual help strings
- expose the enriched token metadata to the admin view and modernize the builder UI with dynamic inputs and helper text
- verify multi-line normalization and new token types through updated support tests

## Testing
- php tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68de9f6cc774832e954add74ef7c73d3