### PR TITLE
Make mobile layout preview responsive

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/page-layout-builder.css
+++ b/supersede-css-jlg-enhanced/assets/css/page-layout-builder.css
@@ -17,7 +17,8 @@
 }
 
 .ssc-layout-preview-mobile {
-    width: 375px;
+    width: min(375px, 100%);
+    max-width: 100%;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- make the mobile layout preview container width fluid to avoid horizontal overflow
- verified that the preview wrapper already relies on auto width so no additional PHP changes were required

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68debe35f728832eaaa264759026b72e