### PR TITLE
Allow visual effect tabs to wrap

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/visual-effects.css
+++ b/supersede-css-jlg-enhanced/assets/css/visual-effects.css
@@ -1,7 +1,9 @@
 .ssc-ve-tabs {
     display: flex;
+    flex-wrap: wrap;
     border-bottom: 1px solid var(--ssc-border);
     margin-bottom: 16px;
+    gap: 8px 12px;
 }
 
 .ssc-ve-tab {
@@ -13,6 +15,14 @@
     color: inherit;
     font: inherit;
     margin: 0;
+}
+
+@media (max-width: 600px) {
+    .ssc-ve-tab {
+        flex: 1 1 100%;
+        font-size: 0.95rem;
+        text-align: left;
+    }
 }
 
 .ssc-ve-tab.active {


### PR DESCRIPTION
## Summary
- allow the visual effects tab strip to wrap while keeping consistent spacing
- ensure individual tabs expand to full width and adjust typography on small screens to avoid overlap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec52e57bc832e86c68eabe5458ae3