### PR TITLE
Improve clip-path preview responsiveness

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/clip-path-editor.css
+++ b/supersede-css-jlg-enhanced/assets/css/clip-path-editor.css
@@ -4,12 +4,13 @@
     padding: 24px;
     background: var(--ssc-bg);
     border-radius: 8px;
+    width: 100%;
 }
 
 #ssc-clip-preview {
     background-size: cover;
     background-position: center;
-    height: 300px;
-    width: 300px;
+    width: min(100%, 300px);
+    aspect-ratio: 1 / 1;
     transition: all 0.3s ease;
 }

--- a/supersede-css-jlg-enhanced/assets/js/clip-path-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/clip-path-editor.js
@@ -8,11 +8,16 @@
     }
 
     function updatePreviewSize() {
-        const size = $('#ssc-clip-preview-size').val();
-        $('#ssc-clip-preview').css({
-            'width': size + 'px',
-            'height': size + 'px'
+        const size = parseInt($('#ssc-clip-preview-size').val(), 10);
+        const $preview = $('#ssc-clip-preview');
+        const wrapperWidth = $preview.parent().innerWidth() || size;
+        const appliedSize = Math.min(size, wrapperWidth);
+
+        $preview.css({
+            'width': appliedSize + 'px',
+            'height': ''
         });
+
         $('#ssc-clip-size-val').text(size + 'px');
     }
 
@@ -21,6 +26,7 @@
 
         $('#ssc-clip-preset').on('change', applyClipPath);
         $('#ssc-clip-preview-size').on('input', updatePreviewSize);
+        $(window).on('resize.sscClipPreview', updatePreviewSize);
 
         $('#ssc-clip-copy').on('click', () => {
             window.sscCopyToClipboard($('#ssc-clip-css').text(), {


### PR DESCRIPTION
## Summary
- make the clip-path preview responsive by constraining it to its container
- update the preview sizing script to clamp the applied width and react to resize events

## Testing
- viewport check at 320px width to confirm there is no horizontal overflow

------
https://chatgpt.com/codex/tasks/task_e_68dec52db7b4832e92fffc3439c635e0