### PR TITLE
Improve accessibility of utilities preview controls

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -10,6 +10,18 @@
 .ssc-app h4, .ssc-wrap h4 {
     color: var(--ssc-text);
 }
+.screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
 .ssc-app p, .ssc-wrap p,
 .ssc-app .description, .ssc-wrap .description,
 .ssc-app label, .ssc-wrap label {

--- a/supersede-css-jlg-enhanced/views/utilities.php
+++ b/supersede-css-jlg-enhanced/views/utilities.php
@@ -75,7 +75,10 @@ if (!defined('ABSPATH')) {
                         id="ssc-element-picker-toggle"
                         title="<?php echo esc_attr__('Cibler un élément', 'supersede-css-jlg'); ?>"
                         aria-label="<?php echo esc_attr__('Cibler un élément', 'supersede-css-jlg'); ?>"
-                    >🎯</button>
+                    >
+                        🎯
+                        <span class="screen-reader-text"><?php esc_html_e('Cibler un élément', 'supersede-css-jlg'); ?></span>
+                    </button>
                 </div>
                 <div class="ssc-responsive-toggles">
                     <button
@@ -83,19 +86,28 @@ if (!defined('ABSPATH')) {
                         data-vp="desktop"
                         title="<?php echo esc_attr__('Desktop', 'supersede-css-jlg'); ?>"
                         aria-label="<?php echo esc_attr__('Desktop', 'supersede-css-jlg'); ?>"
-                    >🖥️</button>
+                    >
+                        🖥️
+                        <span class="screen-reader-text"><?php esc_html_e('Basculer vers la vue ordinateur', 'supersede-css-jlg'); ?></span>
+                    </button>
                     <button
                         class="button"
                         data-vp="tablet"
                         title="<?php echo esc_attr__('Tablet', 'supersede-css-jlg'); ?>"
                         aria-label="<?php echo esc_attr__('Tablet', 'supersede-css-jlg'); ?>"
-                    >📲</button>
+                    >
+                        📲
+                        <span class="screen-reader-text"><?php esc_html_e('Basculer vers la vue tablette', 'supersede-css-jlg'); ?></span>
+                    </button>
                     <button
                         class="button"
                         data-vp="mobile"
                         title="<?php echo esc_attr__('Mobile', 'supersede-css-jlg'); ?>"
                         aria-label="<?php echo esc_attr__('Mobile', 'supersede-css-jlg'); ?>"
-                    >📱</button>
+                    >
+                        📱
+                        <span class="screen-reader-text"><?php esc_html_e('Basculer vers la vue mobile', 'supersede-css-jlg'); ?></span>
+                    </button>
                 </div>
             </div>
             <div class="ssc-preview-frame-container">


### PR DESCRIPTION
## Summary
- add hidden screen reader text to the element picker toggle and responsive viewport buttons so the controls announce their purpose
- add a reusable `.screen-reader-text` helper style to keep the hidden labels from affecting layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfccb20ed4832eb0d959dda1d641cc