### PR TITLE
Set aria-pressed state on theme toggle

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/ux.js
+++ b/supersede-css-jlg-enhanced/assets/js/ux.js
@@ -147,9 +147,17 @@
         if (localStorage.getItem('ssc-theme') === 'dark') {
             body.addClass('ssc-dark');
         }
+
+        const updateThemeToggleAria = () => {
+            themeToggle.attr('aria-pressed', body.hasClass('ssc-dark') ? 'true' : 'false');
+        };
+
+        updateThemeToggleAria();
+
         themeToggle.on('click', function() {
             body.toggleClass('ssc-dark');
             localStorage.setItem('ssc-theme', body.hasClass('ssc-dark') ? 'dark' : 'light');
+            updateThemeToggleAria();
         });
 
         // --- Mobile Sidebar Toggle ---

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -319,7 +319,7 @@ class Layout {
                     <span class="ssc-topbar-label">WP Admin</span>
                 </a>
                 <span class="ssc-title">Supersede CSS</span><span class="ssc-spacer"></span>
-                <button type="button" class="button" id="ssc-theme" aria-label="Basculer le thème clair ou sombre">
+                <button type="button" class="button" id="ssc-theme" aria-label="Basculer le thème clair ou sombre" aria-pressed="false">
                     <span aria-hidden="true">🌓</span>
                     <span class="ssc-topbar-label">Thème</span>
                 </button>


### PR DESCRIPTION
## Summary
- initialize the admin theme toggle button with an `aria-pressed` attribute
- keep the toggle's pressed state synchronized with the current theme preference in JavaScript

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfccb293d8832ea40bb85b015e5a18