### PR TITLE
Add collapsible help panel to token editor

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/tokens.css
+++ b/supersede-css-jlg-enhanced/assets/css/tokens.css
@@ -68,3 +68,73 @@
 .token-field-input--duplicate:focus {
     box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.35), 0 0 0 3px rgba(220, 38, 38, 0.2);
 }
+
+.ssc-token-layout {
+    margin-top: 16px;
+    align-items: flex-start;
+}
+
+.ssc-token-help {
+    position: relative;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.ssc-token-help__summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.ssc-token-help__summary::-webkit-details-marker {
+    display: none;
+}
+
+.ssc-token-help__summary::marker {
+    display: none;
+}
+
+.ssc-token-help__title {
+    font-size: 16px;
+    line-height: 1.4;
+}
+
+.ssc-token-help__state {
+    font-size: 13px;
+    color: #2563eb;
+}
+
+.ssc-token-help__content {
+    margin-top: 12px;
+    animation: ssc-token-help-fade 0.24s ease;
+}
+
+.ssc-token-help:not([open]) {
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.15);
+}
+
+.ssc-token-layout--help-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.ssc-token-layout--help-collapsed .ssc-token-help,
+.ssc-token-layout--help-collapsed .ssc-token-editor {
+    grid-column: 1 / -1;
+}
+
+.ssc-token-layout--help-collapsed .ssc-token-help {
+    margin-bottom: 12px;
+}
+
+@keyframes ssc-token-help-fade {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/supersede-css-jlg-enhanced/assets/js/tokens.js
+++ b/supersede-css-jlg-enhanced/assets/js/tokens.js
@@ -747,6 +747,65 @@
         refreshCssFromTokens();
         fetchTokensFromServer();
 
+        const helpToggleElement = document.getElementById('ssc-token-help-toggle');
+        const layoutContainer = document.querySelector('.ssc-token-layout');
+        const helpStateLabel = helpToggleElement ? helpToggleElement.querySelector('.ssc-token-help__state') : null;
+        const helpStorageKey = 'sscTokenHelpCollapsed';
+
+        if (helpToggleElement) {
+            const expandedText = helpStateLabel
+                ? (helpStateLabel.getAttribute('data-expanded') || helpStateLabel.textContent || '')
+                : '';
+            const collapsedText = helpStateLabel
+                ? (helpStateLabel.getAttribute('data-collapsed') || helpStateLabel.textContent || expandedText)
+                : expandedText;
+
+            const applyHelpState = function(collapsed) {
+                if (layoutContainer) {
+                    layoutContainer.classList.toggle('ssc-token-layout--help-collapsed', collapsed);
+                }
+                if (helpStateLabel) {
+                    helpStateLabel.textContent = collapsed ? collapsedText : expandedText;
+                }
+            };
+
+            const persistHelpState = function(collapsed) {
+                try {
+                    window.localStorage.setItem(helpStorageKey, collapsed ? '1' : '0');
+                } catch (error) {
+                    // Ignore persistence errors (private mode, disabled storage, etc.)
+                }
+            };
+
+            let isRestoringHelpState = true;
+
+            helpToggleElement.addEventListener('toggle', function() {
+                const collapsed = !helpToggleElement.open;
+                applyHelpState(collapsed);
+                if (!isRestoringHelpState) {
+                    persistHelpState(collapsed);
+                }
+            });
+
+            let storedValue = null;
+            try {
+                storedValue = window.localStorage.getItem(helpStorageKey);
+            } catch (error) {
+                storedValue = null;
+            }
+
+            if (storedValue === '1') {
+                helpToggleElement.removeAttribute('open');
+            } else if (storedValue === '0') {
+                helpToggleElement.setAttribute('open', 'open');
+            } else {
+                applyHelpState(!helpToggleElement.open);
+            }
+
+            isRestoringHelpState = false;
+            applyHelpState(!helpToggleElement.open);
+        }
+
         $('#ssc-token-add').on('click', function(event) {
             event.preventDefault();
             addToken();

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -56,27 +56,35 @@ if (function_exists('wp_localize_script')) {
     ]);
 }
 ?>
+<?php
+$help_toggle_expanded = __('Masquer l\'aide', 'supersede-css-jlg');
+$help_toggle_collapsed = __('Afficher l\'aide', 'supersede-css-jlg');
+?>
 <div class="ssc-app ssc-fullwidth">
     <div class="ssc-panel">
         <h2><?php esc_html_e('🚀 Bienvenue dans le Gestionnaire de Tokens', 'supersede-css-jlg'); ?></h2>
         <p><?php esc_html_e('Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, espacements…) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.', 'supersede-css-jlg'); ?></p>
     </div>
 
-    <div class="ssc-two" style="margin-top:16px; align-items: flex-start;">
-        <div class="ssc-pane">
-            <h3><?php esc_html_e('👨‍🏫 Qu\'est-ce qu\'un Token (ou Variable CSS) ?', 'supersede-css-jlg'); ?></h3>
-            <p><?php printf(wp_kses_post(__('Imaginez que vous décidiez d\'utiliser une couleur bleue spécifique (%s) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C\'est long et risqué !', 'supersede-css-jlg')), '<code>#3498db</code>'); ?></p>
-            <p><?php printf(wp_kses_post(__('Un %1$s est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme %2$s. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.', 'supersede-css-jlg')), '<strong>token</strong>', '<code>--couleur-principale</code>'); ?></p>
-            <p><?php echo wp_kses_post(__('<strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s\'applique partout !</strong>', 'supersede-css-jlg')); ?></p>
-            <hr>
-            <h4><?php esc_html_e('Exemple Concret', 'supersede-css-jlg'); ?></h4>
-            <p><?php printf(wp_kses_post(__('<strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l\'élément %s (la racine de votre page).', 'supersede-css-jlg')), '<code>:root</code>'); ?></p>
-            <pre class="ssc-code">:root {
+    <div class="ssc-two ssc-token-layout">
+        <details id="ssc-token-help-toggle" class="ssc-pane ssc-token-help" open>
+            <summary class="ssc-token-help__summary">
+                <span class="ssc-token-help__title" role="heading" aria-level="3"><?php esc_html_e('👨‍🏫 Qu\'est-ce qu\'un Token (ou Variable CSS) ?', 'supersede-css-jlg'); ?></span>
+                <span class="ssc-token-help__state" data-expanded="<?php echo esc_attr($help_toggle_expanded); ?>" data-collapsed="<?php echo esc_attr($help_toggle_collapsed); ?>"><?php echo esc_html($help_toggle_expanded); ?></span>
+            </summary>
+            <div class="ssc-token-help__content">
+                <p><?php printf(wp_kses_post(__('Imaginez que vous décidiez d\'utiliser une couleur bleue spécifique (%s) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C\'est long et risqué !', 'supersede-css-jlg')), '<code>#3498db</code>'); ?></p>
+                <p><?php printf(wp_kses_post(__('Un %1$s est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme %2$s. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.', 'supersede-css-jlg')), '<strong>token</strong>', '<code>--couleur-principale</code>'); ?></p>
+                <p><?php echo wp_kses_post(__('<strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s\'applique partout !</strong>', 'supersede-css-jlg')); ?></p>
+                <hr>
+                <h4><?php esc_html_e('Exemple Concret', 'supersede-css-jlg'); ?></h4>
+                <p><?php printf(wp_kses_post(__('<strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l\'élément %s (la racine de votre page).', 'supersede-css-jlg')), '<code>:root</code>'); ?></p>
+                <pre class="ssc-code">:root {
    --couleur-principale: #3498db;
    --radius-arrondi: 8px;
 }</pre>
-            <p><?php printf(wp_kses_post(__('<strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction %s pour appeler la valeur du token.', 'supersede-css-jlg')), '<code>var()</code>'); ?></p>
-            <pre class="ssc-code">.mon-bouton {
+                <p><?php printf(wp_kses_post(__('<strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction %s pour appeler la valeur du token.', 'supersede-css-jlg')), '<code>var()</code>'); ?></p>
+                <pre class="ssc-code">.mon-bouton {
    background-color: var(--couleur-principale);
    border-radius: var(--radius-arrondi);
    color: white;
@@ -85,8 +93,9 @@ if (function_exists('wp_localize_script')) {
 .mon-titre {
    color: var(--couleur-principale);
 }</pre>
-        </div>
-        <div class="ssc-pane">
+            </div>
+        </details>
+        <div class="ssc-pane ssc-token-editor">
             <h3><?php esc_html_e('🎨 Éditeur Visuel de Tokens', 'supersede-css-jlg'); ?></h3>
             <p><?php esc_html_e('Gérez vos tokens sous forme de fiches structurées : nom technique, valeur, type de champ, description et groupe d\'appartenance. Chaque catégorie est listée séparément pour garder une vision claire de votre système de design.', 'supersede-css-jlg'); ?></p>
 


### PR DESCRIPTION
## Summary
- wrap the pedagogical token pane in a `<details>` element with a toggle label
- wire up JavaScript to persist the help visibility preference and widen the editor when collapsed
- add CSS for the collapsed layout, summary styling, and subtle reveal animation

## Testing
- php -l views/tokens.php

------
https://chatgpt.com/codex/tasks/task_e_68dff8090758832eb7d522cc39ff9e16