### PR TITLE
Improve Tron grid slider accessibility

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/tron-grid.js
+++ b/supersede-css-jlg-enhanced/assets/js/tron-grid.js
@@ -33,9 +33,13 @@
         const thickness = $('#ssc-tron-thickness').val();
         const speed = $('#ssc-tron-speed').val();
 
-        $('#ssc-tron-size-val').text(size + 'px');
-        $('#ssc-tron-thickness-val').text(thickness + 'px');
-        $('#ssc-tron-speed-val').text(speed + 's');
+        const sizeValue = $('#ssc-tron-size-val');
+        const thicknessValue = $('#ssc-tron-thickness-val');
+        const speedValue = $('#ssc-tron-speed-val');
+
+        sizeValue.text(size + 'px').attr('aria-live', 'polite');
+        thicknessValue.text(thickness + 'px').attr('aria-live', 'polite');
+        speedValue.text(speed + 's').attr('aria-live', 'polite');
 
         const keyframes = `@keyframes ssc-tron-scroll {
   from { background-position: 0 0; }

--- a/supersede-css-jlg-enhanced/views/tron-grid.php
+++ b/supersede-css-jlg-enhanced/views/tron-grid.php
@@ -21,15 +21,15 @@ if (!defined('ABSPATH')) {
             </div>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Taille de la grille (pixels)', 'supersede-css-jlg'); ?></strong></label>
-            <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5">
+            <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5" aria-describedby="ssc-tron-size-val">
             <span id="ssc-tron-size-val"><?php echo esc_html__('50px', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Épaisseur des lignes (pixels)', 'supersede-css-jlg'); ?></strong></label>
-            <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1">
+            <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1" aria-describedby="ssc-tron-thickness-val">
             <span id="ssc-tron-thickness-val"><?php echo esc_html__('1px', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Vitesse de l\'animation (secondes)', 'supersede-css-jlg'); ?></strong></label>
-            <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1">
+            <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1" aria-describedby="ssc-tron-speed-val">
             <span id="ssc-tron-speed-val"><?php echo esc_html__('10s', 'supersede-css-jlg'); ?></span>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">


### PR DESCRIPTION
## Summary
- link Tron grid sliders to their live value readouts via aria-describedby
- ensure Tron grid value readouts are announced with polite aria-live updates when values change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e034ad12f8832ebf4eeaf4905d3492