### PR TITLE
Add Supersede token preview block

### DIFF
--- a/supersede-css-jlg-enhanced/blocks/token-preview/block.json
+++ b/supersede-css-jlg-enhanced/blocks/token-preview/block.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": 3,
+  "name": "supersede/token-preview",
+  "version": "1.0.0",
+  "title": "Supersede Token Preview",
+  "category": "widgets",
+  "icon": "admin-customizer",
+  "description": "Affiche un aperçu des tokens Supersede CSS disponibles directement dans l’éditeur.",
+  "textdomain": "supersede-css-jlg",
+  "supports": {
+    "html": false,
+    "reusable": false
+  },
+  "editorScript": "file:./index.js"
+}

--- a/supersede-css-jlg-enhanced/blocks/token-preview/index.asset.php
+++ b/supersede-css-jlg-enhanced/blocks/token-preview/index.asset.php
@@ -1,0 +1,11 @@
+<?php return [
+    'dependencies' => [
+        'wp-api-fetch',
+        'wp-blocks',
+        'wp-components',
+        'wp-data',
+        'wp-element',
+        'wp-i18n'
+    ],
+    'version' => '1.0.0'
+];

--- a/supersede-css-jlg-enhanced/blocks/token-preview/index.js
+++ b/supersede-css-jlg-enhanced/blocks/token-preview/index.js
@@ -1,0 +1,233 @@
+( function ( wp ) {
+    const { registerBlockType } = wp.blocks;
+    const { Fragment, createElement: el, useMemo } = wp.element;
+    const { __ } = wp.i18n;
+    const { Notice, Spinner } = wp.components;
+    const { registerStore, useSelect } = wp.data;
+    const apiFetch = wp.apiFetch;
+
+    const STORE_NAME = 'supersede/token-preview';
+    const BASE_CSS = '.ssc-token-preview{display:grid;gap:1.25rem;margin:0;padding:0;}' +
+        '.ssc-token-preview__items{display:grid;gap:0.75rem;}' +
+        '.ssc-token-preview__item{display:grid;gap:0.35rem;padding:1rem;border-radius:0.85rem;border:1px solid rgba(15,23,42,0.12);background:rgba(255,255,255,0.9);box-shadow:0 1px 2px rgba(15,23,42,0.08);}' +
+        '.ssc-token-preview__item code{font-size:0.85rem;font-weight:600;}' +
+        '.ssc-token-preview__value{font-size:0.95rem;}' +
+        '.ssc-token-preview__description{font-size:0.8rem;color:rgba(15,23,42,0.7);}' +
+        '.ssc-token-preview__group{font-size:0.75rem;text-transform:uppercase;letter-spacing:0.04em;color:rgba(15,23,42,0.6);}' +
+        '.ssc-token-preview__swatch{display:block;height:40px;border-radius:0.75rem;border:1px solid rgba(15,23,42,0.15);}' +
+        '.ssc-token-preview__empty{margin:0;font-style:italic;color:rgba(15,23,42,0.75);}';
+
+    const DEFAULT_STATE = {
+        tokens: [],
+        css: '',
+        isLoading: false,
+        error: null,
+    };
+
+    const ACTION_TYPES = {
+        RECEIVE_TOKENS: 'RECEIVE_TOKENS',
+        SET_IS_LOADING: 'SET_IS_LOADING',
+        SET_ERROR: 'SET_ERROR',
+        FETCH_TOKENS: 'FETCH_TOKENS',
+    };
+
+    const actions = {
+        receiveTokens( tokens, css ) {
+            return {
+                type: ACTION_TYPES.RECEIVE_TOKENS,
+                tokens,
+                css,
+            };
+        },
+        setIsLoading( isLoading ) {
+            return {
+                type: ACTION_TYPES.SET_IS_LOADING,
+                isLoading,
+            };
+        },
+        setError( error ) {
+            return {
+                type: ACTION_TYPES.SET_ERROR,
+                error,
+            };
+        },
+        fetchTokens() {
+            return {
+                type: ACTION_TYPES.FETCH_TOKENS,
+            };
+        },
+    };
+
+    const selectors = {
+        getTokens( state ) {
+            return state.tokens;
+        },
+        getCss( state ) {
+            return state.css;
+        },
+        isLoading( state ) {
+            return state.isLoading;
+        },
+        getError( state ) {
+            return state.error;
+        },
+    };
+
+    const controls = {
+        [ ACTION_TYPES.FETCH_TOKENS ]() {
+            return apiFetch( { path: '/ssc/v1/tokens' } );
+        },
+    };
+
+    const resolvers = {
+        * getTokens() {
+            yield actions.setIsLoading( true );
+            yield actions.setError( null );
+
+            try {
+                const response = yield actions.fetchTokens();
+                const tokens = Array.isArray( response?.tokens ) ? response.tokens : [];
+                const css = typeof response?.css === 'string' ? response.css : '';
+                yield actions.receiveTokens( tokens, css );
+            } catch ( error ) {
+                const message = error?.message || __( 'Impossible de récupérer les tokens Supersede.', 'supersede-css-jlg' );
+                yield actions.setError( message );
+            }
+
+            yield actions.setIsLoading( false );
+        },
+    };
+
+    const reducer = ( state = DEFAULT_STATE, action ) => {
+        switch ( action.type ) {
+            case ACTION_TYPES.RECEIVE_TOKENS:
+                return {
+                    ...state,
+                    tokens: action.tokens,
+                    css: action.css,
+                };
+            case ACTION_TYPES.SET_IS_LOADING:
+                return {
+                    ...state,
+                    isLoading: action.isLoading,
+                };
+            case ACTION_TYPES.SET_ERROR:
+                return {
+                    ...state,
+                    error: action.error,
+                };
+            default:
+                return state;
+        }
+    };
+
+    if ( ! wp.data?.stores || ! Object.prototype.hasOwnProperty.call( wp.data.stores, STORE_NAME ) ) {
+        registerStore( STORE_NAME, {
+            reducer,
+            actions,
+            selectors,
+            controls,
+            resolvers,
+        } );
+    }
+
+    const TokenList = ( { tokens } ) => {
+        if ( ! tokens?.length ) {
+            return el(
+                'p',
+                { className: 'ssc-token-preview__empty' },
+                __( 'Aucun token n\'est défini pour le moment. Ajoutez vos premiers tokens dans Supersede CSS.', 'supersede-css-jlg' )
+            );
+        }
+
+        return el(
+            'div',
+            { className: 'ssc-token-preview__items' },
+            tokens.map( ( token ) => {
+                const children = [
+                    el( 'code', { key: 'name', className: 'ssc-token-preview__name' }, token.name ),
+                    el( 'span', { key: 'value', className: 'ssc-token-preview__value' }, token.value ),
+                ];
+
+                if ( token.type === 'color' ) {
+                    children.unshift(
+                        el( 'span', {
+                            key: 'swatch',
+                            className: 'ssc-token-preview__swatch',
+                            style: { background: token.value },
+                            'aria-hidden': true,
+                        } )
+                    );
+                }
+
+                if ( token.description ) {
+                    children.push(
+                        el( 'span', { key: 'description', className: 'ssc-token-preview__description' }, token.description )
+                    );
+                }
+
+                if ( token.group ) {
+                    children.push(
+                        el( 'span', { key: 'group', className: 'ssc-token-preview__group' }, token.group )
+                    );
+                }
+
+                return el(
+                    'div',
+                    {
+                        key: token.name,
+                        className: 'ssc-token-preview__item',
+                    },
+                    children
+                );
+            } )
+        );
+    };
+
+    registerBlockType( 'supersede/token-preview', {
+        apiVersion: 3,
+        title: __( 'Supersede Token Preview', 'supersede-css-jlg' ),
+        category: 'widgets',
+        icon: 'admin-customizer',
+        description: __( 'Affiche un aperçu des tokens Supersede CSS disponibles directement dans l\'éditeur.', 'supersede-css-jlg' ),
+        edit() {
+            const tokens = useSelect( ( select ) => select( STORE_NAME ).getTokens(), [] );
+            const isLoading = useSelect( ( select ) => select( STORE_NAME ).isLoading(), [] );
+            const error = useSelect( ( select ) => select( STORE_NAME ).getError(), [] );
+            const css = useSelect( ( select ) => select( STORE_NAME ).getCss(), [] );
+
+            const inlineStyles = useMemo( () => {
+                const combinedCss = css ? BASE_CSS + '\n' + css : BASE_CSS;
+
+                return el( 'style', {
+                    key: 'inline-style',
+                    className: 'ssc-token-preview__inline-styles',
+                    dangerouslySetInnerHTML: { __html: combinedCss },
+                } );
+            }, [ css ] );
+
+            let content;
+            if ( isLoading && ! tokens.length ) {
+                content = el( 'div', { className: 'ssc-token-preview__loading' }, el( Spinner, null ) );
+            } else if ( error ) {
+                content = el( Notice, { status: 'error', isDismissible: false }, error );
+            } else {
+                content = el( TokenList, { tokens } );
+            }
+
+            return el(
+                Fragment,
+                null,
+                inlineStyles,
+                el(
+                    'div',
+                    { className: 'ssc-token-preview ssc-token-preview--editor' },
+                    content
+                )
+            );
+        },
+        save() {
+            return null;
+        },
+    } );
+} )( window.wp );

--- a/supersede-css-jlg-enhanced/src/Blocks/TokenPreview.php
+++ b/supersede-css-jlg-enhanced/src/Blocks/TokenPreview.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace SSC\Blocks;
+
+use SSC\Support\CssSanitizer;
+use SSC\Support\TokenRegistry;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class TokenPreview
+{
+    public static function register(): void
+    {
+        register_block_type(
+            SSC_PLUGIN_DIR . 'blocks/token-preview',
+            [
+                'render_callback' => [self::class, 'render'],
+            ]
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $attributes
+     */
+    public static function render(array $attributes = [], string $content = '', $block = null): string
+    {
+        $tokens = TokenRegistry::getRegistry();
+        $cachedCss = ssc_get_cached_css();
+        $baseCss = '.ssc-token-preview{display:grid;gap:1.25rem;margin:0;padding:0;}'
+            .'.ssc-token-preview__items{display:grid;gap:0.75rem;}'
+            .'.ssc-token-preview__item{display:grid;gap:0.35rem;padding:1rem;border-radius:0.85rem;border:1px solid rgba(15,23,42,0.12);background:rgba(255,255,255,0.9);box-shadow:0 1px 2px rgba(15,23,42,0.08);}'
+            .'.ssc-token-preview__item code{font-size:0.85rem;font-weight:600;}'
+            .'.ssc-token-preview__value{font-size:0.95rem;}'
+            .'.ssc-token-preview__description{font-size:0.8rem;color:rgba(15,23,42,0.7);}'
+            .'.ssc-token-preview__group{font-size:0.75rem;text-transform:uppercase;letter-spacing:0.04em;color:rgba(15,23,42,0.6);}'
+            .'.ssc-token-preview__swatch{display:block;height:40px;border-radius:0.75rem;border:1px solid rgba(15,23,42,0.15);}'
+            .'.ssc-token-preview__empty{margin:0;font-style:italic;color:rgba(15,23,42,0.75);}';
+        $css = CssSanitizer::sanitize(trim($baseCss . "\n" . $cachedCss));
+
+        $items = array_map(static function (array $token): string {
+            $name = isset($token['name']) && is_string($token['name']) ? $token['name'] : '';
+            $value = isset($token['value']) && is_string($token['value']) ? $token['value'] : '';
+            $type = isset($token['type']) && is_string($token['type']) ? $token['type'] : '';
+            $description = isset($token['description']) && is_string($token['description']) ? $token['description'] : '';
+            $group = isset($token['group']) && is_string($token['group']) ? $token['group'] : '';
+
+            $parts = [];
+
+            if ($type === 'color' && $value !== '') {
+                $parts[] = sprintf(
+                    '<span class="ssc-token-preview__swatch" aria-hidden="true" style="background:%s"></span>',
+                    esc_attr($value)
+                );
+            }
+
+            $parts[] = sprintf(
+                '<code class="ssc-token-preview__name">%s</code>',
+                esc_html($name)
+            );
+
+            if ($value !== '') {
+                $parts[] = sprintf(
+                    '<span class="ssc-token-preview__value">%s</span>',
+                    esc_html($value)
+                );
+            }
+
+            if ($description !== '') {
+                $parts[] = sprintf(
+                    '<span class="ssc-token-preview__description">%s</span>',
+                    esc_html($description)
+                );
+            }
+
+            if ($group !== '') {
+                $parts[] = sprintf(
+                    '<span class="ssc-token-preview__group">%s</span>',
+                    esc_html($group)
+                );
+            }
+
+            return sprintf(
+                '<div class="ssc-token-preview__item">%s</div>',
+                implode('', $parts)
+            );
+        }, $tokens);
+
+        $body = $items !== []
+            ? implode('', $items)
+            : sprintf(
+                '<p class="ssc-token-preview__empty">%s</p>',
+                esc_html__('Aucun token n\'est défini pour le moment. Ajoutez vos premiers tokens dans Supersede CSS.', 'supersede-css-jlg')
+            );
+
+        $styleTag = $css !== ''
+            ? sprintf('<style class="ssc-token-preview__inline-styles">%s</style>', $css)
+            : '';
+
+        return sprintf(
+            '<div class="ssc-token-preview wp-block-supersede-token-preview">%s<div class="ssc-token-preview__items">%s</div></div>',
+            $styleTag,
+            $body
+        );
+    }
+}

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -10,6 +10,7 @@
  */
 if (!defined('ABSPATH')) { exit; }
 
+use SSC\Blocks\TokenPreview;
 use SSC\Support\CssSanitizer;
 
 define('SSC_VERSION','10.0.5');
@@ -158,4 +159,17 @@ add_action('enqueue_block_editor_assets', 'ssc_enqueue_block_editor_inline_css')
 add_action('plugins_loaded', function() {
     load_plugin_textdomain('supersede-css-jlg', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
+
+if (!function_exists('ssc_register_blocks')) {
+    function ssc_register_blocks(): void
+    {
+        if (!function_exists('register_block_type')) {
+            return;
+        }
+
+        TokenPreview::register();
+    }
+}
+
+add_action('init', 'ssc_register_blocks');
 

--- a/supersede-css-jlg-enhanced/views/dashboard.php
+++ b/supersede-css-jlg-enhanced/views/dashboard.php
@@ -19,6 +19,12 @@ if (!defined('ABSPATH')) {
     </div>
 
     <div class="ssc-panel" style="margin-top: 24px;">
+        <h2><?php esc_html_e('🧩 Nouveau : Bloc « Token Preview »', 'supersede-css-jlg'); ?></h2>
+        <p><?php echo esc_html__('Dans l’éditeur de blocs WordPress, insérez le bloc « Supersede › Token Preview » pour visualiser instantanément les tokens et presets activés (couleurs, espacements, etc.).', 'supersede-css-jlg'); ?></p>
+        <p><?php echo esc_html__('Le bloc injecte automatiquement les mêmes styles que le frontal : plus besoin de copier les classes manuellement, il suffit de placer le bloc à l’endroit voulu pour partager votre bibliothèque de tokens avec l’équipe éditoriale.', 'supersede-css-jlg'); ?></p>
+    </div>
+
+    <div class="ssc-panel" style="margin-top: 24px;">
         <h2><?php esc_html_e('💡 Comprendre le Workflow (Créer et Activer un Style)', 'supersede-css-jlg'); ?></h2>
         <p><?php printf(wp_kses_post(__('Pour utiliser efficacement les modules créatifs comme %1$s ou %2$s, suivez ces 3 étapes logiques :', 'supersede-css-jlg')), '<strong>Avatar Glow</strong>', '<strong>Preset Designer</strong>'); ?></p>
         <ol style="list-style-type: decimal; margin-left: 20px;">


### PR DESCRIPTION
## Summary
- register the Supersede Token Preview block and expose it on init with a dynamic renderer that injects sanitized CSS
- add the block implementation that fetches tokens via wp.data/wp.apiFetch and applies shared styling for editor previews
- surface guidance in the dashboard so editors know to insert the new block instead of copying classes manually

## Testing
- php -l supersede-css-jlg-enhanced/src/Blocks/TokenPreview.php
- php -l supersede-css-jlg-enhanced/supersede-css-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68e034af026c832eb875852ded03de96