### PR TITLE
Add collapsible help panel to token editor

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/tokens.css
+++ b/supersede-css-jlg-enhanced/assets/css/tokens.css
@@ -1,3 +1,56 @@
+.ssc-token-layout {
+    grid-template-columns: minmax(280px, 1fr) minmax(0, 2fr);
+    transition: grid-template-columns 0.3s ease;
+}
+
+.ssc-token-layout.ssc-help-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.ssc-token-layout.ssc-help-collapsed .ssc-token-editor {
+    grid-column: 1 / -1;
+}
+
+#ssc-token-help[hidden] {
+    display: none !important;
+}
+
+.ssc-token-help__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.ssc-token-help__toggle.button {
+    margin-left: auto;
+    height: auto;
+    line-height: 1.4;
+    padding: 4px 12px;
+    white-space: nowrap;
+}
+
+.ssc-token-help__content {
+    margin-top: 12px;
+    display: grid;
+    gap: 12px;
+}
+
+.ssc-token-layout.ssc-help-collapsed .ssc-token-help__content {
+    display: none;
+}
+
+@media (max-width: 782px) {
+    .ssc-token-layout,
+    .ssc-token-layout.ssc-help-collapsed {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .ssc-token-help__toggle.button {
+        margin-left: 0;
+    }
+}
+
 .ssc-token-builder {
     display: flex;
     flex-direction: column;

--- a/supersede-css-jlg-enhanced/assets/js/tokens.js
+++ b/supersede-css-jlg-enhanced/assets/js/tokens.js
@@ -735,6 +735,57 @@
     }
 
     $(document).ready(function() {
+        const tokenLayout = $('.ssc-token-layout');
+        const helpPane = $('#ssc-token-help');
+        const helpToggle = $('#ssc-token-help-toggle');
+        const helpStorageKey = 'ssc-token-help-collapsed';
+
+        if (helpToggle.length && helpPane.length && tokenLayout.length) {
+            const expandedLabel = helpToggle.data('expandedLabel');
+            const collapsedLabel = helpToggle.data('collapsedLabel');
+
+            const setHelpState = function(collapsed, persist) {
+                tokenLayout.toggleClass('ssc-help-collapsed', collapsed);
+                helpPane.attr('aria-hidden', collapsed ? 'true' : 'false');
+
+                if (collapsed) {
+                    helpPane.attr('hidden', 'hidden');
+                } else {
+                    helpPane.removeAttr('hidden');
+                }
+
+                helpToggle.attr('aria-expanded', collapsed ? 'false' : 'true');
+
+                const label = collapsed ? collapsedLabel : expandedLabel;
+                if (typeof label === 'string' && label.length) {
+                    helpToggle.text(label);
+                }
+
+                if (persist) {
+                    try {
+                        window.localStorage.setItem(helpStorageKey, collapsed ? '1' : '0');
+                    } catch (storageError) {
+                        // Ignore storage errors (private mode, quota, etc.).
+                    }
+                }
+            };
+
+            let initialCollapsed = false;
+            try {
+                initialCollapsed = window.localStorage.getItem(helpStorageKey) === '1';
+            } catch (storageError) {
+                initialCollapsed = false;
+            }
+
+            setHelpState(initialCollapsed, false);
+
+            helpToggle.on('click', function(event) {
+                event.preventDefault();
+                const collapsed = !tokenLayout.hasClass('ssc-help-collapsed');
+                setHelpState(collapsed, true);
+            });
+        }
+
         if (!builder.length || !cssTextarea.length) {
             return;
         }

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -62,21 +62,35 @@ if (function_exists('wp_localize_script')) {
         <p><?php esc_html_e('Cet outil vous aide à centraliser les valeurs fondamentales de votre design (couleurs, polices, espacements…) pour les réutiliser facilement et maintenir une cohérence parfaite sur votre site.', 'supersede-css-jlg'); ?></p>
     </div>
 
-    <div class="ssc-two" style="margin-top:16px; align-items: flex-start;">
-        <div class="ssc-pane">
-            <h3><?php esc_html_e('👨‍🏫 Qu\'est-ce qu\'un Token (ou Variable CSS) ?', 'supersede-css-jlg'); ?></h3>
-            <p><?php printf(wp_kses_post(__('Imaginez que vous décidiez d\'utiliser une couleur bleue spécifique (%s) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C\'est long et risqué !', 'supersede-css-jlg')), '<code>#3498db</code>'); ?></p>
-            <p><?php printf(wp_kses_post(__('Un %1$s est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme %2$s. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.', 'supersede-css-jlg')), '<strong>token</strong>', '<code>--couleur-principale</code>'); ?></p>
-            <p><?php echo wp_kses_post(__('<strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s\'applique partout !</strong>', 'supersede-css-jlg')); ?></p>
-            <hr>
-            <h4><?php esc_html_e('Exemple Concret', 'supersede-css-jlg'); ?></h4>
-            <p><?php printf(wp_kses_post(__('<strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l\'élément %s (la racine de votre page).', 'supersede-css-jlg')), '<code>:root</code>'); ?></p>
-            <pre class="ssc-code">:root {
+    <div class="ssc-two ssc-token-layout" style="margin-top:16px; align-items: flex-start;">
+        <div class="ssc-pane ssc-token-help" id="ssc-token-help">
+            <div class="ssc-token-help__header">
+                <h3><?php esc_html_e('👨‍🏫 Qu\'est-ce qu\'un Token (ou Variable CSS) ?', 'supersede-css-jlg'); ?></h3>
+                <button
+                    type="button"
+                    id="ssc-token-help-toggle"
+                    class="button button-secondary ssc-token-help__toggle"
+                    data-expanded-label="<?php esc_attr_e('Masquer l’aide pédagogique', 'supersede-css-jlg'); ?>"
+                    data-collapsed-label="<?php esc_attr_e('Afficher l’aide pédagogique', 'supersede-css-jlg'); ?>"
+                    aria-controls="ssc-token-help"
+                    aria-expanded="true"
+                >
+                    <?php esc_html_e('Masquer l’aide pédagogique', 'supersede-css-jlg'); ?>
+                </button>
+            </div>
+            <div class="ssc-token-help__content">
+                <p><?php printf(wp_kses_post(__('Imaginez que vous décidiez d\'utiliser une couleur bleue spécifique (%s) pour tous vos boutons et titres. Si un jour vous voulez changer ce bleu, vous devriez chercher et remplacer cette valeur partout dans votre code. C\'est long et risqué !', 'supersede-css-jlg')), '<code>#3498db</code>'); ?></p>
+                <p><?php printf(wp_kses_post(__('Un %1$s est un « raccourci ». Vous donnez un nom facile à retenir à votre couleur, comme %2$s. Ensuite, vous utilisez ce nom partout où vous avez besoin de ce bleu.', 'supersede-css-jlg')), '<strong>token</strong>', '<code>--couleur-principale</code>'); ?></p>
+                <p><?php echo wp_kses_post(__('<strong>Le jour où vous voulez changer de couleur, il suffit de modifier la valeur du token en un seul endroit, et la modification s\'applique partout !</strong>', 'supersede-css-jlg')); ?></p>
+                <hr>
+                <h4><?php esc_html_e('Exemple Concret', 'supersede-css-jlg'); ?></h4>
+                <p><?php printf(wp_kses_post(__('<strong>1. Définition du Token :</strong><br>On définit le token une seule fois, généralement sur l\'élément %s (la racine de votre page).', 'supersede-css-jlg')), '<code>:root</code>'); ?></p>
+                <pre class="ssc-code">:root {
    --couleur-principale: #3498db;
    --radius-arrondi: 8px;
 }</pre>
-            <p><?php printf(wp_kses_post(__('<strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction %s pour appeler la valeur du token.', 'supersede-css-jlg')), '<code>var()</code>'); ?></p>
-            <pre class="ssc-code">.mon-bouton {
+                <p><?php printf(wp_kses_post(__('<strong>2. Utilisation des Tokens :</strong><br>Ensuite, on utilise la fonction %s pour appeler la valeur du token.', 'supersede-css-jlg')), '<code>var()</code>'); ?></p>
+                <pre class="ssc-code">.mon-bouton {
    background-color: var(--couleur-principale);
    border-radius: var(--radius-arrondi);
    color: white;
@@ -85,8 +99,9 @@ if (function_exists('wp_localize_script')) {
 .mon-titre {
    color: var(--couleur-principale);
 }</pre>
+            </div>
         </div>
-        <div class="ssc-pane">
+        <div class="ssc-pane ssc-token-editor">
             <h3><?php esc_html_e('🎨 Éditeur Visuel de Tokens', 'supersede-css-jlg'); ?></h3>
             <p><?php esc_html_e('Gérez vos tokens sous forme de fiches structurées : nom technique, valeur, type de champ, description et groupe d\'appartenance. Chaque catégorie est listée séparément pour garder une vision claire de votre système de design.', 'supersede-css-jlg'); ?></p>
 


### PR DESCRIPTION
## Summary
- add a toggle button to collapse or expand the pedagogical help block in the token view
- persist the help panel state with localStorage so the editor remembers user preference
- adjust token editor layout and styles to widen the workspace when the help is hidden

## Testing
- php -l supersede-css-jlg-enhanced/views/tokens.php

------
https://chatgpt.com/codex/tasks/task_e_68e034ace4a8832ea5baac8d097e8e0b