### PR TITLE
Refine token preview block output

### DIFF
--- a/supersede-css-jlg-enhanced/docs/TOKEN-PREVIEW-BLOCK.md
+++ b/supersede-css-jlg-enhanced/docs/TOKEN-PREVIEW-BLOCK.md
@@ -1,0 +1,24 @@
+# Bloc « Supersede Token Preview »
+
+Le bloc *Supersede › Token Preview* permet d'afficher automatiquement la bibliothèque de tokens CSS gérée par Supersede directement depuis l'éditeur WordPress.
+
+## Installation dans une page ou un article
+
+1. Ouvrez l'éditeur de blocs (Gutenberg).
+2. Cliquez sur « Ajouter un bloc » puis cherchez « Supersede ».
+3. Sélectionnez le bloc **Supersede › Token Preview**.
+4. Publiez ou mettez à jour le contenu.
+
+> 💡 Astuce : combinez ce bloc avec un paragraphe explicatif pour guider les rédacteurs sur la manière d'utiliser les tokens.
+
+## Fonctionnement
+
+- Le bloc appelle l'API REST Supersede (`/ssc/v1/tokens`) pour récupérer la liste des tokens et le CSS compilé.
+- Les styles sont injectés via la fonction PHP `ssc_get_cached_css()` afin que le rendu soit identique dans l'éditeur et sur le frontal.
+- Chaque token est présenté avec sa valeur, sa description et, pour les couleurs, un échantillon visuel.
+
+## Pourquoi l'utiliser ?
+
+- Plus besoin de copier/coller des classes : les tokens sont visualisés et documentés directement dans la page.
+- Les équipes éditoriales disposent d'un catalogue à jour, synchronisé avec les presets Supersede.
+- La mise en page reste fidèle au thème grâce au CSS partagé entre l'admin et le site public.

--- a/supersede-css-jlg-enhanced/src/Blocks/TokenPreview.php
+++ b/supersede-css-jlg-enhanced/src/Blocks/TokenPreview.php
@@ -24,7 +24,18 @@ final class TokenPreview
      */
     public static function render(array $attributes = [], string $content = '', $block = null): string
     {
-        $tokens = TokenRegistry::getRegistry();
+        $tokens = array_values(array_filter(
+            TokenRegistry::getRegistry(),
+            static function ($token): bool {
+                if (!is_array($token)) {
+                    return false;
+                }
+
+                $name = $token['name'] ?? '';
+
+                return is_string($name) && $name !== '';
+            }
+        ));
         $cachedCss = ssc_get_cached_css();
         $baseCss = '.ssc-token-preview{display:grid;gap:1.25rem;margin:0;padding:0;}'
             .'.ssc-token-preview__items{display:grid;gap:0.75rem;}'


### PR DESCRIPTION
## Summary
- ignore malformed entries before rendering the Supersede token preview block
- add end-user documentation explaining how to insert and benefit from the token preview block

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e03bb32760832e9194ff1e019ae4a8