### PR TITLE
Improve Tron grid slider accessibility

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/tron-grid.js
+++ b/supersede-css-jlg-enhanced/assets/js/tron-grid.js
@@ -37,9 +37,15 @@
         const thicknessValue = $('#ssc-tron-thickness-val');
         const speedValue = $('#ssc-tron-speed-val');
 
-        sizeValue.text(size + 'px').attr('aria-live', 'polite');
-        thicknessValue.text(thickness + 'px').attr('aria-live', 'polite');
-        speedValue.text(speed + 's').attr('aria-live', 'polite');
+        const updateLiveValue = (element, text) => {
+            element
+                .text(text)
+                .attr('aria-live', 'polite');
+        };
+
+        updateLiveValue(sizeValue, `${size}px`);
+        updateLiveValue(thicknessValue, `${thickness}px`);
+        updateLiveValue(speedValue, `${speed}s`);
 
         const keyframes = `@keyframes ssc-tron-scroll {
   from { background-position: 0 0; }

--- a/supersede-css-jlg-enhanced/views/tron-grid.php
+++ b/supersede-css-jlg-enhanced/views/tron-grid.php
@@ -22,15 +22,15 @@ if (!defined('ABSPATH')) {
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Taille de la grille (pixels)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-size" min="20" max="200" value="50" step="5" aria-describedby="ssc-tron-size-val">
-            <span id="ssc-tron-size-val"><?php echo esc_html__('50px', 'supersede-css-jlg'); ?></span>
+            <span id="ssc-tron-size-val" role="status" aria-live="polite"><?php echo esc_html__('50px', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Épaisseur des lignes (pixels)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-thickness" min="1" max="5" value="1" step="1" aria-describedby="ssc-tron-thickness-val">
-            <span id="ssc-tron-thickness-val"><?php echo esc_html__('1px', 'supersede-css-jlg'); ?></span>
+            <span id="ssc-tron-thickness-val" role="status" aria-live="polite"><?php echo esc_html__('1px', 'supersede-css-jlg'); ?></span>
 
             <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Vitesse de l\'animation (secondes)', 'supersede-css-jlg'); ?></strong></label>
             <input type="range" id="ssc-tron-speed" min="1" max="30" value="10" step="1" aria-describedby="ssc-tron-speed-val">
-            <span id="ssc-tron-speed-val"><?php echo esc_html__('10s', 'supersede-css-jlg'); ?></span>
+            <span id="ssc-tron-speed-val" role="status" aria-live="polite"><?php echo esc_html__('10s', 'supersede-css-jlg'); ?></span>
 
             <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
                 <button id="ssc-tron-apply" class="button button-primary"><?php esc_html_e('Appliquer sur le site', 'supersede-css-jlg'); ?></button>


### PR DESCRIPTION
## Summary
- add live region roles to the Tron grid slider value displays and ensure inputs describe them
- refactor the Tron grid script to reapply the polite aria-live attribute whenever values change so announcements fire consistently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03bb08434832e9ccb4617f3ddc623