### PR TITLE
Normalize tokens during import and add REST test

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/ImportExportControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/ImportExportControllerTest.php
@@ -98,6 +98,62 @@ final class ImportExportControllerTest extends WP_UnitTestCase
         ], $stored);
     }
 
+    public function test_import_config_returns_ok_for_valid_tokens_registry_payload(): void
+    {
+        $payload = [
+            'modules' => ['tokens'],
+            'options' => [
+                'ssc_tokens_registry' => [
+                    [
+                        'name' => 'primary-color',
+                        'value' => ' #0ea5e9 ',
+                        'type' => 'color',
+                        'description' => " Couleur principale ",
+                        'group' => 'Identité ',
+                    ],
+                    [
+                        'name' => 'Heading Font',
+                        'value' => "\n\t'Inter', sans-serif\n",
+                        'type' => 'font',
+                        'description' => "Police titres",
+                        'group' => '',
+                    ],
+                ],
+            ],
+        ];
+
+        $request = new WP_REST_Request('POST', '/ssc/v1/import-config');
+        $request->set_body(wp_json_encode($payload));
+
+        $response = $this->controller->importConfig($request);
+
+        $this->assertSame(200, $response->get_status());
+
+        $data = $response->get_data();
+        $this->assertIsArray($data);
+        $this->assertTrue($data['ok']);
+        $this->assertContains('ssc_tokens_registry', $data['applied']);
+        $this->assertSame([], $data['skipped']);
+
+        $stored = get_option('ssc_tokens_registry');
+        $this->assertSame([
+            [
+                'name' => '--primary-color',
+                'value' => '#0ea5e9',
+                'type' => 'color',
+                'description' => 'Couleur principale',
+                'group' => 'Identité',
+            ],
+            [
+                'name' => '--Heading-Font',
+                'value' => "'Inter', sans-serif",
+                'type' => 'font',
+                'description' => 'Police titres',
+                'group' => 'Général',
+            ],
+        ], $stored);
+    }
+
     public function test_import_config_skips_duplicate_tokens(): void
     {
         $payload = [


### PR DESCRIPTION
## Summary
- add a dedicated token name normalizer and reuse it within the registry workflow
- ensure imported tokens leverage the shared helper so registry data stays consistent
- cover a valid `ssc_tokens_registry` payload with a REST integration test

## Testing
- `composer test` *(fails: WordPress test suite requires a MySQL connection in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ee5e603c832e96b3f7c1933b51c9