### PR TITLE
Enhance debug center filtering, diff, and export tools

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -37,8 +37,13 @@
 }
 
 .ssc-two { display:grid; grid-template-columns: 1fr 1fr; gap:16px; }
-@media (max-width: 782px) { .ssc-two { grid-template-columns: 1fr; } }
+@media (max-width: 782px) {
+    .ssc-two { grid-template-columns: 1fr; }
+    .ssc-filter { flex:1 1 140px; }
+}
 .ssc-pane, .ssc-panel { background:var(--ssc-card); border:1px solid var(--ssc-border); border-radius:12px; padding:16px; }
+.ssc-panel-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:16px; align-items:flex-start; margin-bottom:12px; }
+.ssc-panel-actions { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
 .ssc-actions { display:flex; gap:8px; align-items:center; flex-wrap: wrap; }
 .ssc-code { background:#0f172a; color:#e5e7eb; border-radius:8px; padding:12px; overflow:auto; font-family: monospace; font-size: 13px; line-height: 1.6; }
 .ssc-list { list-style:none; padding:0; margin:0; display:grid; gap:8px;}
@@ -65,6 +70,29 @@
 .ssc-dark #ssc-danger-desc {
     color: #ffffff !important;
 }
+
+
+.ssc-filter-bar { display:flex; gap:12px; flex-wrap:wrap; margin-bottom:16px; padding:8px 12px; border-radius:10px; background:rgba(15,23,42,0.04); border:1px solid var(--ssc-border); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+.ssc-filter-bar.is-active { border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.1); }
+.ssc-filter { min-width:140px; }
+.ssc-filter label { font-weight:600; display:block; margin-bottom:4px; color:var(--ssc-muted); }
+.ssc-filter input,
+.ssc-filter select { width:100%; min-width:140px; }
+
+.ssc-revision-diff { margin-top:24px; border-top:1px solid var(--ssc-border); padding-top:16px; }
+.ssc-revision-diff h3 { margin-top:0; }
+.ssc-diff-controls { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
+.ssc-diff-output { margin-top:16px; padding:16px; border:1px dashed var(--ssc-border); border-radius:12px; min-height:120px; background:rgba(15,23,42,0.02); color:var(--ssc-muted); font-family:monospace; white-space:pre-wrap; overflow:auto; }
+.ssc-diff-output.has-diff { border-style:solid; background:#0f172a; color:#e5e7eb; }
+.ssc-diff-output table.diff { width:100%; font-size:13px; }
+.ssc-diff-output table.diff td { font-family:monospace; }
+
+.ssc-panel .widefat tbody tr.is-selected { outline:2px solid #2563eb; outline-offset:-2px; background:rgba(37,99,235,0.08); }
+.ssc-panel .widefat tbody tr:not(.is-selected):hover { background:rgba(37,99,235,0.06); cursor:pointer; }
+
+.ssc-panel-actions .button-link-delete { margin-left:auto; }
+
+.ssc-panel .description + .ssc-filter-bar { margin-top:0; }
 
 
 /* Utilities Page */

--- a/supersede-css-jlg-enhanced/assets/js/debug-center.js
+++ b/supersede-css-jlg-enhanced/assets/js/debug-center.js
@@ -1,8 +1,6 @@
 (function($) {
     $(document).ready(function() {
         const healthRunButton = $('#ssc-health-run');
-        if (!healthRunButton.length) return;
-
         const l10n = window.sscDebugCenterL10n || {};
         const domain = typeof l10n.domain === 'string' && l10n.domain.length ? l10n.domain : 'supersede-css-jlg';
         const strings = l10n.strings && typeof l10n.strings === 'object' ? l10n.strings : {};
@@ -19,38 +17,40 @@
                 });
             };
 
-        const translate = (key) => {
-            const fallback = Object.prototype.hasOwnProperty.call(strings, key) ? strings[key] : key;
-            return hasI18n ? wpI18n.__(fallback, domain) : fallback;
+        const translate = (key, fallback = null) => {
+            const defaultValue = fallback !== null ? fallback : key;
+            const localized = Object.prototype.hasOwnProperty.call(strings, key) ? strings[key] : defaultValue;
+            return hasI18n ? wpI18n.__(localized, domain) : localized;
         };
 
         const resultPane = $('#ssc-health-json');
+        if (healthRunButton.length && resultPane.length) {
+            healthRunButton.on('click', function() {
+                const btn = $(this);
+                btn.text(translate('healthCheckCheckingLabel', 'Vérification en cours…')).prop('disabled', true);
+                resultPane.text(translate('healthCheckRunningMessage', 'Analyse du système…'));
 
-        // Lancer le Health Check
-        healthRunButton.on('click', function() {
-            const btn = $(this);
-            btn.text(translate('healthCheckCheckingLabel')).prop('disabled', true);
-            resultPane.text(translate('healthCheckRunningMessage'));
-
-            $.ajax({
-                url: SSC.rest.root + 'health',
-                method: 'GET',
-                data: { _wpnonce: SSC.rest.nonce },
-                beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-            }).done(response => {
-                resultPane.text(JSON.stringify(response, null, 2));
-                window.sscToast(translate('healthCheckSuccessMessage'));
-            }).fail(err => {
-                resultPane.text(translate('healthCheckErrorMessage'));
-                console.error('Health Check Error:', err);
-            }).always(() => {
-                btn.text(translate('healthCheckRunLabel')).prop('disabled', false);
+                $.ajax({
+                    url: SSC.rest.root + 'health',
+                    method: 'GET',
+                    data: { _wpnonce: SSC.rest.nonce },
+                    beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
+                }).done(response => {
+                    resultPane.text(JSON.stringify(response, null, 2));
+                    window.sscToast && window.sscToast(translate('healthCheckSuccessMessage', 'Health check terminé.'));
+                }).fail(err => {
+                    resultPane.text(translate('healthCheckErrorMessage', 'Une erreur est survenue.'));
+                    console.error('Health Check Error:', err);
+                }).always(() => {
+                    btn.text(translate('healthCheckRunLabel', 'Lancer Health Check')).prop('disabled', false);
+                });
             });
-        });
+        }
 
-        // Vider le journal d'activité
         $('#ssc-clear-log').on('click', function() {
-            if (!confirm(translate('confirmClearLog'))) return;
+            if (!confirm(translate('confirmClearLog', 'Voulez-vous vraiment vider le journal ?'))) {
+                return;
+            }
 
             const btn = $(this);
             btn.prop('disabled', true);
@@ -61,22 +61,21 @@
                 data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => {
-                window.sscToast(translate('clearLogSuccess'));
+                window.sscToast && window.sscToast(translate('clearLogSuccess', 'Journal vidé.'));
                 setTimeout(() => location.reload(), 1000);
             }).fail(() => {
-                window.sscToast(translate('clearLogError'));
+                window.sscToast && window.sscToast(translate('clearLogError', 'Impossible de vider le journal.'));
                 btn.prop('disabled', false);
             });
         });
 
-        // Réinitialiser tout le CSS
         $('#ssc-reset-all-css').on('click', function() {
-            if (!confirm(translate('confirmResetAllCss'))) {
+            if (!confirm(translate('confirmResetAllCss', 'Réinitialiser tout le CSS personnalisé ?'))) {
                 return;
             }
 
             const btn = $(this);
-            btn.text(translate('resetAllCssWorking')).prop('disabled', true);
+            btn.text(translate('resetAllCssWorking', 'Réinitialisation…')).prop('disabled', true);
 
             $.ajax({
                 url: SSC.rest.root + 'reset-all-css',
@@ -84,19 +83,17 @@
                 data: { _wpnonce: SSC.rest.nonce },
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(() => {
-                window.sscToast(translate('resetAllCssSuccess'));
-                btn.text(translate('resetAllCssLabel')).prop('disabled', false);
-                // Optionnellement, recharger la page pour voir les changements
-                // location.reload();
+                window.sscToast && window.sscToast(translate('resetAllCssSuccess', 'CSS réinitialisé.'));
+                btn.text(translate('resetAllCssLabel', 'Réinitialiser tout le CSS')).prop('disabled', false);
             }).fail(() => {
-                window.sscToast(translate('resetAllCssError'));
-                btn.text(translate('resetAllCssLabel')).prop('disabled', false);
+                window.sscToast && window.sscToast(translate('resetAllCssError', 'La réinitialisation a échoué.'));
+                btn.text(translate('resetAllCssLabel', 'Réinitialiser tout le CSS')).prop('disabled', false);
             });
         });
 
         $('.ssc-revision-restore').on('click', function() {
             if (typeof SSC === 'undefined' || !SSC.rest || !SSC.rest.root) {
-                window.sscToast(translate('restUnavailable'));
+                window.sscToast && window.sscToast(translate('restUnavailable', 'API REST indisponible.'));
                 return;
             }
 
@@ -105,20 +102,20 @@
             const optionName = btn.data('option') || '';
 
             if (!revisionId) {
-                window.sscToast(translate('revisionNotFound'));
+                window.sscToast && window.sscToast(translate('revisionNotFound', 'Révision introuvable.'));
                 return;
             }
 
             const confirmationMessage = optionName
-                ? sprintf(translate('confirmRestoreRevisionWithOption'), optionName)
-                : translate('confirmRestoreRevision');
+                ? sprintf(translate('confirmRestoreRevisionWithOption', 'Restaurer la révision pour %s ?'), optionName)
+                : translate('confirmRestoreRevision', 'Restaurer cette révision ?');
 
             if (!confirm(confirmationMessage)) {
                 return;
             }
 
             const originalText = btn.text();
-            btn.prop('disabled', true).text(translate('restoreWorking'));
+            btn.prop('disabled', true).text(translate('restoreWorking', 'Restauration…'));
 
             $.ajax({
                 url: SSC.rest.root + 'css-revisions/' + encodeURIComponent(revisionId) + '/restore',
@@ -127,15 +124,15 @@
                 beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
             }).done(response => {
                 if (response && response.ok) {
-                    window.sscToast(translate('restoreSuccess'));
+                    window.sscToast && window.sscToast(translate('restoreSuccess', 'Révision restaurée.'));
                     setTimeout(() => location.reload(), 800);
                     return;
                 }
 
-                window.sscToast(translate('restoreError'));
+                window.sscToast && window.sscToast(translate('restoreError', 'Impossible de restaurer la révision.'));
                 btn.prop('disabled', false).text(originalText);
             }).fail(err => {
-                let message = translate('restoreError');
+                let message = translate('restoreError', 'Impossible de restaurer la révision.');
                 let duplicates = [];
 
                 if (err && err.responseJSON) {
@@ -155,9 +152,332 @@
                     console.error('Revision restore error:', err);
                 }
 
-                window.sscToast(message);
+                window.sscToast && window.sscToast(message);
                 btn.prop('disabled', false).text(originalText);
             });
+        });
+
+        const parseJsonFromScript = (selector) => {
+            const node = document.querySelector(selector);
+            if (!node) {
+                return [];
+            }
+
+            try {
+                return JSON.parse(node.textContent || '[]');
+            } catch (err) {
+                console.error('Unable to parse JSON for selector', selector, err);
+                return [];
+            }
+        };
+
+        const parseDateValue = (value, isEnd = false) => {
+            if (!value) {
+                return null;
+            }
+
+            const isoCandidate = `${value}T${isEnd ? '23:59:59' : '00:00:00'}Z`;
+            const parsed = new Date(isoCandidate);
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+        };
+
+        const revisionsData = parseJsonFromScript('#ssc-revisions-data');
+        const revisionsById = revisionsData.reduce((acc, item) => {
+            if (item && typeof item.id !== 'undefined') {
+                acc[String(item.id)] = item;
+            }
+            return acc;
+        }, {});
+
+        const revisionRows = $('#ssc-revisions-table tbody tr');
+        const revisionEmptyState = $('#ssc-revision-empty');
+        const revisionFilterBar = $('#ssc-revision-filters');
+
+        const applyRevisionFilters = () => {
+            if (!revisionRows.length) {
+                return;
+            }
+
+            const startValue = $('#ssc-revision-date-start').val();
+            const endValue = $('#ssc-revision-date-end').val();
+            const userValue = ($('#ssc-revision-user').val() || '').toString().toLowerCase();
+
+            const startDate = parseDateValue(startValue);
+            const endDate = parseDateValue(endValue, true);
+
+            let visibleCount = 0;
+
+            revisionRows.each(function() {
+                const row = $(this);
+                const ts = row.attr('data-timestamp');
+                const author = (row.attr('data-author') || '').toLowerCase();
+
+                let isVisible = true;
+
+                if (startDate || endDate) {
+                    const rowDate = ts ? new Date(ts) : null;
+                    if (!rowDate || Number.isNaN(rowDate.getTime())) {
+                        isVisible = false;
+                    } else {
+                        if (startDate && rowDate < startDate) {
+                            isVisible = false;
+                        }
+                        if (endDate && rowDate > endDate) {
+                            isVisible = false;
+                        }
+                    }
+                }
+
+                if (isVisible && userValue) {
+                    isVisible = author.indexOf(userValue) !== -1;
+                }
+
+                row.toggle(isVisible);
+
+                if (isVisible) {
+                    visibleCount += 1;
+                }
+            });
+
+            const hasActiveFilter = Boolean(startValue || endValue || userValue);
+            revisionFilterBar.toggleClass('is-active', hasActiveFilter);
+
+            if (revisionEmptyState.length) {
+                if (visibleCount === 0) {
+                    revisionEmptyState.removeAttr('hidden');
+                } else {
+                    revisionEmptyState.attr('hidden', 'hidden');
+                }
+            }
+        };
+
+        if (revisionRows.length) {
+            $('#ssc-revision-filters [data-filter]').on('change input', applyRevisionFilters);
+            applyRevisionFilters();
+        }
+
+        const diffOutput = $('#ssc-diff-output');
+        const diffPlaceholder = diffOutput.data('placeholder') || translate('diffPlaceholder', 'Sélectionnez deux révisions pour visualiser leurs différences.');
+        const setDiffPlaceholder = () => {
+            diffOutput.removeClass('has-diff').text(diffPlaceholder);
+        };
+
+        if (diffOutput.length) {
+            setDiffPlaceholder();
+        }
+
+        const getRevisionFromSelect = (selector) => {
+            const id = $(selector).val();
+            return id ? revisionsById[String(id)] || null : null;
+        };
+
+        $('#ssc-diff-load').on('click', function() {
+            const baseRevision = getRevisionFromSelect('#ssc-diff-base');
+            const compareRevision = getRevisionFromSelect('#ssc-diff-compare');
+
+            if (!baseRevision || !compareRevision) {
+                setDiffPlaceholder();
+                return;
+            }
+
+            const diffApi = window.wp && window.wp.diff ? window.wp.diff : null;
+            const baseLabel = baseRevision.timestamp || translate('diffBaseLabel', 'Révision de base');
+            const compareLabel = compareRevision.timestamp || translate('diffCompareLabel', 'Révision à comparer');
+
+            if (diffApi) {
+                const result = diffApi(baseLabel, compareLabel, baseRevision.css || '', compareRevision.css || '');
+                if (result) {
+                    diffOutput.addClass('has-diff').html(result);
+                    return;
+                }
+            }
+
+            if ((baseRevision.css || '') === (compareRevision.css || '')) {
+                diffOutput.addClass('has-diff').text(translate('noDiffDetected', 'Aucune différence détectée.'));
+                return;
+            }
+
+            const fallback = [
+                `--- ${baseLabel}`,
+                `+++ ${compareLabel}`,
+                '',
+                compareRevision.css || ''
+            ].join('\n');
+
+            diffOutput.addClass('has-diff').text(fallback);
+        });
+
+        $('#ssc-revisions-table tbody tr').on('click', function() {
+            const revisionId = $(this).attr('data-revision-id');
+            if (!revisionId) {
+                return;
+            }
+
+            $('#ssc-revisions-table tbody tr').removeClass('is-selected');
+            $(this).addClass('is-selected');
+
+            const compareSelect = $('#ssc-diff-compare');
+            if (!compareSelect.val()) {
+                compareSelect.val(revisionId);
+            }
+        });
+
+        const triggerDownload = (filename, content, mime = 'text/plain') => {
+            const blob = new Blob([content], { type: mime });
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = filename;
+            document.body.appendChild(link);
+            link.click();
+            setTimeout(() => {
+                URL.revokeObjectURL(link.href);
+                document.body.removeChild(link);
+            }, 0);
+        };
+
+        $('#ssc-export-css').on('click', function() {
+            const activeId = $('#ssc-diff-compare').val() || $('#ssc-diff-base').val();
+            if (!activeId) {
+                window.sscToast && window.sscToast(translate('revisionNotFound', 'Révision introuvable.'));
+                return;
+            }
+
+            const revision = revisionsById[String(activeId)];
+            if (!revision) {
+                window.sscToast && window.sscToast(translate('revisionNotFound', 'Révision introuvable.'));
+                return;
+            }
+
+            const label = (revision.timestamp || 'revision').replace(/[\s:]/g, '-');
+            const fileName = `supersede-css-${label}.css`;
+            triggerDownload(fileName, revision.css || '', 'text/css');
+        });
+
+        const logRows = $('#ssc-log-table tbody tr');
+        const logEmptyState = $('#ssc-log-empty');
+        const logFilterBar = $('#ssc-log-filters');
+        const logData = parseJsonFromScript('#ssc-log-data');
+
+        const getLogEntryByIndex = (index) => {
+            if (typeof index === 'undefined') {
+                return null;
+            }
+            const intIndex = parseInt(index, 10);
+            if (Number.isNaN(intIndex) || intIndex < 0 || intIndex >= logData.length) {
+                return null;
+            }
+            return logData[intIndex];
+        };
+
+        const applyLogFilters = () => {
+            const startValue = $('#ssc-log-date-start').val();
+            const endValue = $('#ssc-log-date-end').val();
+            const userValue = ($('#ssc-log-user').val() || '').toString().toLowerCase();
+            const actionValue = ($('#ssc-log-action').val() || '').toString().toLowerCase();
+
+            const startDate = parseDateValue(startValue);
+            const endDate = parseDateValue(endValue, true);
+
+            let visibleCount = 0;
+
+            logRows.each(function() {
+                const row = $(this);
+                const ts = row.attr('data-timestamp');
+                const user = (row.attr('data-user') || '').toLowerCase();
+                const action = (row.attr('data-action') || '').toLowerCase();
+
+                let isVisible = true;
+
+                if (startDate || endDate) {
+                    const rowDate = ts ? new Date(ts) : null;
+                    if (!rowDate || Number.isNaN(rowDate.getTime())) {
+                        isVisible = false;
+                    } else {
+                        if (startDate && rowDate < startDate) {
+                            isVisible = false;
+                        }
+                        if (endDate && rowDate > endDate) {
+                            isVisible = false;
+                        }
+                    }
+                }
+
+                if (isVisible && userValue) {
+                    isVisible = user.indexOf(userValue) !== -1;
+                }
+
+                if (isVisible && actionValue) {
+                    isVisible = action.indexOf(actionValue) !== -1;
+                }
+
+                row.toggle(isVisible);
+
+                if (isVisible) {
+                    visibleCount += 1;
+                }
+            });
+
+            const hasActiveFilter = Boolean(startValue || endValue || userValue || actionValue);
+            logFilterBar.toggleClass('is-active', hasActiveFilter);
+
+            if (logEmptyState.length) {
+                if (visibleCount === 0) {
+                    logEmptyState.removeAttr('hidden');
+                } else {
+                    logEmptyState.attr('hidden', 'hidden');
+                }
+            }
+        };
+
+        if (logRows.length) {
+            $('#ssc-log-filters [data-filter]').on('change input', applyLogFilters);
+            applyLogFilters();
+        }
+
+        const getVisibleLogEntries = () => {
+            const visibleEntries = [];
+            logRows.each(function() {
+                const row = $(this);
+                if (!row.is(':visible')) {
+                    return;
+                }
+                const index = row.attr('data-index');
+                const entry = getLogEntryByIndex(index);
+                if (entry) {
+                    visibleEntries.push(entry);
+                }
+            });
+            return visibleEntries;
+        };
+
+        $('#ssc-export-log-json').on('click', function() {
+            const entries = getVisibleLogEntries();
+            if (!entries.length) {
+                window.sscToast && window.sscToast(translate('emptySelectionMessage', 'Aucune donnée à exporter.'));
+                return;
+            }
+
+            triggerDownload('supersede-css-log.json', JSON.stringify(entries, null, 2), 'application/json');
+        });
+
+        $('#ssc-export-log-csv').on('click', function() {
+            const entries = getVisibleLogEntries();
+            if (!entries.length) {
+                window.sscToast && window.sscToast(translate('emptySelectionMessage', 'Aucune donnée à exporter.'));
+                return;
+            }
+
+            const csvHeader = ['date', 'user', 'action', 'data'];
+            const csvRows = entries.map(item => {
+                const rowData = [item.t || '', item.user || '', item.action || '', JSON.stringify(item.data || {})];
+                return rowData.map(value => {
+                    const safeValue = String(value).replace(/"/g, '""');
+                    return `"${safeValue}"`;
+                }).join(',');
+            });
+
+            const csvContent = [csvHeader.join(','), ...csvRows].join('\n');
+            triggerDownload('supersede-css-log.csv', csvContent, 'text/csv');
         });
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- add filter controls, export actions, and revision diff UI to the debug center view
- implement client-side filtering, diff rendering, and export helpers in the debug center script
- style the new filter bars, diff panel, and table selection states in the admin stylesheet

## Testing
- php -l supersede-css-jlg-enhanced/views/debug-center.php

------
https://chatgpt.com/codex/tasks/task_e_68e1a3fb5e18832ea95d832e5eb98d91