### PR TITLE
Add context-aware token management and preview toggles

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Pages/Tokens.php
@@ -19,6 +19,8 @@ class Tokens extends AbstractPage
             'tokens_registry' => $registry,
             'tokens_css' => TokenRegistry::tokensToCss($registry),
             'token_types' => TokenRegistry::getSupportedTypes(),
+            'token_contexts' => TokenRegistry::getSupportedContexts(),
+            'default_context' => TokenRegistry::getDefaultContext(),
         ]);
     }
 }

--- a/supersede-css-jlg-enhanced/src/Infra/Rest/CssController.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Rest/CssController.php
@@ -128,6 +128,8 @@ final class CssController extends BaseController
             $css_to_store = $incoming_css;
         }
 
+        $responsePayload = ['ok' => true];
+
         if ($option_name === 'ssc_tokens_css') {
             $tokens = TokenRegistry::convertCssToRegistry($css_to_store);
             $existingRegistry = TokenRegistry::getRegistry();
@@ -141,8 +143,13 @@ final class CssController extends BaseController
                 ], 422);
             }
             $css_to_store = TokenRegistry::tokensToCss($sanitizedTokens['tokens']);
+            $responsePayload['tokens'] = $sanitizedTokens['tokens'];
+            $responsePayload['css'] = $css_to_store;
+            $responsePayload['contexts'] = TokenRegistry::getSupportedContexts();
+            $responsePayload['defaultContext'] = TokenRegistry::getDefaultContext();
         } else {
             update_option($option_name, $css_to_store, false);
+            $responsePayload['css'] = $css_to_store;
         }
 
         $revisionContext = [];
@@ -160,7 +167,7 @@ final class CssController extends BaseController
             ssc_invalidate_css_cache();
         }
 
-        return new WP_REST_Response(['ok' => true], 200);
+        return new WP_REST_Response($responsePayload, 200);
     }
 
     public function restoreCssRevision(WP_REST_Request $request): WP_REST_Response

--- a/supersede-css-jlg-enhanced/src/Infra/Rest/TokensController.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Rest/TokensController.php
@@ -32,6 +32,8 @@ final class TokensController extends BaseController
             'tokens' => $registry,
             'css' => TokenRegistry::tokensToCss($registry),
             'types' => TokenRegistry::getSupportedTypes(),
+            'contexts' => TokenRegistry::getSupportedContexts(),
+            'defaultContext' => TokenRegistry::getDefaultContext(),
         ], 200);
     }
 
@@ -76,6 +78,8 @@ final class TokensController extends BaseController
             'ok' => true,
             'tokens' => $sanitized,
             'css' => TokenRegistry::tokensToCss($sanitized),
+            'contexts' => TokenRegistry::getSupportedContexts(),
+            'defaultContext' => TokenRegistry::getDefaultContext(),
         ], 200);
     }
 }

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -3,8 +3,10 @@ if (!defined('ABSPATH')) {
     exit;
 }
 /** @var string $tokens_css */
-/** @var array<int, array{name: string, value: string, type: string, description: string, group: string}> $tokens_registry */
+/** @var array<int, array{name: string, value: string, type: string, description: string, group: string, context: string}> $tokens_registry */
 /** @var array<string, array{label: string, input: string, placeholder?: string, help?: string, rows?: int}> $token_types */
+/** @var array<int, array{value: string, label: string, preview?: array<string, string>}> $token_contexts */
+/** @var string $default_context */
 
 if (function_exists('wp_localize_script')) {
     $localized_types = [];
@@ -37,6 +39,8 @@ if (function_exists('wp_localize_script')) {
         'tokens' => $tokens_registry,
         'types' => $localized_types,
         'css' => $tokens_css,
+        'contexts' => $token_contexts,
+        'defaultContext' => $default_context,
         'i18n' => [
             'addToken' => __('Ajouter un token', 'supersede-css-jlg'),
             'emptyState' => __('Aucun token pour le moment. Utilisez le bouton ci-dessous pour commencer.', 'supersede-css-jlg'),
@@ -45,6 +49,7 @@ if (function_exists('wp_localize_script')) {
             'valueLabel' => __('Valeur', 'supersede-css-jlg'),
             'typeLabel' => __('Type', 'supersede-css-jlg'),
             'descriptionLabel' => __('Description', 'supersede-css-jlg'),
+            'contextLabel' => __('Contexte', 'supersede-css-jlg'),
             'deleteLabel' => __('Supprimer', 'supersede-css-jlg'),
             'saveSuccess' => __('Tokens enregistrés', 'supersede-css-jlg'),
             'saveError' => __('Impossible d’enregistrer les tokens.', 'supersede-css-jlg'),
@@ -52,6 +57,9 @@ if (function_exists('wp_localize_script')) {
             'duplicateListPrefix' => __('Doublons :', 'supersede-css-jlg'),
             'copySuccess' => __('Tokens copiés', 'supersede-css-jlg'),
             'reloadConfirm' => __('Des modifications locales non enregistrées seront perdues. Continuer ?', 'supersede-css-jlg'),
+            'previewContextTitle' => __('Tester d’autres contextes', 'supersede-css-jlg'),
+            'previewContextDescription' => __('Activez un contexte supplémentaire pour simuler des styles conditionnels.', 'supersede-css-jlg'),
+            'previewContextAriaLabel' => __('Contextes d’aperçu', 'supersede-css-jlg'),
         ],
     ]);
 }
@@ -130,6 +138,17 @@ if (function_exists('wp_localize_script')) {
         <h3><?php esc_html_e('👁️ Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
         <p><?php esc_html_e('Voyez comment vos tokens affectent les éléments. Le style de cet aperçu est directement contrôlé par le code CSS ci-dessus.', 'supersede-css-jlg'); ?></p>
         <style id="ssc-tokens-preview-style"></style>
+        <div class="ssc-preview-context-panel" hidden aria-hidden="true">
+            <h4><?php esc_html_e('Tester d’autres contextes', 'supersede-css-jlg'); ?></h4>
+            <p id="ssc-preview-context-description"><?php esc_html_e('Activez un contexte supplémentaire pour simuler des styles conditionnels.', 'supersede-css-jlg'); ?></p>
+            <div
+                id="ssc-preview-context-switcher"
+                class="ssc-preview-context-switcher"
+                role="group"
+                aria-label="<?php esc_attr_e('Contextes d’aperçu', 'supersede-css-jlg'); ?>"
+                aria-describedby="ssc-preview-context-description"
+            ></div>
+        </div>
         <div id="ssc-tokens-preview" style="padding: 24px; border: 2px dashed var(--couleur-principale, #ccc); border-radius: var(--radius-moyen, 8px); background: #fff;">
             <button class="button button-primary" style="background-color: var(--couleur-principale); border-radius: var(--radius-moyen);"><?php esc_html_e('Bouton Principal', 'supersede-css-jlg'); ?></button>
             <a href="#" style="color: var(--couleur-principale); margin-left: 16px;"><?php esc_html_e('Lien Principal', 'supersede-css-jlg'); ?></a>


### PR DESCRIPTION
## Summary
- add context metadata support to TokenRegistry and expose supported contexts/default via admin and REST endpoints
- extend the tokens editor to edit contexts, group generated CSS per context, and provide preview toggles tied to supported contexts
- update persistence helpers and TokenRegistry tests for the new context-aware structure

## Testing
- php supersede-css-jlg-enhanced/tests/Support/TokenRegistryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e1a3f4fbf4832eb56ac7975c12c49d