### PR TITLE
Fix import/export view to use REST controller modules

### DIFF
--- a/supersede-css-jlg-enhanced/views/import-export.php
+++ b/supersede-css-jlg-enhanced/views/import-export.php
@@ -1,11 +1,11 @@
 <?php
-use SSC\Infra\Routes;
+use SSC\Infra\Rest\ImportExportController;
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
-$modules = Routes::getConfigModules();
+$modules = ImportExportController::getConfigModules();
 
 if (function_exists('wp_set_script_translations')) {
     wp_set_script_translations('ssc-import-export', 'supersede-css-jlg', SSC_PLUGIN_DIR . 'languages');


### PR DESCRIPTION
## Summary
- update the import/export view to reference the REST ImportExportController
- ensure the modules list comes from ImportExportController::getConfigModules

## Testing
- php -l supersede-css-jlg-enhanced/views/import-export.php

------
https://chatgpt.com/codex/tasks/task_e_68e2763efa74832e9e1056b3c9d0b55d