### PR TITLE
Wrap REST error messages in translation calls

### DIFF
--- a/supersede-css-jlg-enhanced/languages/supersede-css-jlg-fr_FR.po
+++ b/supersede-css-jlg-enhanced/languages/supersede-css-jlg-fr_FR.po
@@ -177,3 +177,15 @@ msgstr "Échec de l'enregistrement du fond animé."
 #: assets/js/visual-effects.js:315
 msgid "Impossible d'appliquer l'effet ECG."
 msgstr "Impossible d'appliquer l'effet ECG."
+
+#: src/Infra/Rest/CssController.php:82
+msgid "Invalid CSS segment."
+msgstr "Segment CSS invalide."
+
+#: src/Infra/Rest/CssController.php:117
+msgid "Invalid CSS."
+msgstr "CSS invalide."
+
+#: src/Infra/Rest/CssController.php:210
+msgid "All CSS options have been reset."
+msgstr "Toutes les options CSS ont été réinitialisées."

--- a/supersede-css-jlg-enhanced/src/Infra/Rest/CssController.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Rest/CssController.php
@@ -76,7 +76,10 @@ final class CssController extends BaseController
                 if ($raw_value !== null) {
                     $segment_payload = true;
                     if (!is_string($raw_value)) {
-                        return new WP_REST_Response(['ok' => false, 'message' => 'Invalid CSS segment.'], 400);
+                        return new WP_REST_Response([
+                            'ok' => false,
+                            'message' => __('Invalid CSS segment.', 'supersede-css-jlg'),
+                        ], 400);
                     }
 
                     $sanitized_value = $this->sanitizer->sanitizeCssSegment($raw_value);
@@ -108,7 +111,10 @@ final class CssController extends BaseController
             $append = false;
         } else {
             if (!is_string($css_raw)) {
-                return new WP_REST_Response(['ok' => false, 'message' => 'Invalid CSS.'], 400);
+                return new WP_REST_Response([
+                    'ok' => false,
+                    'message' => __('Invalid CSS.', 'supersede-css-jlg'),
+                ], 400);
             }
 
             $incoming_css = CssSanitizer::sanitize(wp_unslash($css_raw));
@@ -233,6 +239,9 @@ final class CssController extends BaseController
             \SSC\Infra\Logger::add('css_resetted', []);
         }
 
-        return new WP_REST_Response(['ok' => true, 'message' => 'All CSS options have been reset.']);
+        return new WP_REST_Response([
+            'ok' => true,
+            'message' => __('All CSS options have been reset.', 'supersede-css-jlg'),
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- wrap CSS REST controller responses in translation helpers so error messages are localizable
- provide French translations for the new REST responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27f57bb6c832e9716aefd663bd192