### PR TITLE
Improve health check integrity diagnostics

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/debug-center.js
+++ b/supersede-css-jlg-enhanced/assets/js/debug-center.js
@@ -54,7 +54,7 @@
             php_version: translate('healthLabelPhpVersion', 'Version PHP'),
             rest_api_status: translate('healthLabelRestStatus', 'Statut de l’API REST'),
             asset_files_exist: translate('healthLabelAssets', 'Fichiers d’assets'),
-            composer_dependencies: translate('healthLabelComposer', 'Dépendances Composer')
+            plugin_integrity: translate('healthLabelIntegrity', 'Intégrité du plugin')
         };
 
         const updateCopyButton = (payload) => {
@@ -216,8 +216,8 @@
                 return sprintf(translate('healthMessageAssetStatus', 'Statut : %s'), asString);
             }
 
-            if (sourcePath.includes('composer_dependencies')) {
-                return sprintf(translate('healthMessageComposerStatus', 'État : %s'), asString);
+            if (sourcePath.includes('plugin_integrity')) {
+                return sprintf(translate('healthMessageIntegrityStatus', 'Intégrité : %s'), asString);
             }
 
             if (sourcePath.includes('rest_api_status')) {
@@ -236,8 +236,8 @@
                 return translate('healthActionAsset', 'Vérifiez que les fichiers d’assets du plugin sont présents (réinstallation ou permissions).');
             }
 
-            if (sourcePath.includes('composer_dependencies')) {
-                return translate('healthActionComposer', 'Installez ou rechargez les dépendances PHP via Composer.');
+            if (sourcePath.includes('plugin_integrity')) {
+                return translate('healthActionIntegrity', 'Vérifiez le chargement des classes et fonctions critiques du plugin.');
             }
 
             if (sourcePath.includes('rest_api_status')) {

--- a/supersede-css-jlg-enhanced/docs/REST-ARCHITECTURE.md
+++ b/supersede-css-jlg-enhanced/docs/REST-ARCHITECTURE.md
@@ -7,7 +7,7 @@ Ce plugin expose ses endpoints via une série de contrôleurs spécialisés situ
 - `PresetsController` : gestion des presets et des presets Avatar Glow.
 - `ImportExportController` : flux d'import/export de configuration et d'assets CSS.
 - `LogsController` : nettoyage du journal interne.
-- `SystemController` : route de diagnostic/health-check.
+- `SystemController` : route de diagnostic/health-check qui vérifie l'état des assets, les versions et l'intégrité des composants critiques (autoload des classes principales, fonctions de cache CSS, statut du registre de tokens).
 
 Les contrôleurs implémentent l'interface `ControllerInterface` et héritent de `BaseController`, qui centralise la logique d'autorisation REST (nonce, authentification alternative et contrôle de capacité).
 

--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/SystemControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/SystemControllerTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+use SSC\Infra\Rest\SystemController;
+use SSC\Support\TokenRegistry;
+use WP_REST_Response;
+
+final class SystemControllerTest extends WP_UnitTestCase
+{
+    private SystemController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new SystemController();
+    }
+
+    public function test_health_check_reports_integrity_information(): void
+    {
+        $response = $this->controller->healthCheck();
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey('plugin_integrity', $data);
+        $integrity = $data['plugin_integrity'];
+        $this->assertIsArray($integrity);
+
+        $this->assertArrayHasKey('classes', $integrity);
+        $this->assertArrayHasKey('functions', $integrity);
+        $this->assertArrayHasKey('token_registry', $integrity);
+
+        $this->assertArrayHasKey(TokenRegistry::class, $integrity['classes']);
+        $this->assertSame('OK', $integrity['classes'][TokenRegistry::class]);
+
+        $this->assertArrayHasKey('ssc_get_cached_css', $integrity['functions']);
+        $this->assertSame('OK', $integrity['functions']['ssc_get_cached_css']);
+
+        $this->assertArrayHasKey('status', $integrity['token_registry']);
+        $this->assertIsString($integrity['token_registry']['status']);
+        $this->assertStringStartsWith('OK', $integrity['token_registry']['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the composer dependency placeholder with integrity checks for critical classes, functions, and the token registry in the health endpoint
- align the debug center UI labels and messaging with the new plugin integrity diagnostics
- document the expanded health-check scope and cover it with a dedicated PHPUnit test

## Testing
- composer test *(fails: WordPress test suite cannot connect to 127.0.0.1 database in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27fe28e84832eb2db1d86174d75a7