### PR TITLE
Allow container properties in CSS sanitizer

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssSanitizer.php
@@ -2196,6 +2196,9 @@ final class CssSanitizer
         'contain-intrinsic-inline-size' => true,
         'contain-intrinsic-size' => true,
         'contain-intrinsic-width' => true,
+        'container' => true,
+        'container-name' => true,
+        'container-type' => true,
         'content' => true,
         'counter-increment' => true,
         'counter-reset' => true,
@@ -2461,6 +2464,7 @@ final class CssSanitizer
         'font-variation-',
         'text-emphasis-',
         'scrollbar-',
+        'container-',
     ];
 
     public static function sanitizeAvatarGlowPresets(array $presets): array

--- a/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Support/CssSanitizerTest.php
@@ -79,6 +79,17 @@ class CssSanitizerTest extends WP_UnitTestCase
         $this->assertStringNotContainsString('behavior', $sanitizedKeyframes);
     }
 
+    public function test_container_rule_preserves_container_properties(): void
+    {
+        $css = '@container layout (min-width: 500px) { .card { container-type: inline-size; container-name: layout; } }';
+        $sanitized = CssSanitizer::sanitize($css);
+
+        $this->assertSame(
+            '@container layout (min-width: 500px) {.card {container-type:inline-size; container-name:layout}}',
+            $sanitized
+        );
+    }
+
     public function test_text_wrap_and_text_size_adjust_are_preserved(): void
     {
         $css = '.hero { text-wrap: balance; text-size-adjust: 100%; }';


### PR DESCRIPTION
## Summary
- allow container-related CSS properties in the sanitizer whitelist
- permit the `container-` prefix for CSS property validation
- add a unit test ensuring `@container` rules retain `container-type` and `container-name`

## Testing
- `vendor/bin/phpunit --filter CssSanitizerTest` *(fails: WordPress test environment cannot connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6b8c3a8832e9b9068e3a9c5cec9