### PR TITLE
Prevent sanitizeImportArray from overwriting duplicate keys

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Import/Sanitizer.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Import/Sanitizer.php
@@ -193,6 +193,14 @@ final class Sanitizer
                 continue;
             }
 
+            $duplicatePath = $this->formatDuplicateKeyPath($parentPath, $sanitizedKey);
+
+            if (array_key_exists($sanitizedKey, $sanitized)) {
+                $this->recordDuplicateWarning($duplicatePath);
+
+                continue;
+            }
+
             $itemBudget--;
 
             if (is_array($item)) {
@@ -205,7 +213,7 @@ final class Sanitizer
 
                 if ($referenceId !== null) {
                     if (isset($arrayReferenceStack[$referenceId])) {
-                        $this->recordDuplicateWarning($this->formatDuplicateKeyPath($parentPath, $sanitizedKey));
+                        $this->recordDuplicateWarning($duplicatePath);
                         continue;
                     }
 
@@ -217,7 +225,7 @@ final class Sanitizer
                     $depth + 1,
                     $objectStack,
                     $itemBudget,
-                    $this->formatDuplicateKeyPath($parentPath, $sanitizedKey),
+                    $duplicatePath,
                     $arrayReferenceStack
                 );
 
@@ -235,7 +243,7 @@ final class Sanitizer
 
             if ($item instanceof \JsonSerializable) {
                 if ($objectStack->contains($item)) {
-                    $this->recordDuplicateWarning($this->formatDuplicateKeyPath($parentPath, $sanitizedKey));
+                    $this->recordDuplicateWarning($duplicatePath);
                     continue;
                 }
 
@@ -258,7 +266,7 @@ final class Sanitizer
 
             if (is_object($item)) {
                 if ($objectStack->contains($item)) {
-                    $this->recordDuplicateWarning($this->formatDuplicateKeyPath($parentPath, $sanitizedKey));
+                    $this->recordDuplicateWarning($duplicatePath);
                     continue;
                 }
 

--- a/supersede-css-jlg-enhanced/tests/Infra/Import/SanitizerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Import/SanitizerTest.php
@@ -47,4 +47,20 @@ final class SanitizerTest extends WP_UnitTestCase
         $duplicates = $sanitizer->consumeDuplicateWarnings();
         $this->assertNotEmpty($duplicates);
     }
+
+    public function test_sanitize_import_array_records_duplicate_keys(): void
+    {
+        $sanitizer = new Sanitizer();
+        $sanitizer->resetDuplicateWarnings();
+
+        $result = $sanitizer->sanitizeImportArray([
+            'Foo' => 'first',
+            'foo' => 'second',
+        ]);
+
+        $this->assertSame(['foo' => 'first'], $result);
+
+        $duplicates = $sanitizer->consumeDuplicateWarnings();
+        $this->assertSame(['foo'], $duplicates);
+    }
 }


### PR DESCRIPTION
## Summary
- prevent `sanitizeImportArray` from overwriting existing entries when normalized keys collide and reuse the duplicate path for warnings
- ensure duplicate warnings are emitted consistently for nested arrays and object references
- add a regression test covering mixed-case keys that normalize to the same value

## Testing
- `vendor/bin/phpunit --filter SanitizerTest` *(fails: WordPress database connection not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c7903574832e9fe0650acbb98465