### PR TITLE
Fix syntax error in visual effects AJAX requests

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/visual-effects.js
+++ b/supersede-css-jlg-enhanced/assets/js/visual-effects.js
@@ -1237,8 +1237,12 @@ ${reduceMotionBlock}`;
                  });
              }
 
-             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: requestData, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-             }).done(() => window.sscToast('Fond animé appliqué !'))
+            $.ajax({
+                url: SSC.rest.root + 'save-css',
+                method: 'POST',
+                data: requestData,
+                beforeSend: (xhr) => xhr.setRequestHeader('X-WP-Nonce', SSC.rest.nonce),
+            }).done(() => window.sscToast('Fond animé appliqué !'))
              .fail((jqXHR, textStatus, errorThrown) => {
                  console.error(errorMessage, { jqXHR, textStatus, errorThrown });
                  window.sscToast(
@@ -1334,8 +1338,12 @@ ${reduceMotionBlock}`;
                  .attr('aria-disabled', 'true')
                  .text(ecgApplyingLabel);
 
-             $.ajax({ url: SSC.rest.root + 'save-css', method: 'POST', data: { css, append: true, _wpnonce: SSC.rest.nonce }, beforeSend: x => x.setRequestHeader('X-WP-Nonce', SSC.rest.nonce)
-             })
+            $.ajax({
+                url: SSC.rest.root + 'save-css',
+                method: 'POST',
+                data: { css, append: true, _wpnonce: SSC.rest.nonce },
+                beforeSend: (xhr) => xhr.setRequestHeader('X-WP-Nonce', SSC.rest.nonce),
+            })
              .done(() => window.sscToast('Effet ECG appliqué !'))
              .fail((jqXHR, textStatus, errorThrown) => {
                  console.error(errorMessage, { jqXHR, textStatus, errorThrown });


### PR DESCRIPTION
## Summary
- replace the shorthand beforeSend callbacks in the visual effects background and ECG AJAX requests with properly closed arrow functions
- resolve the syntax error that prevented the visual effects UI from applying presets reliably

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2f728a9ac832e8dc5f1a7bba6e76a