### PR TITLE
Add competitive analysis and improvement roadmap

### DIFF
--- a/supersede-css-jlg-enhanced/docs/COMPETITIVE-ANALYSIS.md
+++ b/supersede-css-jlg-enhanced/docs/COMPETITIVE-ANALYSIS.md
@@ -1,0 +1,57 @@
+# Analyse comparative et recommandations d'amélioration
+
+Cette note compare Supersede CSS JLG (Enhanced) à trois solutions professionnelles largement utilisées pour la conception d'interfaces et la gestion de design systems, puis propose des pistes concrètes pour rapprocher l'expérience utilisateur et la valeur produit des standards du marché.
+
+## Tableau comparatif synthétique
+
+| Critère | Supersede CSS JLG (Enhanced) | Elementor Pro | Webflow | Figma avec Design Tokens plugins |
+| --- | --- | --- | --- | --- |
+| Positionnement | Boîte à outils WordPress pour styliser via tokens, éditeurs spécialisés | Constructeur de pages drag-and-drop WordPress | Plateforme no-code Web (hébergement + design) | Outil de design collaboratif orienté UI + gestion de tokens |
+| Cible principale | Intégrateurs WordPress avancés / équipes techniques | Agences & freelances WordPress | Designers + marketeurs souhaitant livrer des sites autonomes | Designers produit / design systems |
+| Gestion de design system | Tokens CSS, presets, import/export JSON | Style kits limités (global colors/fonts) | Design system basique (classes, combos) | Tokens synchronisés multi-plateforme via plugins |
+| Collaboration | Accès via capability WordPress | Contrôle d'accès par rôle utilisateur WP | Collaboration visuelle temps réel + partage lien | Collaboration temps réel, commentaires, versioning |
+| Prévisualisation | Iframe responsive, blocs Gutenberg dédiés | Éditeur visuel complet | Canvas pixel-perfect avec breakpoints | Preview en direct dans le canvas design |
+| Automatisation | Export CSS/JSON, pas de workflow CI natif | Modèles, kit marketing | Publication/hosting, CMS dynamique | Plugins pour exporter vers code/variables |
+| Tarification | Gratuit (GPL) | Abonnement annuel | Abonnement mensuel | Abonnement + plugins payants |
+
+## Forces actuelles face aux apps pro
+
+- **Spécialisation WordPress poussée** : intégration native (capabilities, REST, bloc Gutenberg Token Preview) qui manque souvent aux outils généralistes comme Figma ou Webflow.
+- **Granularité des modules** : la segmentation en studios (Shadow, Gradient, Tron Grid…) permet d'aller plus loin que les kits de style globaux d'Elementor.
+- **Respect du code** : le CSS généré est assaini, exportable et peut être versionné — avantage par rapport à l'HTML/CSS parfois verbeux produit par les builders visuels.
+- **Automatisation via hooks** : possibilité d'étendre via filtres WordPress, contrairement aux plateformes SaaS fermées.
+
+## Axes d'amélioration prioritaires
+
+1. **Expérience collaborative et workflows**  
+   - Ajout d'une _Activity Log_ listant les modifications (création/édition de tokens, presets, CSS importé) avec auteurs et timestamps pour se rapprocher de l'historique détaillé offert par Figma ou Webflow.  
+   - Intégration d'un système de commentaires/contextualisation sur chaque token ou preset, afin de favoriser la revue entre designers et développeurs.  
+   - Support natif de _drafts_ ou d'environnements (staging vs production) pour éviter de pousser directement les changements sur un site live.
+
+2. **Prévisualisation avancée**  
+   - Introduire un _Device Lab_ inspiré d'Elementor/Webflow : pré-réglages d'écrans (iPhone, iPad, desktop, ultra-wide) et simulation des interactions (hover/tap) sans quitter l'éditeur.  
+   - Permettre l'import d'URL externes dans l'iframe pour appliquer les tokens/presets sur des pages existantes, à la manière des _live previews_ de Webflow.
+
+3. **Design tokens multi-plateforme**  
+   - Export/bridge vers des formats standards (Style Dictionary, Tokens Studio) pour faciliter la synchro avec Figma et les pipelines front-end.  
+   - Génération automatique de variables CSS personnalisées (`--ssc-color-primary`) et de thèmes JSON (Android, iOS) pour aligner le plugin sur les pratiques de design system des apps pro.
+
+4. **Automatisation & CI/CD**  
+   - Fournir un package CLI ou des scripts npm pour déclencher l'export des tokens/CSS en CI, similaire aux hooks de publication Webflow.  
+   - Ajouter des webhooks WordPress (REST) pour déclencher des builds front-end lorsque les tokens changent.
+
+5. **Onboarding & accompagnement**  
+   - Créer un _guided tour_ interactif façon Figma/Elementor avec étapes contextualisées pour chaque module.  
+   - Ajouter une bibliothèque de _templates_ (landing, blog, dashboard) utilisant les presets générés par défaut pour prouver la valeur immédiatement.
+
+6. **Qualité et accessibilité**  
+   - Intégrer un validateur d'accessibilité (contraste WCAG, focus states) dans les éditeurs de couleurs/effets, comme Webflow Audit.  
+   - Proposer des _lint rules_ ou recommandations (ex. limiter les animations pour préférences de mouvement réduites).
+
+## Roadmap suggérée
+
+1. **Court terme (1-2 releases)** : Activity Log, commentaires sur tokens, export Style Dictionary.  
+2. **Moyen terme (3-4 releases)** : Device Lab responsive, guided tour, bibliothèque de templates.  
+3. **Long terme** : Webhooks/CLI, validation accessibilité approfondie, gestion multi-environnements.
+
+En implémentant ces améliorations, Supersede CSS JLG (Enhanced) se rapprochera des standards d'outils professionnels tout en conservant son avantage WordPress natif.


### PR DESCRIPTION
## Summary
- document how Supersede CSS compares with professional design tools
- outline strengths, gaps, and a roadmap of improvements to reach market standards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35ab4c960832eb3c01b8b8089a62c