### PR TITLE
feat: introduce design tokens and clean grid editor UI

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -1,14 +1,52 @@
 /* Main SSC Styles */
-.ssc-app, .ssc-wrap { 
-    font: 14px/1.5 system-ui, sans-serif; 
+.ssc-app,
+.ssc-wrap {
+    font-family: var(--ssc-font-family-base);
+    font-size: var(--ssc-font-size-200);
+    line-height: var(--ssc-line-height-base);
     max-width: none;
     color: var(--ssc-text);
+    background-color: var(--ssc-bg);
 }
-.ssc-app h1, .ssc-wrap h1,
-.ssc-app h2, .ssc-wrap h2,
-.ssc-app h3, .ssc-wrap h3,
-.ssc-app h4, .ssc-wrap h4 {
+
+.ssc-app h1,
+.ssc-wrap h1,
+.ssc-app h2,
+.ssc-wrap h2,
+.ssc-app h3,
+.ssc-wrap h3,
+.ssc-app h4,
+.ssc-wrap h4 {
     color: var(--ssc-text);
+    font-family: var(--ssc-font-family-base);
+    font-weight: var(--ssc-font-weight-semibold);
+    line-height: var(--ssc-line-height-snug);
+    margin-top: 0;
+}
+
+.ssc-app h1,
+.ssc-wrap h1 {
+    font-size: var(--ssc-font-size-600);
+    margin-bottom: var(--ssc-space-sm);
+}
+
+.ssc-app h2,
+.ssc-wrap h2 {
+    font-size: var(--ssc-font-size-500);
+    margin-bottom: var(--ssc-space-xs);
+}
+
+.ssc-app h3,
+.ssc-wrap h3 {
+    font-size: var(--ssc-font-size-400);
+    margin-bottom: var(--ssc-space-2xs);
+}
+
+.ssc-app h4,
+.ssc-wrap h4 {
+    font-size: var(--ssc-font-size-300);
+    font-weight: var(--ssc-font-weight-medium);
+    margin-bottom: var(--ssc-space-3xs);
 }
 .screen-reader-text {
     position: absolute;
@@ -22,10 +60,15 @@
     white-space: nowrap;
     border: 0;
 }
-.ssc-app p, .ssc-wrap p,
-.ssc-app .description, .ssc-wrap .description,
-.ssc-app label, .ssc-wrap label {
+.ssc-app p,
+.ssc-wrap p,
+.ssc-app .description,
+.ssc-wrap .description,
+.ssc-app label,
+.ssc-wrap label {
     color: var(--ssc-muted);
+    font-size: var(--ssc-font-size-200);
+    line-height: var(--ssc-line-height-relaxed);
 }
 
 #ssc-import-msg.ssc-success {
@@ -36,18 +79,66 @@
     color: #b91c1c;
 }
 
-.ssc-two { display:grid; grid-template-columns: 1fr 1fr; gap:16px; }
+.ssc-two {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--ssc-space-md);
+}
+
+.ssc-two--align-start {
+    align-items: flex-start;
+}
 @media (max-width: 782px) {
     .ssc-two { grid-template-columns: 1fr; }
     .ssc-filter { flex:1 1 140px; }
 }
-.ssc-pane, .ssc-panel { background:var(--ssc-card); border:1px solid var(--ssc-border); border-radius:12px; padding:16px; }
-.ssc-panel-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:16px; align-items:flex-start; margin-bottom:12px; }
-.ssc-panel-actions { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
-.ssc-actions { display:flex; gap:8px; align-items:center; flex-wrap: wrap; }
+.ssc-pane,
+.ssc-panel {
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-md);
+    padding: var(--ssc-space-md);
+}
+
+.ssc-panel-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: var(--ssc-space-md);
+    align-items: flex-start;
+    margin-bottom: var(--ssc-space-sm);
+}
+
+.ssc-panel-actions {
+    display: flex;
+    gap: var(--ssc-space-xs);
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.ssc-actions {
+    display: flex;
+    gap: var(--ssc-space-xs);
+    align-items: center;
+    flex-wrap: wrap;
+}
 .ssc-code { background:#0f172a; color:#e5e7eb; border-radius:8px; padding:12px; overflow:auto; font-family: monospace; font-size: 13px; line-height: 1.6; }
-.ssc-list { list-style:none; padding:0; margin:0; display:grid; gap:8px;}
-.ssc-list li { padding:8px 10px; border:1px solid var(--ssc-border); border-radius:8px; display:flex; justify-content:space-between; align-items:center; }
+.ssc-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: var(--ssc-space-xs);
+}
+
+.ssc-list li {
+    padding: var(--ssc-space-xs) calc(var(--ssc-space-xs) + 2px);
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-sm);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
 .ssc-health-badge{display:inline-block;margin-left:8px;padding:2px 8px;border-radius:999px;border:1px solid #e5e7eb}.ssc-health-badge.ok{background:#ecfdf5;color:#065f46}.ssc-health-badge.warn{background:#fffbeb;color:#92400e}.ssc-health-badge.err{background:#fef2f2;color:#991b1b}
 
 /* Style for Danger Zone */
@@ -72,17 +163,27 @@
 }
 
 
-.ssc-filter-bar { display:flex; gap:12px; flex-wrap:wrap; margin-bottom:16px; padding:8px 12px; border-radius:10px; background:rgba(15,23,42,0.04); border:1px solid var(--ssc-border); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+.ssc-filter-bar {
+    display: flex;
+    gap: var(--ssc-space-sm);
+    flex-wrap: wrap;
+    margin-bottom: var(--ssc-space-md);
+    padding: var(--ssc-space-xs) calc(var(--ssc-space-xs) + 4px);
+    border-radius: var(--ssc-radius-sm);
+    background: rgba(15, 23, 42, 0.04);
+    border: 1px solid var(--ssc-border);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
 .ssc-filter-bar.is-active { border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.1); }
 .ssc-filter { min-width:140px; }
 .ssc-filter label { font-weight:600; display:block; margin-bottom:4px; color:var(--ssc-muted); }
 .ssc-filter input,
 .ssc-filter select { width:100%; min-width:140px; }
 
-.ssc-revision-diff { margin-top:24px; border-top:1px solid var(--ssc-border); padding-top:16px; }
+.ssc-revision-diff { margin-top:var(--ssc-space-lg); border-top:1px solid var(--ssc-border); padding-top:var(--ssc-space-md); }
 .ssc-revision-diff h3 { margin-top:0; }
 .ssc-diff-controls { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
-.ssc-diff-output { margin-top:16px; padding:16px; border:1px dashed var(--ssc-border); border-radius:12px; min-height:120px; background:rgba(15,23,42,0.02); color:var(--ssc-muted); font-family:monospace; white-space:pre-wrap; overflow:auto; }
+.ssc-diff-output { margin-top:var(--ssc-space-md); padding:var(--ssc-space-md); border:1px dashed var(--ssc-border); border-radius:var(--ssc-radius-md); min-height:120px; background:rgba(15,23,42,0.02); color:var(--ssc-muted); font-family:monospace; white-space:pre-wrap; overflow:auto; }
 .ssc-diff-output.has-diff { border-style:solid; background:#0f172a; color:#e5e7eb; }
 .ssc-diff-output table.diff { width:100%; font-size:13px; }
 .ssc-diff-output table.diff td { font-family:monospace; }
@@ -96,10 +197,10 @@
 
 
 /* Utilities Page */
-.ssc-utilities-wrap .ssc-editor-layout { display: grid; grid-template-columns: 2fr 1fr; gap: 16px; height: calc(100vh - 250px); }
+.ssc-utilities-wrap .ssc-editor-layout { display: grid; grid-template-columns: 2fr 1fr; gap: var(--ssc-space-md); height: calc(100vh - 250px); }
 .ssc-preview-toggle { display: none; }
 .ssc-editor-column, .ssc-preview-column { display: flex; flex-direction: column; }
-.ssc-editor-header, .ssc-preview-header { display: flex; justify-content: space-between; align-items: center; padding-bottom: 8px; border-bottom: 1px solid var(--ssc-border); margin-bottom: 8px; }
+.ssc-editor-header, .ssc-preview-header { display: flex; justify-content: space-between; align-items: center; padding-bottom: var(--ssc-space-2xs); border-bottom: 1px solid var(--ssc-border); margin-bottom: var(--ssc-space-2xs); }
 .ssc-editor-container, .ssc-preview-frame-container { flex-grow: 1; position: relative; }
 .CodeMirror { border: 1px solid var(--ssc-border); border-radius: 8px; }
 .ssc-editor-container .CodeMirror { position: absolute; inset: 0; height: 100% !important; }
@@ -155,8 +256,87 @@
 
 /* Visual Editors */
 .ssc-kv-builder .kv-row { display: flex; gap: 8px; margin-bottom: 8px; } .ssc-kv-builder .kv-row input { flex: 1; }
-.ssc-shadow-layer { border: 1px solid var(--ssc-border); border-radius: 8px; padding: 12px; margin-bottom: 12px; }
+.ssc-shadow-layer { border: 1px solid var(--ssc-border); border-radius: var(--ssc-radius-sm); padding: var(--ssc-space-sm); margin-bottom: var(--ssc-space-sm); }
 .ssc-grad-preview-bar { height: 40px; border-radius: 8px; border: 1px solid var(--ssc-border); cursor: pointer; }
+
+/* Form foundation */
+.ssc-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-3xs);
+    margin-top: var(--ssc-space-sm);
+}
+
+.ssc-form-field:first-of-type {
+    margin-top: var(--ssc-space-xs);
+}
+
+.ssc-form-label {
+    font-weight: var(--ssc-font-weight-semibold);
+    color: var(--ssc-text);
+    line-height: var(--ssc-line-height-snug);
+}
+
+.ssc-range-control {
+    display: flex;
+    align-items: center;
+    gap: var(--ssc-space-sm);
+}
+
+.ssc-range-control input[type="range"] {
+    flex: 1;
+}
+
+.ssc-range-output {
+    min-width: 3ch;
+    text-align: right;
+    font-weight: var(--ssc-font-weight-semibold);
+    color: var(--ssc-text);
+}
+
+.ssc-form-actions {
+    display: flex;
+    gap: var(--ssc-space-xs);
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.ssc-form-actions--separated {
+    margin-top: var(--ssc-space-lg);
+    padding-top: var(--ssc-space-md);
+    border-top: 1px solid var(--ssc-border);
+}
+
+.ssc-section-heading {
+    margin-top: var(--ssc-space-lg);
+}
+
+.ssc-grid-preview {
+    display: grid;
+    border: 1px dashed var(--ssc-border);
+    padding: var(--ssc-space-sm);
+    border-radius: var(--ssc-radius-sm);
+    background: rgba(15, 23, 42, 0.02);
+    min-height: 220px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ssc-grid-preview:focus-within,
+.ssc-grid-preview:hover {
+    border-color: var(--ssc-accent);
+    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.12);
+}
+
+.ssc-grid-preview-cell {
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-sm);
+    padding: var(--ssc-space-sm);
+    text-align: center;
+    font-weight: var(--ssc-font-weight-medium);
+    color: var(--ssc-text);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
 
 /*
  * App-Like Experience for Supersede CSS Pages

--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -1,77 +1,351 @@
-:root{--ssc-bg:#f8fafc;--ssc-card:#ffffff;--ssc-border:#e5e7eb;--ssc-text:#0f172a;--ssc-muted:#64748b;--ssc-accent:#4f46e5;}
-/* Thème sombre avec contraste encore amélioré */
-.ssc-dark:root,.ssc-dark{--ssc-bg:#030712;--ssc-card:#111827;--ssc-border:#374151;--ssc-text:#e5e7eb;--ssc-muted:#d1d5db;--ssc-accent:#a5b4fc;}
-.ssc-shell{position:relative}
-.ssc-topbar{position:sticky;top:0;z-index:1300;display:flex;align-items:center;gap:8px;background:var(--ssc-card);border-bottom:1px solid var(--ssc-border);padding:8px 16px;margin:0}
-.ssc-topbar .ssc-title{font-weight:700}
-.ssc-topbar .ssc-spacer{flex:1}
-.ssc-topbar .ssc-topbar-label{margin-left:4px}
-.ssc-topbar .ssc-back-to-admin{display:inline-flex;align-items:center;gap:6px;text-decoration:none;padding:4px 8px}
-.ssc-topbar .ssc-back-to-admin .dashicons{font-size:18px;line-height:1}
-.ssc-topbar .button{display:inline-flex;align-items:center;gap:6px}
-.ssc-mobile-menu-toggle{display:none;align-items:center;justify-content:center;gap:4px}
-.ssc-mobile-menu-toggle .dashicons{font-size:18px;line-height:1}
-.ssc-shell-overlay{position:fixed;inset:0;background:rgba(15,23,42,.45);opacity:0;transition:opacity .3s ease;pointer-events:none;z-index:1050}
-.ssc-shell--menu-open .ssc-shell-overlay{opacity:1;pointer-events:auto}
-body.ssc-no-scroll{overflow:hidden}
+:root {
+    --ssc-bg: #f8fafc;
+    --ssc-card: #ffffff;
+    --ssc-border: #e5e7eb;
+    --ssc-text: #0f172a;
+    --ssc-muted: #64748b;
+    --ssc-accent: #4f46e5;
 
-/* CORRECTION : La sidebar utilise maintenant les variables du thème */
-.ssc-sidebar{
-    position:sticky;
-    top:69px; /* Ajusté pour l'espace sous la topbar */
-    align-self:flex-start;
-    width:220px;
-    background:var(--ssc-card); /* Ajout du fond */
-    border:1px solid var(--ssc-border); /* Ajout de la bordure */
-    border-radius:12px; /* Ajout du radius pour la cohérence */
-    padding:8px;
-    display:flex;
-    flex-direction:column;
-    gap:4px;
+    /* Typographic scale */
+    --ssc-font-family-base: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    --ssc-font-size-100: 0.75rem;  /* 12px */
+    --ssc-font-size-200: 0.875rem; /* 14px */
+    --ssc-font-size-300: 1rem;     /* 16px */
+    --ssc-font-size-400: 1.25rem;  /* 20px */
+    --ssc-font-size-500: 1.5rem;   /* 24px */
+    --ssc-font-size-600: 1.875rem; /* 30px */
+    --ssc-font-weight-regular: 400;
+    --ssc-font-weight-medium: 500;
+    --ssc-font-weight-semibold: 600;
+    --ssc-font-weight-bold: 700;
+    --ssc-line-height-tight: 1.2;
+    --ssc-line-height-snug: 1.35;
+    --ssc-line-height-base: 1.5;
+    --ssc-line-height-relaxed: 1.65;
+
+    /* Spacing scale */
+    --ssc-space-3xs: 0.25rem;  /* 4px */
+    --ssc-space-2xs: 0.375rem; /* 6px */
+    --ssc-space-xs: 0.5rem;    /* 8px */
+    --ssc-space-sm: 0.75rem;   /* 12px */
+    --ssc-space-md: 1rem;      /* 16px */
+    --ssc-space-lg: 1.5rem;    /* 24px */
+    --ssc-space-xl: 2rem;      /* 32px */
+    --ssc-space-2xl: 2.5rem;   /* 40px */
+
+    /* Radii */
+    --ssc-radius-sm: 8px;
+    --ssc-radius-md: 12px;
+    --ssc-radius-lg: 16px;
 }
 
-.ssc-sidebar a{display:flex;gap:8px;align-items:center;padding:8px;border-radius:8px;color:var(--ssc-text);text-decoration:none;border:1px solid transparent}
+/* Thème sombre avec contraste encore amélioré */
+.ssc-dark:root,
+.ssc-dark {
+    --ssc-bg: #030712;
+    --ssc-card: #111827;
+    --ssc-border: #374151;
+    --ssc-text: #e5e7eb;
+    --ssc-muted: #d1d5db;
+    --ssc-accent: #a5b4fc;
+}
+
+.ssc-shell {
+    position: relative;
+}
+
+.ssc-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 1300;
+    display: flex;
+    align-items: center;
+    gap: var(--ssc-space-xs);
+    background: var(--ssc-card);
+    border-bottom: 1px solid var(--ssc-border);
+    padding: var(--ssc-space-xs) var(--ssc-space-md);
+    margin: 0;
+}
+
+.ssc-topbar .ssc-title {
+    font-weight: var(--ssc-font-weight-bold);
+    font-size: var(--ssc-font-size-400);
+}
+
+.ssc-topbar .ssc-spacer {
+    flex: 1;
+}
+
+.ssc-topbar .ssc-topbar-label {
+    margin-left: var(--ssc-space-2xs);
+    font-size: var(--ssc-font-size-200);
+}
+
+.ssc-topbar .ssc-back-to-admin {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ssc-space-2xs);
+    text-decoration: none;
+    padding: var(--ssc-space-2xs) var(--ssc-space-xs);
+    border-radius: var(--ssc-radius-sm);
+}
+
+.ssc-topbar .ssc-back-to-admin .dashicons {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.ssc-topbar .button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ssc-space-2xs);
+}
+
+.ssc-mobile-menu-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: var(--ssc-space-2xs);
+}
+
+.ssc-mobile-menu-toggle .dashicons {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.ssc-shell-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 1050;
+}
+
+.ssc-shell--menu-open .ssc-shell-overlay {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+body.ssc-no-scroll {
+    overflow: hidden;
+}
+
+.ssc-sidebar {
+    position: sticky;
+    top: 69px; /* Ajusté pour l'espace sous la topbar */
+    align-self: flex-start;
+    width: 220px;
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-md);
+    padding: var(--ssc-space-xs);
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-2xs);
+}
+
+.ssc-sidebar a {
+    display: flex;
+    gap: var(--ssc-space-2xs);
+    align-items: center;
+    padding: var(--ssc-space-xs);
+    border-radius: var(--ssc-radius-sm);
+    color: var(--ssc-text);
+    text-decoration: none;
+    border: 1px solid transparent;
+    font-size: var(--ssc-font-size-200);
+    line-height: var(--ssc-line-height-snug);
+}
+
 .ssc-sidebar a.active,
-.ssc-sidebar a[aria-current="page"]{background:rgba(165, 180, 252, 0.1);border-color:var(--ssc-border); color: var(--ssc-accent); font-weight: 600;}
-.ssc-layout{display:grid;grid-template-columns:220px minmax(0,1fr);gap:16px;align-items:flex-start;position:relative}
-.ssc-main-content { padding-left: 16px; }
+.ssc-sidebar a[aria-current="page"] {
+    background: rgba(165, 180, 252, 0.1);
+    border-color: var(--ssc-border);
+    color: var(--ssc-accent);
+    font-weight: var(--ssc-font-weight-semibold);
+}
+
+.ssc-layout {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: var(--ssc-space-md);
+    align-items: flex-start;
+    position: relative;
+}
+
+.ssc-main-content {
+    padding-left: var(--ssc-space-md);
+}
 
 /* Titres des groupes dans la sidebar */
-.ssc-sidebar-group { margin-bottom: 12px; }
+.ssc-sidebar-group {
+    margin-bottom: var(--ssc-space-sm);
+}
+
 .ssc-sidebar-heading {
-    padding: 8px 8px 4px;
-    font-size: 11px;
+    padding: var(--ssc-space-xs) var(--ssc-space-xs) var(--ssc-space-2xs);
+    font-size: var(--ssc-font-size-100);
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: var(--ssc-font-weight-semibold);
     color: var(--ssc-muted);
     letter-spacing: 0.5px;
 }
 
-@media (max-width:960px){
-    .ssc-topbar{flex-wrap:wrap;row-gap:6px}
-    .ssc-topbar .ssc-title{flex:1 0 100%;margin-top:4px}
-    .ssc-topbar .ssc-spacer{display:none}
-    .ssc-mobile-menu-toggle{display:inline-flex}
-    .ssc-layout{grid-template-columns:minmax(0,1fr);grid-template-rows:auto auto}
-    .ssc-layout .ssc-main-content{padding-left:0}
-    .ssc-layout aside{position:fixed;inset:0;background:var(--ssc-card);border:0;border-radius:0;padding:92px 16px 24px;max-width:100%;transform:translateY(-100%);opacity:0;visibility:hidden;transition:opacity .3s ease,transform .3s ease;z-index:1100;overflow-y:auto;box-shadow:0 24px 48px rgba(15,23,42,.35);pointer-events:none;display:flex;justify-content:center}
-    .ssc-layout aside .ssc-sidebar{width:100%;height:auto;max-width:640px;margin:0 auto}
-    .ssc-shell--menu-open .ssc-layout aside{transform:translateY(0);opacity:1;visibility:visible;pointer-events:auto}
+@media (max-width: 960px) {
+    .ssc-topbar {
+        flex-wrap: wrap;
+        row-gap: var(--ssc-space-2xs);
+    }
+
+    .ssc-topbar .ssc-title {
+        flex: 1 0 100%;
+        margin-top: var(--ssc-space-2xs);
+    }
+
+    .ssc-topbar .ssc-spacer {
+        display: none;
+    }
+
+    .ssc-mobile-menu-toggle {
+        display: inline-flex;
+    }
+
+    .ssc-layout {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: auto auto;
+    }
+
+    .ssc-layout .ssc-main-content {
+        padding-left: 0;
+    }
+
+    .ssc-layout aside {
+        position: fixed;
+        inset: 0;
+        background: var(--ssc-card);
+        border: 0;
+        border-radius: 0;
+        padding: 92px var(--ssc-space-md) var(--ssc-space-lg);
+        max-width: 100%;
+        transform: translateY(-100%);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.3s ease, transform 0.3s ease;
+        z-index: 1100;
+        overflow-y: auto;
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+        pointer-events: none;
+        display: flex;
+        justify-content: center;
+    }
+
+    .ssc-layout aside .ssc-sidebar {
+        width: 100%;
+        height: auto;
+        max-width: 640px;
+        margin: 0 auto;
+    }
+
+    .ssc-shell--menu-open .ssc-layout aside {
+        transform: translateY(0);
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+    }
 }
 
-@media (max-width:782px){
-    .ssc-topbar .ssc-topbar-label{display:none}
-    .ssc-topbar .ssc-back-to-admin{padding:4px}
-    .ssc-topbar .button{padding:4px 8px}
+@media (max-width: 782px) {
+    .ssc-topbar .ssc-topbar-label {
+        display: none;
+    }
+
+    .ssc-topbar .ssc-back-to-admin {
+        padding: var(--ssc-space-2xs);
+    }
+
+    .ssc-topbar .button {
+        padding: var(--ssc-space-2xs) var(--ssc-space-xs);
+    }
 }
 
-#ssc-cmdp{position:fixed;inset:0;display:none;align-items:flex-start;justify-content:center;background:rgba(2,6,23,.5);z-index:9999}
-#ssc-cmdp.active{display:flex}
-#ssc-cmdp .panel{margin-top:10vh;width:min(720px,92vw);background:var(--ssc-card);border:1px solid var(--ssc-border);border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.25);overflow:hidden}
-#ssc-cmdp ul{max-height:50vh;overflow:auto;margin:0;padding:0;list-style:none}
-#ssc-cmdp li a{display:flex;padding:10px;text-decoration:none;color:var(--ssc-text);border-bottom:1px solid var(--ssc-border)}
-#ssc-cmdp li a:hover{background:rgba(165, 180, 252, 0.1)}
-#ssc-cmdp li a.is-active,#ssc-cmdp li a.is-active:hover{background:rgba(165,180,252,.2)}
-#ssc-toasts{position:fixed;right:16px;bottom:16px;display:flex;flex-direction:column;gap:8px;z-index:99999;pointer-events:none}
-.ssc-toast{background:var(--ssc-card);border:1px solid var(--ssc-border);border-radius:10px;padding:10px 12px;box-shadow:0 10px 20px rgba(0,0,0,.12); opacity: 0; transform: translateY(10px); animation: ssc-toast-in 0.3s ease forwards;pointer-events:auto}
-@keyframes ssc-toast-in { to { opacity: 1; transform: translateY(0); } }
+#ssc-cmdp {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: flex-start;
+    justify-content: center;
+    background: rgba(2, 6, 23, 0.5);
+    z-index: 9999;
+}
+
+#ssc-cmdp.active {
+    display: flex;
+}
+
+#ssc-cmdp .panel {
+    margin-top: 10vh;
+    width: min(720px, 92vw);
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-md);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+}
+
+#ssc-cmdp ul {
+    max-height: 50vh;
+    overflow: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+#ssc-cmdp li a {
+    display: flex;
+    padding: 10px;
+    text-decoration: none;
+    color: var(--ssc-text);
+    border-bottom: 1px solid var(--ssc-border);
+    font-size: var(--ssc-font-size-200);
+}
+
+#ssc-cmdp li a:hover {
+    background: rgba(165, 180, 252, 0.1);
+}
+
+#ssc-cmdp li a.is-active,
+#ssc-cmdp li a.is-active:hover {
+    background: rgba(165, 180, 252, 0.2);
+}
+
+#ssc-toasts {
+    position: fixed;
+    right: var(--ssc-space-md);
+    bottom: var(--ssc-space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-xs);
+    z-index: 99999;
+    pointer-events: none;
+}
+
+.ssc-toast {
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+    border-radius: 10px;
+    padding: 10px 12px;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    transform: translateY(10px);
+    animation: ssc-toast-in 0.3s ease forwards;
+    pointer-events: auto;
+}
+
+@keyframes ssc-toast-in {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/supersede-css-jlg-enhanced/assets/js/grid-editor.js
+++ b/supersede-css-jlg-enhanced/assets/js/grid-editor.js
@@ -22,7 +22,7 @@
         });
 
         for (let i = 1; i <= Math.min(12, cols * 2); i++) {
-            preview.append(`<div style="background:var(--ssc-bg); padding:12px; border-radius:8px; text-align:center;">${i}</div>`);
+            preview.append(`<div class="ssc-grid-preview-cell">${i}</div>`);
         }
     }
 

--- a/supersede-css-jlg-enhanced/views/grid-editor.php
+++ b/supersede-css-jlg-enhanced/views/grid-editor.php
@@ -6,30 +6,38 @@ if (!defined('ABSPATH')) {
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('📏 Visual Grid Editor', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Construisez des mises en page CSS Grid de manière intuitive, sans écrire de code.', 'supersede-css-jlg'); ?></p>
-    <div class="ssc-two" style="align-items: flex-start;">
+    <div class="ssc-two ssc-two--align-start">
         <div class="ssc-pane">
             <h3><?php esc_html_e('Paramètres de la Grille', 'supersede-css-jlg'); ?></h3>
 
-            <label><strong><?php esc_html_e('Nombre de colonnes', 'supersede-css-jlg'); ?></strong></label>
-            <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
-            <span id="ssc-grid-cols-val"><?php echo esc_html__('3', 'supersede-css-jlg'); ?></span>
+            <div class="ssc-form-field">
+                <label class="ssc-form-label" for="ssc-grid-cols"><?php esc_html_e('Nombre de colonnes', 'supersede-css-jlg'); ?></label>
+                <div class="ssc-range-control">
+                    <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
+                    <span id="ssc-grid-cols-val" class="ssc-range-output"><?php echo esc_html__('3', 'supersede-css-jlg'); ?></span>
+                </div>
+            </div>
 
-            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Espacement (gap) en pixels', 'supersede-css-jlg'); ?></strong></label>
-            <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
-            <span id="ssc-grid-gap-val"><?php echo esc_html__('16px', 'supersede-css-jlg'); ?></span>
+            <div class="ssc-form-field">
+                <label class="ssc-form-label" for="ssc-grid-gap"><?php esc_html_e('Espacement (gap) en pixels', 'supersede-css-jlg'); ?></label>
+                <div class="ssc-range-control">
+                    <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
+                    <span id="ssc-grid-gap-val" class="ssc-range-output"><?php echo esc_html__('16px', 'supersede-css-jlg'); ?></span>
+                </div>
+            </div>
 
-            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+            <div class="ssc-form-actions ssc-form-actions--separated">
                 <button id="ssc-grid-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
                 <button id="ssc-grid-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button>
             </div>
 
-            <h3 style="margin-top:24px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
+            <h3 class="ssc-section-heading"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
             <p class="description"><?php printf(wp_kses_post(__('Appliquez la classe %s à votre conteneur.', 'supersede-css-jlg')), '<code>.ssc-grid-container</code>'); ?></p>
             <pre id="ssc-grid-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
             <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
-            <div id="ssc-grid-preview" style="display:grid; border:1px dashed var(--ssc-border); padding:10px; border-radius:8px;">
+            <div id="ssc-grid-preview" class="ssc-grid-preview" role="presentation">
                 <!-- Les éléments de la grille seront générés par JS -->
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a shared typography and spacing token scale to the admin shell
- refactor admin and grid editor styles to consume the new design tokens and remove inline styling
- refresh the grid editor markup and preview cells for clearer spacing and reusable classes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e43315b890832ebaaaa7275e3a334a