### PR TITLE
Introduce design foundations and migrate inline admin styles

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -1,6 +1,8 @@
 /* Main SSC Styles */
-.ssc-app, .ssc-wrap { 
-    font: 14px/1.5 system-ui, sans-serif; 
+.ssc-app, .ssc-wrap {
+    font-family: var(--ssc-font-family-base);
+    font-size: var(--ssc-font-size-sm);
+    line-height: var(--ssc-line-height-default);
     max-width: none;
     color: var(--ssc-text);
 }
@@ -9,7 +11,12 @@
 .ssc-app h3, .ssc-wrap h3,
 .ssc-app h4, .ssc-wrap h4 {
     color: var(--ssc-text);
+    font-family: var(--ssc-font-family-base);
 }
+.ssc-app h1, .ssc-wrap h1 { font-size: var(--ssc-font-size-2xl); line-height: var(--ssc-line-height-snug); }
+.ssc-app h2, .ssc-wrap h2 { font-size: var(--ssc-font-size-xl); line-height: var(--ssc-line-height-snug); }
+.ssc-app h3, .ssc-wrap h3 { font-size: var(--ssc-font-size-lg); line-height: var(--ssc-line-height-tight); }
+.ssc-app h4, .ssc-wrap h4 { font-size: var(--ssc-font-size-md); line-height: var(--ssc-line-height-tight); }
 .screen-reader-text {
     position: absolute;
     width: 1px;
@@ -26,44 +33,40 @@
 .ssc-app .description, .ssc-wrap .description,
 .ssc-app label, .ssc-wrap label {
     color: var(--ssc-muted);
+    font-size: var(--ssc-font-size-sm);
 }
 
-#ssc-import-msg.ssc-success {
-    color: #15803d;
-}
+#ssc-import-msg.ssc-success { color: var(--ssc-success); }
+#ssc-import-msg.ssc-error { color: var(--ssc-danger); }
 
-#ssc-import-msg.ssc-error {
-    color: #b91c1c;
-}
-
-.ssc-two { display:grid; grid-template-columns: 1fr 1fr; gap:16px; }
+.ssc-two { display:grid; grid-template-columns: 1fr 1fr; gap:var(--ssc-space-200); }
 @media (max-width: 782px) {
     .ssc-two { grid-template-columns: 1fr; }
     .ssc-filter { flex:1 1 140px; }
 }
-.ssc-pane, .ssc-panel { background:var(--ssc-card); border:1px solid var(--ssc-border); border-radius:12px; padding:16px; }
-.ssc-panel-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:16px; align-items:flex-start; margin-bottom:12px; }
+.ssc-pane, .ssc-panel { background:var(--ssc-card); border:1px solid var(--ssc-border); border-radius:var(--ssc-radius-lg); padding:var(--ssc-space-200); }
+.ssc-panel-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:var(--ssc-space-200); align-items:flex-start; margin-bottom:var(--ssc-space-150); }
 .ssc-panel-actions { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
 .ssc-actions { display:flex; gap:8px; align-items:center; flex-wrap: wrap; }
-.ssc-code { background:#0f172a; color:#e5e7eb; border-radius:8px; padding:12px; overflow:auto; font-family: monospace; font-size: 13px; line-height: 1.6; }
-.ssc-list { list-style:none; padding:0; margin:0; display:grid; gap:8px;}
-.ssc-list li { padding:8px 10px; border:1px solid var(--ssc-border); border-radius:8px; display:flex; justify-content:space-between; align-items:center; }
-.ssc-health-badge{display:inline-block;margin-left:8px;padding:2px 8px;border-radius:999px;border:1px solid #e5e7eb}.ssc-health-badge.ok{background:#ecfdf5;color:#065f46}.ssc-health-badge.warn{background:#fffbeb;color:#92400e}.ssc-health-badge.err{background:#fef2f2;color:#991b1b}
+.ssc-code { background:#0f172a; color:#e5e7eb; border-radius:var(--ssc-radius-md); padding:var(--ssc-space-150); overflow:auto; font-family: monospace; font-size: 13px; line-height: var(--ssc-line-height-relaxed); }
+.ssc-list { list-style:none; padding:0; margin:0; display:grid; gap:var(--ssc-space-100);}
+.ssc-list li { padding:var(--ssc-space-100) var(--ssc-space-150); border:1px solid var(--ssc-border); border-radius:var(--ssc-radius-md); display:flex; justify-content:space-between; align-items:center; }
+.ssc-health-badge{display:inline-block;margin-left:var(--ssc-space-100);padding:2px var(--ssc-space-100);border-radius:var(--ssc-radius-pill);border:1px solid var(--ssc-border)}.ssc-health-badge.ok{background:#ecfdf5;color:#065f46}.ssc-health-badge.warn{background:#fffbeb;color:#92400e}.ssc-health-badge.err{background:#fef2f2;color:#991b1b}
 
 /* Style for Danger Zone */
 .ssc-danger-zone {
-    background-color: #fef2f2;
-    border-color: #f87171;
+    background-color: color-mix(in srgb, var(--ssc-danger) 12%, #fff 88%);
+    border-color: color-mix(in srgb, var(--ssc-danger) 55%, transparent);
 }
-.ssc-danger-zone h2 { color: #991b1b; }
-.ssc-danger-zone p { color: #b91c1c; }
+.ssc-danger-zone h2 { color: var(--ssc-danger); }
+.ssc-danger-zone p { color: color-mix(in srgb, var(--ssc-danger) 70%, #111 30%); }
 
 .ssc-dark .ssc-danger-zone {
-    background-color: #450a0a;
-    border-color: #991b1b;
+    background-color: color-mix(in srgb, var(--ssc-danger) 35%, transparent);
+    border-color: color-mix(in srgb, var(--ssc-danger) 55%, transparent);
 }
 .ssc-dark .ssc-danger-zone h2 {
-    color: #fca5a5;
+    color: color-mix(in srgb, var(--ssc-danger) 70%, #fff 30%);
 }
 /* CORRECTION : Ciblage par ID pour garantir la couleur du texte */
 .ssc-dark #ssc-danger-intro,
@@ -72,22 +75,22 @@
 }
 
 
-.ssc-filter-bar { display:flex; gap:12px; flex-wrap:wrap; margin-bottom:16px; padding:8px 12px; border-radius:10px; background:rgba(15,23,42,0.04); border:1px solid var(--ssc-border); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+.ssc-filter-bar { display:flex; gap:var(--ssc-space-100); flex-wrap:wrap; margin-bottom:var(--ssc-space-200); padding:var(--ssc-space-075) var(--ssc-space-150); border-radius:var(--ssc-radius-md); background:var(--ssc-surface-muted); border:1px solid var(--ssc-border); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
 .ssc-filter-bar.is-active { border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.1); }
 .ssc-filter { min-width:140px; }
-.ssc-filter label { font-weight:600; display:block; margin-bottom:4px; color:var(--ssc-muted); }
+.ssc-filter label { font-weight:var(--ssc-font-weight-semibold); display:block; margin-bottom:var(--ssc-space-050); color:var(--ssc-muted); }
 .ssc-filter input,
 .ssc-filter select { width:100%; min-width:140px; }
 
-.ssc-revision-diff { margin-top:24px; border-top:1px solid var(--ssc-border); padding-top:16px; }
+.ssc-revision-diff { margin-top:var(--ssc-space-300); border-top:1px solid var(--ssc-border); padding-top:var(--ssc-space-200); }
 .ssc-revision-diff h3 { margin-top:0; }
-.ssc-diff-controls { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
-.ssc-diff-output { margin-top:16px; padding:16px; border:1px dashed var(--ssc-border); border-radius:12px; min-height:120px; background:rgba(15,23,42,0.02); color:var(--ssc-muted); font-family:monospace; white-space:pre-wrap; overflow:auto; }
+.ssc-diff-controls { display:flex; flex-wrap:wrap; gap:var(--ssc-space-150); align-items:center; }
+.ssc-diff-output { margin-top:var(--ssc-space-200); padding:var(--ssc-space-200); border:1px dashed var(--ssc-border); border-radius:var(--ssc-radius-lg); min-height:120px; background:var(--ssc-surface-muted); color:var(--ssc-muted); font-family:monospace; white-space:pre-wrap; overflow:auto; }
 .ssc-diff-output.has-diff { border-style:solid; background:#0f172a; color:#e5e7eb; }
 .ssc-diff-output table.diff { width:100%; font-size:13px; }
 .ssc-diff-output table.diff td { font-family:monospace; }
 
-.ssc-panel .widefat tbody tr.is-selected { outline:2px solid #2563eb; outline-offset:-2px; background:rgba(37,99,235,0.08); }
+.ssc-panel .widefat tbody tr.is-selected { outline:2px solid var(--ssc-info); outline-offset:-2px; background:rgba(37,99,235,0.08); }
 .ssc-panel .widefat tbody tr:not(.is-selected):hover { background:rgba(37,99,235,0.06); cursor:pointer; }
 
 .ssc-panel-actions .button-link-delete { margin-left:auto; }

--- a/supersede-css-jlg-enhanced/assets/css/foundation.css
+++ b/supersede-css-jlg-enhanced/assets/css/foundation.css
@@ -1,0 +1,200 @@
+:root {
+    /* Color palette */
+    --ssc-bg: #f8fafc;
+    --ssc-card: #ffffff;
+    --ssc-border: #e5e7eb;
+    --ssc-text: #0f172a;
+    --ssc-muted: #64748b;
+    --ssc-accent: #4f46e5;
+    --ssc-accent-soft: color-mix(in srgb, var(--ssc-accent) 18%, #ffffff 82%);
+    --ssc-success: #15803d;
+    --ssc-danger: #b91c1c;
+    --ssc-warning: #92400e;
+    --ssc-info: #2563eb;
+    --ssc-surface-muted: color-mix(in srgb, var(--ssc-card) 92%, var(--ssc-border) 8%);
+    --ssc-focus-ring: rgba(79, 70, 229, 0.18);
+
+    /* Typography scale */
+    --ssc-font-family-base: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    --ssc-font-size-xs: 0.75rem;   /* 12px */
+    --ssc-font-size-sm: 0.875rem;  /* 14px */
+    --ssc-font-size-md: 1rem;      /* 16px */
+    --ssc-font-size-lg: 1.125rem;  /* 18px */
+    --ssc-font-size-xl: 1.375rem;  /* 22px */
+    --ssc-font-size-2xl: 1.75rem;  /* 28px */
+    --ssc-line-height-tight: 1.2;
+    --ssc-line-height-snug: 1.35;
+    --ssc-line-height-relaxed: 1.6;
+    --ssc-line-height-default: 1.5;
+    --ssc-font-weight-regular: 400;
+    --ssc-font-weight-medium: 500;
+    --ssc-font-weight-semibold: 600;
+    --ssc-font-weight-bold: 700;
+
+    /* Spacing scale */
+    --ssc-space-050: 0.25rem;  /* 4px */
+    --ssc-space-075: 0.375rem; /* 6px */
+    --ssc-space-100: 0.5rem;   /* 8px */
+    --ssc-space-150: 0.75rem;  /* 12px */
+    --ssc-space-200: 1rem;     /* 16px */
+    --ssc-space-250: 1.25rem;  /* 20px */
+    --ssc-space-300: 1.5rem;   /* 24px */
+    --ssc-space-400: 2rem;     /* 32px */
+    --ssc-space-500: 2.5rem;   /* 40px */
+
+    /* Radii & elevation */
+    --ssc-radius-sm: 6px;
+    --ssc-radius-md: 10px;
+    --ssc-radius-lg: 12px;
+    --ssc-radius-pill: 999px;
+    --ssc-shadow-soft: 0 16px 32px rgba(15, 23, 42, 0.08);
+    --ssc-shadow-elevated: 0 20px 40px rgba(15, 23, 42, 0.12);
+}
+
+.ssc-dark:root,
+.ssc-dark {
+    --ssc-bg: #030712;
+    --ssc-card: #111827;
+    --ssc-border: #374151;
+    --ssc-text: #e5e7eb;
+    --ssc-muted: #d1d5db;
+    --ssc-accent: #a5b4fc;
+    --ssc-accent-soft: color-mix(in srgb, var(--ssc-accent) 22%, #020617 78%);
+    --ssc-success: #34d399;
+    --ssc-danger: #f87171;
+    --ssc-warning: #f59e0b;
+    --ssc-info: #60a5fa;
+    --ssc-surface-muted: color-mix(in srgb, var(--ssc-card) 86%, var(--ssc-border) 14%);
+    --ssc-focus-ring: rgba(165, 180, 252, 0.22);
+}
+
+/* Spacing utilities */
+.ssc-mt-050 { margin-top: var(--ssc-space-050); }
+.ssc-mt-075 { margin-top: var(--ssc-space-075); }
+.ssc-mt-100 { margin-top: var(--ssc-space-100); }
+.ssc-mt-150 { margin-top: var(--ssc-space-150); }
+.ssc-mt-200 { margin-top: var(--ssc-space-200); }
+.ssc-mt-250 { margin-top: var(--ssc-space-250); }
+.ssc-mt-300 { margin-top: var(--ssc-space-300); }
+.ssc-mt-400 { margin-top: var(--ssc-space-400); }
+.ssc-mb-200 { margin-bottom: var(--ssc-space-200); }
+.ssc-pt-200 { padding-top: var(--ssc-space-200); }
+
+/* Layout helpers */
+.ssc-align-start { align-items: flex-start; }
+.ssc-stack { display: flex; flex-direction: column; gap: var(--ssc-space-150); }
+.ssc-stack-lg { gap: var(--ssc-space-200); }
+.ssc-divider-top {
+    margin-top: var(--ssc-space-300);
+    padding-top: var(--ssc-space-200);
+    border-top: 1px solid var(--ssc-border);
+}
+.ssc-hidden { display: none; }
+.ssc-flex-1 { flex: 1 1 auto; }
+
+/* Preview helpers */
+.ssc-preview-surface {
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-lg);
+    padding: var(--ssc-space-150);
+    background: var(--ssc-card);
+}
+.ssc-preview-surface--dashed { border-style: dashed; }
+.ssc-preview-surface--grid { display: grid; gap: var(--ssc-space-100); }
+.ssc-preview-area {
+    display: grid;
+    place-items: center;
+    min-height: 200px;
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-lg);
+    padding: var(--ssc-space-150);
+    background: var(--ssc-card);
+    transition: background 0.3s ease;
+}
+.ssc-preview-area--tall { min-height: 250px; }
+.ssc-preview-area--dark { background: #0b1020; }
+.ssc-preview-box {
+    width: 100px;
+    height: 100px;
+    border-radius: var(--ssc-radius-lg);
+    background: var(--ssc-accent);
+    display: grid;
+    place-items: center;
+    color: #fff;
+    font-weight: var(--ssc-font-weight-semibold);
+}
+.ssc-preview-box--avatar {
+    width: 128px;
+    height: 128px;
+    border-radius: 50%;
+    overflow: hidden;
+    display: block;
+}
+.ssc-preview-box--wide {
+    width: 200px;
+    height: 120px;
+    margin: var(--ssc-space-300) auto;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-lg);
+    background: #fff;
+    transition: all 0.2s ease;
+}
+
+/* Form helpers */
+.ssc-field-label {
+    display: block;
+    font-weight: var(--ssc-font-weight-semibold);
+    margin-bottom: var(--ssc-space-050);
+    color: var(--ssc-muted);
+}
+.ssc-field-group { display: flex; flex-wrap: wrap; gap: var(--ssc-space-100); }
+.ssc-avatar-preview-frame {
+    width: 128px;
+    height: 128px;
+    border-radius: 50%;
+    overflow: hidden;
+}
+.ssc-avatar-preview-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+}
+
+/* Typography helpers */
+.ssc-title-lg {
+    font-size: var(--ssc-font-size-xl);
+    line-height: var(--ssc-line-height-snug);
+    font-weight: var(--ssc-font-weight-semibold);
+    color: var(--ssc-text);
+}
+.ssc-title-md {
+    font-size: var(--ssc-font-size-lg);
+    line-height: var(--ssc-line-height-snug);
+    font-weight: var(--ssc-font-weight-semibold);
+}
+.ssc-subtext { font-size: var(--ssc-font-size-sm); color: var(--ssc-muted); }
+
+/* Badge helper */
+.ssc-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ssc-space-050);
+    padding: 2px var(--ssc-space-075);
+    border-radius: var(--ssc-radius-pill);
+    border: 1px solid var(--ssc-border);
+    font-size: var(--ssc-font-size-xs);
+    font-weight: var(--ssc-font-weight-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ssc-muted);
+}
+
+/* Focus ring */
+.ssc-focus-ring:focus {
+    outline: 2px solid var(--ssc-focus-ring);
+    outline-offset: 2px;
+}

--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -1,15 +1,12 @@
-:root{--ssc-bg:#f8fafc;--ssc-card:#ffffff;--ssc-border:#e5e7eb;--ssc-text:#0f172a;--ssc-muted:#64748b;--ssc-accent:#4f46e5;}
-/* Thème sombre avec contraste encore amélioré */
-.ssc-dark:root,.ssc-dark{--ssc-bg:#030712;--ssc-card:#111827;--ssc-border:#374151;--ssc-text:#e5e7eb;--ssc-muted:#d1d5db;--ssc-accent:#a5b4fc;}
 .ssc-shell{position:relative}
-.ssc-topbar{position:sticky;top:0;z-index:1300;display:flex;align-items:center;gap:8px;background:var(--ssc-card);border-bottom:1px solid var(--ssc-border);padding:8px 16px;margin:0}
-.ssc-topbar .ssc-title{font-weight:700}
+.ssc-topbar{position:sticky;top:0;z-index:1300;display:flex;align-items:center;gap:var(--ssc-space-100);background:var(--ssc-card);border-bottom:1px solid var(--ssc-border);padding:var(--ssc-space-100) var(--ssc-space-200);margin:0}
+.ssc-topbar .ssc-title{font-weight:var(--ssc-font-weight-semibold);font-size:var(--ssc-font-size-lg);}
 .ssc-topbar .ssc-spacer{flex:1}
-.ssc-topbar .ssc-topbar-label{margin-left:4px}
-.ssc-topbar .ssc-back-to-admin{display:inline-flex;align-items:center;gap:6px;text-decoration:none;padding:4px 8px}
+.ssc-topbar .ssc-topbar-label{margin-left:var(--ssc-space-075)}
+.ssc-topbar .ssc-back-to-admin{display:inline-flex;align-items:center;gap:var(--ssc-space-075);text-decoration:none;padding:var(--ssc-space-075) var(--ssc-space-100)}
 .ssc-topbar .ssc-back-to-admin .dashicons{font-size:18px;line-height:1}
-.ssc-topbar .button{display:inline-flex;align-items:center;gap:6px}
-.ssc-mobile-menu-toggle{display:none;align-items:center;justify-content:center;gap:4px}
+.ssc-topbar .button{display:inline-flex;align-items:center;gap:var(--ssc-space-075)}
+.ssc-mobile-menu-toggle{display:none;align-items:center;justify-content:center;gap:var(--ssc-space-050)}
 .ssc-mobile-menu-toggle .dashicons{font-size:18px;line-height:1}
 .ssc-shell-overlay{position:fixed;inset:0;background:rgba(15,23,42,.45);opacity:0;transition:opacity .3s ease;pointer-events:none;z-index:1050}
 .ssc-shell--menu-open .ssc-shell-overlay{opacity:1;pointer-events:auto}
@@ -23,38 +20,38 @@ body.ssc-no-scroll{overflow:hidden}
     width:220px;
     background:var(--ssc-card); /* Ajout du fond */
     border:1px solid var(--ssc-border); /* Ajout de la bordure */
-    border-radius:12px; /* Ajout du radius pour la cohérence */
-    padding:8px;
+    border-radius:var(--ssc-radius-lg); /* Ajout du radius pour la cohérence */
+    padding:var(--ssc-space-100);
     display:flex;
     flex-direction:column;
-    gap:4px;
+    gap:var(--ssc-space-050);
 }
 
 .ssc-sidebar a{display:flex;gap:8px;align-items:center;padding:8px;border-radius:8px;color:var(--ssc-text);text-decoration:none;border:1px solid transparent}
 .ssc-sidebar a.active,
-.ssc-sidebar a[aria-current="page"]{background:rgba(165, 180, 252, 0.1);border-color:var(--ssc-border); color: var(--ssc-accent); font-weight: 600;}
-.ssc-layout{display:grid;grid-template-columns:220px minmax(0,1fr);gap:16px;align-items:flex-start;position:relative}
-.ssc-main-content { padding-left: 16px; }
+.ssc-sidebar a[aria-current="page"]{background:var(--ssc-accent-soft);border-color:var(--ssc-border); color: var(--ssc-accent); font-weight: var(--ssc-font-weight-semibold);}
+.ssc-layout{display:grid;grid-template-columns:220px minmax(0,1fr);gap:var(--ssc-space-200);align-items:flex-start;position:relative}
+.ssc-main-content { padding-left: var(--ssc-space-200); }
 
 /* Titres des groupes dans la sidebar */
 .ssc-sidebar-group { margin-bottom: 12px; }
 .ssc-sidebar-heading {
-    padding: 8px 8px 4px;
-    font-size: 11px;
+    padding: var(--ssc-space-100) var(--ssc-space-100) var(--ssc-space-075);
+    font-size: var(--ssc-font-size-xs);
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: var(--ssc-font-weight-semibold);
     color: var(--ssc-muted);
-    letter-spacing: 0.5px;
+    letter-spacing: 0.05em;
 }
 
 @media (max-width:960px){
-    .ssc-topbar{flex-wrap:wrap;row-gap:6px}
+    .ssc-topbar{flex-wrap:wrap;row-gap:var(--ssc-space-075)}
     .ssc-topbar .ssc-title{flex:1 0 100%;margin-top:4px}
     .ssc-topbar .ssc-spacer{display:none}
     .ssc-mobile-menu-toggle{display:inline-flex}
     .ssc-layout{grid-template-columns:minmax(0,1fr);grid-template-rows:auto auto}
     .ssc-layout .ssc-main-content{padding-left:0}
-    .ssc-layout aside{position:fixed;inset:0;background:var(--ssc-card);border:0;border-radius:0;padding:92px 16px 24px;max-width:100%;transform:translateY(-100%);opacity:0;visibility:hidden;transition:opacity .3s ease,transform .3s ease;z-index:1100;overflow-y:auto;box-shadow:0 24px 48px rgba(15,23,42,.35);pointer-events:none;display:flex;justify-content:center}
+    .ssc-layout aside{position:fixed;inset:0;background:var(--ssc-card);border:0;border-radius:0;padding:92px var(--ssc-space-200) var(--ssc-space-300);max-width:100%;transform:translateY(-100%);opacity:0;visibility:hidden;transition:opacity .3s ease,transform .3s ease;z-index:1100;overflow-y:auto;box-shadow:0 24px 48px rgba(15,23,42,.35);pointer-events:none;display:flex;justify-content:center}
     .ssc-layout aside .ssc-sidebar{width:100%;height:auto;max-width:640px;margin:0 auto}
     .ssc-shell--menu-open .ssc-layout aside{transform:translateY(0);opacity:1;visibility:visible;pointer-events:auto}
 }

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -194,8 +194,9 @@ final class Admin
             wp_enqueue_media();
         }
 
-        wp_enqueue_style('ssc-ux', SSC_PLUGIN_URL . 'assets/css/ux.css', [], SSC_VERSION);
-        wp_enqueue_style('ssc-admin', SSC_PLUGIN_URL . 'assets/css/admin.css', [], SSC_VERSION);
+        wp_enqueue_style('ssc-foundation', SSC_PLUGIN_URL . 'assets/css/foundation.css', [], SSC_VERSION);
+        wp_enqueue_style('ssc-ux', SSC_PLUGIN_URL . 'assets/css/ux.css', ['ssc-foundation'], SSC_VERSION);
+        wp_enqueue_style('ssc-admin', SSC_PLUGIN_URL . 'assets/css/admin.css', ['ssc-foundation'], SSC_VERSION);
         wp_enqueue_script('ssc-ux', SSC_PLUGIN_URL . 'assets/js/ux.js', ['jquery'], SSC_VERSION, true);
 
         // CodeMirror

--- a/supersede-css-jlg-enhanced/src/Infra/Rest/SystemController.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Rest/SystemController.php
@@ -89,7 +89,7 @@ final class SystemController extends BaseController
     private function buildResponseData(): array
     {
         $assets_to_check = [
-            'css/admin.css', 'css/ux.css', 'js/ux.js', 'js/utilities.js',
+            'css/foundation.css', 'css/admin.css', 'css/ux.css', 'js/ux.js', 'js/utilities.js',
             'codemirror/lib/codemirror.js', 'codemirror/lib/codemirror.css'
         ];
 

--- a/supersede-css-jlg-enhanced/views/animation-studio.php
+++ b/supersede-css-jlg-enhanced/views/animation-studio.php
@@ -6,31 +6,31 @@ if (!defined('ABSPATH')) {
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('🎬 Animation Studio', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e("Choisissez un preset d'animation, personnalisez-le et appliquez-le à vos éléments.", 'supersede-css-jlg'); ?></p>
-    <div class="ssc-two" style="align-items: flex-start;">
+    <div class="ssc-two ssc-align-start">
         <div class="ssc-pane">
             <h3><?php esc_html_e("Paramètres de l'Animation", 'supersede-css-jlg'); ?></h3>
-            <label><strong><?php esc_html_e("Preset d'animation", 'supersede-css-jlg'); ?></strong></label>
+            <label class="ssc-field-label"><?php esc_html_e("Preset d'animation", 'supersede-css-jlg'); ?></label>
             <select id="ssc-anim-preset" class="regular-text">
                 <option value="bounce"><?php esc_html_e('Bounce (Rebond)', 'supersede-css-jlg'); ?></option>
                 <option value="pulse"><?php esc_html_e('Pulse (Pulsation)', 'supersede-css-jlg'); ?></option>
                 <option value="fade-in"><?php esc_html_e('Fade In (Apparition)', 'supersede-css-jlg'); ?></option>
                 <option value="slide-in-left"><?php esc_html_e('Slide In Left (Glisse depuis la gauche)', 'supersede-css-jlg'); ?></option>
             </select>
-            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Durée (secondes)', 'supersede-css-jlg'); ?></strong></label>
+            <label class="ssc-field-label ssc-mt-200"><?php esc_html_e('Durée (secondes)', 'supersede-css-jlg'); ?></label>
             <input type="range" id="ssc-anim-duration" min="0.1" max="5" value="1.5" step="0.1">
             <span id="ssc-anim-duration-val"><?php echo esc_html__('1.5s', 'supersede-css-jlg'); ?></span>
-            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+            <div class="ssc-actions ssc-divider-top">
                 <button id="ssc-anim-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
                 <button id="ssc-anim-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button>
             </div>
-            <h3 style="margin-top:24px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
+            <h3 class="ssc-mt-300"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
             <p class="description"><?php printf(wp_kses_post(__('Appliquez la classe %1$s et la classe du preset (ex: %2$s) à votre élément.', 'supersede-css-jlg')), '<code>.ssc-animated</code>', '<code>.ssc-bounce</code>'); ?></p>
             <pre id="ssc-anim-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
             <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
-            <div id="ssc-anim-preview-container" style="display:grid; place-items:center; height:200px;">
-                <div id="ssc-anim-preview-box" style="width: 100px; height: 100px; background: var(--ssc-accent); border-radius: 12px;"></div>
+            <div id="ssc-anim-preview-container" class="ssc-preview-area">
+                <div id="ssc-anim-preview-box" class="ssc-preview-box"></div>
             </div>
         </div>
     </div>

--- a/supersede-css-jlg-enhanced/views/avatar-glow.php
+++ b/supersede-css-jlg-enhanced/views/avatar-glow.php
@@ -8,55 +8,55 @@ if (!defined('ABSPATH')) {
     <h2><?php esc_html_e('✨ Gestionnaire de Presets Avatar Glow', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e("Créez et gérez des effets d'aura réutilisables pour vos rédacteurs. Chaque preset aura son propre nom de classe.", 'supersede-css-jlg'); ?></p>
 
-    <div class="ssc-two" style="align-items: flex-start;">
+    <div class="ssc-two ssc-align-start">
         <div class="ssc-pane">
             <h3><?php esc_html_e('Éditeur de Presets', 'supersede-css-jlg'); ?></h3>
-            <label><strong><?php esc_html_e('Preset Actif', 'supersede-css-jlg'); ?></strong></label>
-            <div class="ssc-actions">
-                <select id="ssc-glow-preset-select" class="regular-text" style="flex: 1;"></select>
+            <label class="ssc-field-label"><?php esc_html_e('Preset Actif', 'supersede-css-jlg'); ?></label>
+            <div class="ssc-actions ssc-field-group">
+                <select id="ssc-glow-preset-select" class="regular-text ssc-flex-1"></select>
                 <button id="ssc-glow-new-preset" class="button"><?php esc_html_e('Nouveau', 'supersede-css-jlg'); ?></button>
             </div>
 
             <div id="ssc-glow-editor-fields">
                 <hr>
-                <div class="ssc-two">
-                    <div><label><strong><?php esc_html_e('Nom du Preset', 'supersede-css-jlg'); ?></strong></label><input type="text" id="ssc-glow-preset-name" class="regular-text" placeholder="<?php echo esc_attr__('Aura Bleue Rapide', 'supersede-css-jlg'); ?>"></div>
-                    <div><label><strong><?php esc_html_e('Nom de la Classe CSS', 'supersede-css-jlg'); ?></strong></label><input type="text" id="ssc-glow-preset-class" class="regular-text" placeholder="<?php echo esc_attr__('.avatar-glow-blue', 'supersede-css-jlg'); ?>"></div>
+                <div class="ssc-two ssc-align-start">
+                    <div><label class="ssc-field-label"><?php esc_html_e('Nom du Preset', 'supersede-css-jlg'); ?></label><input type="text" id="ssc-glow-preset-name" class="regular-text" placeholder="<?php echo esc_attr__('Aura Bleue Rapide', 'supersede-css-jlg'); ?>"></div>
+                    <div><label class="ssc-field-label"><?php esc_html_e('Nom de la Classe CSS', 'supersede-css-jlg'); ?></label><input type="text" id="ssc-glow-preset-class" class="regular-text" placeholder="<?php echo esc_attr__('.avatar-glow-blue', 'supersede-css-jlg'); ?>"></div>
                 </div>
                 <p class="description"><?php printf(wp_kses_post(__('Le nom de la classe doit être unique et commencer par un point (ex: %s).', 'supersede-css-jlg')), '<code>.glow-team-1</code>'); ?></p>
                 <hr>
 
                 <h4><?php esc_html_e("Paramètres de l'Effet", 'supersede-css-jlg'); ?></h4>
-                <label><strong><?php esc_html_e('Couleur du dégradé', 'supersede-css-jlg'); ?></strong></label>
-                <div class="ssc-actions">
+                <label class="ssc-field-label"><?php esc_html_e('Couleur du dégradé', 'supersede-css-jlg'); ?></label>
+                <div class="ssc-actions ssc-field-group">
                     <span><?php esc_html_e('Début :', 'supersede-css-jlg'); ?></span> <input type="color" id="ssc-glow-color1" value="#8b5cf6">
                     <span><?php esc_html_e('Fin :', 'supersede-css-jlg'); ?></span> <input type="color" id="ssc-glow-color2" value="#ec4899">
                 </div>
-                <label style="margin-top:16px;"><strong><?php esc_html_e('Vitesse (secondes)', 'supersede-css-jlg'); ?></strong></label>
+                <label class="ssc-field-label ssc-mt-200"><?php esc_html_e('Vitesse (secondes)', 'supersede-css-jlg'); ?></label>
                 <input type="range" id="ssc-glow-speed" min="1" max="20" value="5" step="0.5">
                 <span id="ssc-glow-speed-val"><?php echo esc_html__('5s', 'supersede-css-jlg'); ?></span>
-                <label style="margin-top:16px;"><strong><?php esc_html_e('Épaisseur (pixels)', 'supersede-css-jlg'); ?></strong></label>
+                <label class="ssc-field-label ssc-mt-200"><?php esc_html_e('Épaisseur (pixels)', 'supersede-css-jlg'); ?></label>
                 <input type="range" id="ssc-glow-thickness" min="2" max="12" value="4" step="1">
                 <span id="ssc-glow-thickness-val"><?php echo esc_html__('4px', 'supersede-css-jlg'); ?></span>
             </div>
 
-            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+            <div class="ssc-actions ssc-divider-top">
                 <button id="ssc-glow-save-preset" class="button button-primary"><?php esc_html_e('Enregistrer ce Preset', 'supersede-css-jlg'); ?></button>
                 <button id="ssc-glow-apply" class="button"><?php esc_html_e('Appliquer sur le site', 'supersede-css-jlg'); ?></button>
-                <button id="ssc-glow-delete-preset" class="button button-link-delete" style="display: none;"><?php esc_html_e('Supprimer ce Preset', 'supersede-css-jlg'); ?></button>
+                <button id="ssc-glow-delete-preset" class="button button-link-delete ssc-hidden"><?php esc_html_e('Supprimer ce Preset', 'supersede-css-jlg'); ?></button>
             </div>
         </div>
 
         <div class="ssc-pane">
             <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
-            <div id="ssc-glow-preview-bg" style="display:grid; place-items:center; height:250px; background: #0b1020; border-radius: 12px; transition: background 0.3s; border: 1px solid var(--ssc-border);">
-                <div id="ssc-glow-preview-container" style="width: 128px; height: 128px;">
-                    <img id="ssc-glow-preview-img" src="<?php echo esc_url($avatar_placeholder); ?>" alt="<?php echo esc_attr__('avatar', 'supersede-css-jlg'); ?>" style="width:100%; height:100%; border-radius:50%; object-fit:cover;">
+            <div id="ssc-glow-preview-bg" class="ssc-preview-area ssc-preview-area--tall ssc-preview-area--dark">
+                <div id="ssc-glow-preview-container" class="ssc-avatar-preview-frame">
+                    <img id="ssc-glow-preview-img" class="ssc-avatar-preview-img" src="<?php echo esc_url($avatar_placeholder); ?>" alt="<?php echo esc_attr__('avatar', 'supersede-css-jlg'); ?>">
                 </div>
             </div>
-            <button id="ssc-glow-upload-btn" class="button" style="margin-top:16px;"><?php esc_html_e("Changer l'image d'avatar", 'supersede-css-jlg'); ?></button>
+            <button id="ssc-glow-upload-btn" class="button ssc-mt-200"><?php esc_html_e("Changer l'image d'avatar", 'supersede-css-jlg'); ?></button>
 
-             <h4 style="margin-top:16px;"><?php esc_html_e("Comment l'utiliser ?", 'supersede-css-jlg'); ?></h4>
+             <h4 class="ssc-mt-200"><?php esc_html_e("Comment l'utiliser ?", 'supersede-css-jlg'); ?></h4>
              <p class="description"><?php printf(wp_kses_post(__("Une fois le preset enregistré et appliqué, demandez à vos rédacteurs d'ajouter la classe %s au conteneur (la `div`) de leur image.", 'supersede-css-jlg')), '<code id="ssc-glow-how-to-use-class">.avatar-glow-blue</code>'); ?></p>
              <pre id="ssc-glow-css-output" class="ssc-code"></pre>
         </div>

--- a/supersede-css-jlg-enhanced/views/grid-editor.php
+++ b/supersede-css-jlg-enhanced/views/grid-editor.php
@@ -6,30 +6,30 @@ if (!defined('ABSPATH')) {
 <div class="ssc-app ssc-fullwidth">
     <h2><?php esc_html_e('📏 Visual Grid Editor', 'supersede-css-jlg'); ?></h2>
     <p><?php esc_html_e('Construisez des mises en page CSS Grid de manière intuitive, sans écrire de code.', 'supersede-css-jlg'); ?></p>
-    <div class="ssc-two" style="align-items: flex-start;">
+    <div class="ssc-two ssc-align-start">
         <div class="ssc-pane">
             <h3><?php esc_html_e('Paramètres de la Grille', 'supersede-css-jlg'); ?></h3>
 
-            <label><strong><?php esc_html_e('Nombre de colonnes', 'supersede-css-jlg'); ?></strong></label>
+            <label class="ssc-field-label"><?php esc_html_e('Nombre de colonnes', 'supersede-css-jlg'); ?></label>
             <input type="range" id="ssc-grid-cols" min="1" max="12" value="3" step="1">
             <span id="ssc-grid-cols-val"><?php echo esc_html__('3', 'supersede-css-jlg'); ?></span>
 
-            <label style="margin-top:16px; display:block;"><strong><?php esc_html_e('Espacement (gap) en pixels', 'supersede-css-jlg'); ?></strong></label>
+            <label class="ssc-field-label ssc-mt-200"><?php esc_html_e('Espacement (gap) en pixels', 'supersede-css-jlg'); ?></label>
             <input type="range" id="ssc-grid-gap" min="0" max="100" value="16" step="1">
             <span id="ssc-grid-gap-val"><?php echo esc_html__('16px', 'supersede-css-jlg'); ?></span>
 
-            <div class="ssc-actions" style="margin-top:24px; border-top: 1px solid var(--ssc-border); padding-top: 16px;">
+            <div class="ssc-actions ssc-divider-top">
                 <button id="ssc-grid-apply" class="button button-primary"><?php esc_html_e('Appliquer', 'supersede-css-jlg'); ?></button>
                 <button id="ssc-grid-copy" class="button"><?php esc_html_e('Copier CSS', 'supersede-css-jlg'); ?></button>
             </div>
 
-            <h3 style="margin-top:24px;"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
+            <h3 class="ssc-mt-300"><?php esc_html_e('Code CSS Généré', 'supersede-css-jlg'); ?></h3>
             <p class="description"><?php printf(wp_kses_post(__('Appliquez la classe %s à votre conteneur.', 'supersede-css-jlg')), '<code>.ssc-grid-container</code>'); ?></p>
             <pre id="ssc-grid-css" class="ssc-code"></pre>
         </div>
         <div class="ssc-pane">
             <h3><?php esc_html_e('Aperçu en Direct', 'supersede-css-jlg'); ?></h3>
-            <div id="ssc-grid-preview" style="display:grid; border:1px dashed var(--ssc-border); padding:10px; border-radius:8px;">
+            <div id="ssc-grid-preview" class="ssc-preview-surface ssc-preview-surface--dashed ssc-preview-surface--grid">
                 <!-- Les éléments de la grille seront générés par JS -->
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a shared foundation stylesheet with color, typography, spacing and preview utility tokens
- refactor core admin and UX styles to rely on the design tokens and updated helpers
- replace inline admin styles in key views (Grid, Animation, Avatar Glow) with the new utilities and register the stylesheet in loaders and diagnostics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e43318a6e4832eae1f93c4261d54f9