### PR TITLE
Fix MySQL grant syntax in CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Prepare database
         run: |
           mysql -h 127.0.0.1 -uroot -proot -e "CREATE DATABASE IF NOT EXISTS wordpress_test;"
-          mysql -h 127.0.0.1 -uroot -proot -e "GRANT ALL PRIVILEGES ON wordpress_test.* TO 'wp'@'%' IDENTIFIED BY 'password';"
+          mysql -h 127.0.0.1 -uroot -proot -e "CREATE USER IF NOT EXISTS 'wp'@'%' IDENTIFIED BY 'password';"
+          mysql -h 127.0.0.1 -uroot -proot -e "GRANT ALL PRIVILEGES ON wordpress_test.* TO 'wp'@'%';"
 
       - name: Run PHPUnit
         working-directory: supersede-css-jlg-enhanced


### PR DESCRIPTION
## Summary
- create the wp database user separately from granting privileges to support MySQL 8

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e441c3ab24832ebcd17c91084a83a6