### PR TITLE
Handle unchanged CSS saves and harden cache invalidation

### DIFF
--- a/supersede-css-jlg-enhanced/src/Infra/Rest/CssController.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Rest/CssController.php
@@ -135,6 +135,18 @@ final class CssController extends BaseController
         }
 
         $responsePayload = ['ok' => true];
+        $isUnchanged = ($css_to_store === $existing_css);
+
+        if ($isUnchanged) {
+            $responsePayload['unchanged'] = true;
+
+            if ($option_name === 'ssc_tokens_css') {
+                $responsePayload['tokens'] = TokenRegistry::getRegistry();
+                $responsePayload['css'] = $existing_css;
+            }
+
+            return new WP_REST_Response($responsePayload, 200);
+        }
 
         if ($option_name === 'ssc_tokens_css') {
             $tokens = TokenRegistry::convertCssToRegistry($css_to_store);

--- a/supersede-css-jlg-enhanced/tests/Infra/CssCacheInvalidationHooksTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/CssCacheInvalidationHooksTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+final class CssCacheInvalidationHooksTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        delete_option('ssc_css_cache');
+        delete_option('ssc_css_cache_meta');
+        delete_option('ssc_active_css');
+        delete_option('ssc_tokens_css');
+        delete_option('ssc_tokens_registry');
+        delete_option('ssc_css_desktop');
+        delete_option('ssc_css_tablet');
+        delete_option('ssc_css_mobile');
+    }
+
+    private function primeCache(): void
+    {
+        update_option('ssc_css_cache', 'cached', false);
+        update_option('ssc_css_cache_meta', ['version' => '1'], false);
+    }
+
+    public function test_cache_is_invalidated_when_managed_option_is_updated(): void
+    {
+        $this->primeCache();
+
+        update_option('ssc_active_css', 'body {color:red;}', false);
+
+        $this->assertFalse(get_option('ssc_css_cache'));
+        $this->assertFalse(get_option('ssc_css_cache_meta'));
+    }
+
+    public function test_cache_is_not_touched_for_unrelated_options(): void
+    {
+        $this->primeCache();
+
+        update_option('ssc_unrelated_option', 'value', false);
+
+        $this->assertSame('cached', get_option('ssc_css_cache'));
+        $this->assertSame(['version' => '1'], get_option('ssc_css_cache_meta'));
+    }
+
+    public function test_cache_is_invalidated_when_managed_option_is_deleted(): void
+    {
+        update_option('ssc_active_css', 'body {color:red;}', false);
+        $this->primeCache();
+
+        delete_option('ssc_active_css');
+
+        $this->assertFalse(get_option('ssc_css_cache'));
+        $this->assertFalse(get_option('ssc_css_cache_meta'));
+    }
+}


### PR DESCRIPTION
## Summary
- treat save-css REST requests as no-ops when the sanitized payload matches stored CSS so clients receive an `unchanged` flag and no redundant work occurs
- automatically purge the inline CSS cache when any managed Supersede CSS option changes to keep front-end output in sync
- cover the new cache invalidation hooks with dedicated unit tests to prevent regressions

## Testing
- `vendor/bin/phpunit` *(fails: WordPress test suite cannot reach the database server in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e448139b98832ebca608e266c39912