### PR TITLE
Improve design token factorization and documentation

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -91,11 +91,10 @@
     .ssc-two { grid-template-columns: 1fr; }
     .ssc-filter { flex:1 1 140px; }
 }
+
+/* Surface primitives for panes/panels live in foundation.css */
 .ssc-pane,
 .ssc-panel {
-    background: var(--ssc-card);
-    border: 1px solid var(--ssc-border);
-    border-radius: var(--ssc-radius-md);
     padding: var(--ssc-space-md);
 }
 

--- a/supersede-css-jlg-enhanced/assets/css/foundation.css
+++ b/supersede-css-jlg-enhanced/assets/css/foundation.css
@@ -1,3 +1,12 @@
+/**
+ * Supersede CSS foundation
+ * ------------------------
+ * This file centralises design tokens, primitives and low-level utilities that
+ * are shared across the admin screens. The goal is to keep higher level
+ * stylesheets focused on layout or feature specific rules while delegating
+ * anything reusable here.
+ */
+
 :root {
     /* Color palette */
     --ssc-bg: #f8fafc;
@@ -31,6 +40,15 @@
     --ssc-font-weight-semibold: 600;
     --ssc-font-weight-bold: 700;
 
+    /* Step-based typography aliases used across older screens */
+    --ssc-font-size-100: var(--ssc-font-size-xs);
+    --ssc-font-size-200: var(--ssc-font-size-sm);
+    --ssc-font-size-300: var(--ssc-font-size-md);
+    --ssc-font-size-400: 1.25rem;  /* 20px */
+    --ssc-font-size-500: 1.5rem;   /* 24px */
+    --ssc-font-size-600: 1.875rem; /* 30px */
+    --ssc-line-height-base: var(--ssc-line-height-default);
+
     /* Spacing scale */
     --ssc-space-050: 0.25rem;  /* 4px */
     --ssc-space-075: 0.375rem; /* 6px */
@@ -41,6 +59,17 @@
     --ssc-space-300: 1.5rem;   /* 24px */
     --ssc-space-400: 2rem;     /* 32px */
     --ssc-space-500: 2.5rem;   /* 40px */
+
+    /* Spacing aliases (t-shirt scale) */
+    --ssc-space-3xs: var(--ssc-space-050);
+    --ssc-space-2xs: var(--ssc-space-075);
+    --ssc-space-xs: var(--ssc-space-100);
+    --ssc-space-sm: var(--ssc-space-150);
+    --ssc-space-md: var(--ssc-space-200);
+    --ssc-space-lg: var(--ssc-space-250);
+    --ssc-space-xl: var(--ssc-space-300);
+    --ssc-space-2xl: var(--ssc-space-400);
+    --ssc-space-3xl: var(--ssc-space-500);
 
     /* Radii & elevation */
     --ssc-radius-sm: 6px;
@@ -68,25 +97,38 @@
     --ssc-focus-ring: rgba(165, 180, 252, 0.22);
 }
 
-/* Spacing utilities */
-.ssc-mt-050 { margin-top: var(--ssc-space-050); }
-.ssc-mt-075 { margin-top: var(--ssc-space-075); }
-.ssc-mt-100 { margin-top: var(--ssc-space-100); }
-.ssc-mt-150 { margin-top: var(--ssc-space-150); }
-.ssc-mt-200 { margin-top: var(--ssc-space-200); }
-.ssc-mt-250 { margin-top: var(--ssc-space-250); }
-.ssc-mt-300 { margin-top: var(--ssc-space-300); }
-.ssc-mt-400 { margin-top: var(--ssc-space-400); }
-.ssc-mb-200 { margin-bottom: var(--ssc-space-200); }
-.ssc-pt-200 { padding-top: var(--ssc-space-200); }
+/* Surface primitives ----------------------------------------------------- */
+/* Use .ssc-surface on new containers to reuse these shared styles. */
+
+:where(.ssc-surface, .ssc-pane, .ssc-panel, .ssc-preview-surface) {
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+}
+
+:where(.ssc-surface, .ssc-pane, .ssc-panel) {
+    border-radius: var(--ssc-radius-md);
+    padding: var(--ssc-space-md);
+}
+
+/* Spacing utilities ------------------------------------------------------ */
+.ssc-mt-050 { margin-top: var(--ssc-space-3xs); }
+.ssc-mt-075 { margin-top: var(--ssc-space-2xs); }
+.ssc-mt-100 { margin-top: var(--ssc-space-xs); }
+.ssc-mt-150 { margin-top: var(--ssc-space-sm); }
+.ssc-mt-200 { margin-top: var(--ssc-space-md); }
+.ssc-mt-250 { margin-top: var(--ssc-space-lg); }
+.ssc-mt-300 { margin-top: var(--ssc-space-xl); }
+.ssc-mt-400 { margin-top: var(--ssc-space-2xl); }
+.ssc-mb-200 { margin-bottom: var(--ssc-space-md); }
+.ssc-pt-200 { padding-top: var(--ssc-space-md); }
 
 /* Layout helpers */
 .ssc-align-start { align-items: flex-start; }
-.ssc-stack { display: flex; flex-direction: column; gap: var(--ssc-space-150); }
-.ssc-stack-lg { gap: var(--ssc-space-200); }
+.ssc-stack { display: flex; flex-direction: column; gap: var(--ssc-space-sm); }
+.ssc-stack-lg { gap: var(--ssc-space-md); }
 .ssc-divider-top {
-    margin-top: var(--ssc-space-300);
-    padding-top: var(--ssc-space-200);
+    margin-top: var(--ssc-space-xl);
+    padding-top: var(--ssc-space-md);
     border-top: 1px solid var(--ssc-border);
 }
 .ssc-hidden { display: none; }
@@ -94,20 +136,19 @@
 
 /* Preview helpers */
 .ssc-preview-surface {
-    border: 1px solid var(--ssc-border);
     border-radius: var(--ssc-radius-lg);
-    padding: var(--ssc-space-150);
+    padding: var(--ssc-space-sm);
     background: var(--ssc-card);
 }
 .ssc-preview-surface--dashed { border-style: dashed; }
-.ssc-preview-surface--grid { display: grid; gap: var(--ssc-space-100); }
+.ssc-preview-surface--grid { display: grid; gap: var(--ssc-space-xs); }
 .ssc-preview-area {
     display: grid;
     place-items: center;
     min-height: 200px;
     border: 1px solid var(--ssc-border);
     border-radius: var(--ssc-radius-lg);
-    padding: var(--ssc-space-150);
+    padding: var(--ssc-space-sm);
     background: var(--ssc-card);
     transition: background 0.3s ease;
 }
@@ -133,7 +174,7 @@
 .ssc-preview-box--wide {
     width: 200px;
     height: 120px;
-    margin: var(--ssc-space-300) auto;
+    margin: var(--ssc-space-xl) auto;
     display: grid;
     place-items: center;
     border: 1px solid var(--ssc-border);
@@ -146,10 +187,10 @@
 .ssc-field-label {
     display: block;
     font-weight: var(--ssc-font-weight-semibold);
-    margin-bottom: var(--ssc-space-050);
+    margin-bottom: var(--ssc-space-3xs);
     color: var(--ssc-muted);
 }
-.ssc-field-group { display: flex; flex-wrap: wrap; gap: var(--ssc-space-100); }
+.ssc-field-group { display: flex; flex-wrap: wrap; gap: var(--ssc-space-xs); }
 .ssc-avatar-preview-frame {
     width: 128px;
     height: 128px;
@@ -182,8 +223,8 @@
 .ssc-badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--ssc-space-050);
-    padding: 2px var(--ssc-space-075);
+    gap: var(--ssc-space-3xs);
+    padding: 2px var(--ssc-space-2xs);
     border-radius: var(--ssc-radius-pill);
     border: 1px solid var(--ssc-border);
     font-size: var(--ssc-font-size-xs);

--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -1,53 +1,8 @@
 :root {
-    --ssc-bg: #f8fafc;
-    --ssc-card: #ffffff;
-    --ssc-border: #e5e7eb;
-    --ssc-text: #0f172a;
-    --ssc-muted: #64748b;
-    --ssc-accent: #4f46e5;
-
-    /* Typographic scale */
-    --ssc-font-family-base: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-    --ssc-font-size-100: 0.75rem;  /* 12px */
-    --ssc-font-size-200: 0.875rem; /* 14px */
-    --ssc-font-size-300: 1rem;     /* 16px */
-    --ssc-font-size-400: 1.25rem;  /* 20px */
-    --ssc-font-size-500: 1.5rem;   /* 24px */
-    --ssc-font-size-600: 1.875rem; /* 30px */
-    --ssc-font-weight-regular: 400;
-    --ssc-font-weight-medium: 500;
-    --ssc-font-weight-semibold: 600;
-    --ssc-font-weight-bold: 700;
-    --ssc-line-height-tight: 1.2;
-    --ssc-line-height-snug: 1.35;
-    --ssc-line-height-base: 1.5;
-    --ssc-line-height-relaxed: 1.65;
-
-    /* Spacing scale */
-    --ssc-space-3xs: 0.25rem;  /* 4px */
-    --ssc-space-2xs: 0.375rem; /* 6px */
-    --ssc-space-xs: 0.5rem;    /* 8px */
-    --ssc-space-sm: 0.75rem;   /* 12px */
-    --ssc-space-md: 1rem;      /* 16px */
-    --ssc-space-lg: 1.5rem;    /* 24px */
-    --ssc-space-xl: 2rem;      /* 32px */
-    --ssc-space-2xl: 2.5rem;   /* 40px */
-
-    /* Radii */
+    /* Keep slightly rounder corners for the immersive UX layout */
     --ssc-radius-sm: 8px;
     --ssc-radius-md: 12px;
     --ssc-radius-lg: 16px;
-}
-
-/* Thème sombre avec contraste encore amélioré */
-.ssc-dark:root,
-.ssc-dark {
-    --ssc-bg: #030712;
-    --ssc-card: #111827;
-    --ssc-border: #374151;
-    --ssc-text: #e5e7eb;
-    --ssc-muted: #d1d5db;
-    --ssc-accent: #a5b4fc;
 }
 
 .ssc-shell {

--- a/supersede-css-jlg-enhanced/docs/STYLING-GUIDE.md
+++ b/supersede-css-jlg-enhanced/docs/STYLING-GUIDE.md
@@ -1,0 +1,57 @@
+# Guide de factorisation des styles
+
+Ce document complète `assets/css/foundation.css` et explique comment utiliser les tokens, primitives et utilitaires mis à disposition par le design system de Supersede CSS.
+
+## 1. Design tokens
+
+Tous les tokens de base sont définis dans `foundation.css` au niveau de `:root`. Ils couvrent :
+
+- **Couleurs** (`--ssc-bg`, `--ssc-card`, `--ssc-accent`, etc.)
+- **Typographie** (famille, graisses, échelles `--ssc-font-size-xs` → `--ssc-font-size-2xl`)
+- **Espacements** (`--ssc-space-050` → `--ssc-space-500`)
+- **Rayons & ombres**
+
+Pour garantir la compatibilité avec les anciens écrans, des alias ont été ajoutés :
+
+- `--ssc-font-size-100` → `--ssc-font-size-600` répliquent l'ancienne numérotation par pas de 100.
+- `--ssc-space-3xs` → `--ssc-space-3xl` répliquent les espacements "t-shirt" (3xs, 2xs, xs, etc.).
+- `--ssc-line-height-base` pointe sur `--ssc-line-height-default` pour les mises en page historiques.
+
+> **Bonnes pratiques :** privilégiez les tokens `xs/sm/md/...` pour les nouveaux écrans. Les alias par incréments (`100`, `200`, etc.) doivent uniquement servir à maintenir du code existant.
+
+## 2. Primitives de surface
+
+Les panneaux, cartes et surfaces éditoriales partagent désormais les mêmes styles via le sélecteur :
+
+```css
+:where(.ssc-surface, .ssc-pane, .ssc-panel, .ssc-preview-surface) {
+    background: var(--ssc-card);
+    border: 1px solid var(--ssc-border);
+}
+```
+
+- `.ssc-pane` et `.ssc-panel` héritent automatiquement du rayon `--ssc-radius-md` et d'un padding `--ssc-space-md`.
+- `.ssc-preview-surface` conserve son rayon spécifique (`--ssc-radius-lg`) mais mutualise le fond et la bordure.
+
+Lorsque vous créez une nouvelle carte, utilisez idéalement l'une de ces classes ou ajoutez `.ssc-surface` pour profiter des mêmes tokens.
+
+## 3. Utilitaires d'espacement
+
+Les utilitaires `.ssc-mt-*`, `.ssc-mb-*` et `.ssc-pt-*` sont maintenant documentés dans `foundation.css`. Ils s'appuient sur l'échelle "t-shirt" (`--ssc-space-sm`, `--ssc-space-lg`, etc.) pour une meilleure lisibilité. Exemple :
+
+- `.ssc-mt-150` → `margin-top: var(--ssc-space-sm);`
+- `.ssc-mt-400` → `margin-top: var(--ssc-space-2xl);`
+
+N'hésitez pas à créer un nouvel utilitaire uniquement si l'espacement n'existe pas déjà dans cette grille.
+
+## 4. Thème sombre
+
+Le thème sombre continue de s'activer via `.ssc-dark`. Les tokens définis dans `foundation.css` couvrent la majorité des besoins. Évitez de redéfinir couleurs et contrastes directement dans les vues : surchargez plutôt les tokens au besoin.
+
+## 5. Rayons spécifiques à l'UX immersif
+
+Les écrans immersifs (`ux.css`) conservent des rayons plus généreux. Le fichier redéfinit uniquement `--ssc-radius-sm`, `--ssc-radius-md` et `--ssc-radius-lg`, tout en réutilisant le reste des tokens centralisés. Si un autre contexte nécessite des rayons différents, créez une portée (`:root` scoped) similaire au lieu de dupliquer tout le bloc de tokens.
+
+---
+
+En cas de doute, consultez `foundation.css` : chaque section est commentée et les tokens sont regroupés par type pour faciliter la découverte. Toute nouvelle règle générique doit être envisagée dans ce fichier avant d'être implémentée ailleurs.


### PR DESCRIPTION
## Summary
- centralize legacy typography and spacing aliases inside `foundation.css`
- introduce shared surface primitives and rely on them from the admin panels
- document the token scales and utilities in a new styling guide and slim `ux.css` overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e53ee3ee00832ea4eb8ab27ab79cc5