### PR TITLE
feat: restyle admin UI with Radix-inspired theme

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -120,7 +120,18 @@
     align-items: center;
     flex-wrap: wrap;
 }
-.ssc-code { background:#0f172a; color:#e5e7eb; border-radius:8px; padding:12px; overflow:auto; font-family: monospace; font-size: 13px; line-height: 1.6; }
+.ssc-code {
+    background: color-mix(in srgb, var(--ssc-text) 14%, var(--ssc-card) 86%);
+    color: color-mix(in srgb, var(--ssc-text) 92%, var(--ssc-card) 8%);
+    border-radius: var(--ssc-radius-md);
+    border: 1px solid var(--ssc-border);
+    padding: 12px;
+    overflow: auto;
+    font-family: monospace;
+    font-size: 13px;
+    line-height: 1.6;
+    box-shadow: inset 0 1px 0 var(--ssc-border-subtle);
+}
 .ssc-list {
     list-style: none;
     padding: 0;
@@ -137,15 +148,45 @@
     justify-content: space-between;
     align-items: center;
 }
-.ssc-health-badge{display:inline-block;margin-left:8px;padding:2px 8px;border-radius:999px;border:1px solid #e5e7eb}.ssc-health-badge.ok{background:#ecfdf5;color:#065f46}.ssc-health-badge.warn{background:#fffbeb;color:#92400e}.ssc-health-badge.err{background:#fef2f2;color:#991b1b}
+.ssc-health-badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: var(--ssc-radius-pill);
+    border: 1px solid var(--ssc-border);
+    background: var(--ssc-accent-soft);
+    color: var(--ssc-muted);
+    font-weight: var(--ssc-font-weight-medium);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    font-size: var(--ssc-font-size-xs);
+}
+
+.ssc-health-badge.ok {
+    background: color-mix(in srgb, var(--ssc-success) 16%, transparent);
+    color: color-mix(in srgb, var(--ssc-success) 65%, var(--ssc-text) 35%);
+    border-color: color-mix(in srgb, var(--ssc-success) 30%, var(--ssc-border));
+}
+
+.ssc-health-badge.warn {
+    background: color-mix(in srgb, var(--ssc-warning) 16%, transparent);
+    color: color-mix(in srgb, var(--ssc-warning) 65%, var(--ssc-text) 35%);
+    border-color: color-mix(in srgb, var(--ssc-warning) 30%, var(--ssc-border));
+}
+
+.ssc-health-badge.err {
+    background: color-mix(in srgb, var(--ssc-danger) 16%, transparent);
+    color: color-mix(in srgb, var(--ssc-danger) 65%, var(--ssc-text) 35%);
+    border-color: color-mix(in srgb, var(--ssc-danger) 30%, var(--ssc-border));
+}
 
 /* Style for Danger Zone */
 .ssc-danger-zone {
-    background-color: color-mix(in srgb, var(--ssc-danger) 12%, #fff 88%);
+    background-color: color-mix(in srgb, var(--ssc-danger) 12%, var(--ssc-card) 88%);
     border-color: color-mix(in srgb, var(--ssc-danger) 55%, transparent);
 }
 .ssc-danger-zone h2 { color: var(--ssc-danger); }
-.ssc-danger-zone p { color: color-mix(in srgb, var(--ssc-danger) 70%, #111 30%); }
+.ssc-danger-zone p { color: color-mix(in srgb, var(--ssc-danger) 70%, var(--ssc-text) 30%); }
 
 .ssc-dark .ssc-danger-zone {
     background-color: color-mix(in srgb, var(--ssc-danger) 35%, transparent);
@@ -168,11 +209,15 @@
     margin-bottom: var(--ssc-space-md);
     padding: var(--ssc-space-xs) calc(var(--ssc-space-xs) + 4px);
     border-radius: var(--ssc-radius-sm);
-    background: rgba(15, 23, 42, 0.04);
+    background: color-mix(in srgb, var(--ssc-accent-soft) 16%, transparent);
     border: 1px solid var(--ssc-border);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
-.ssc-filter-bar.is-active { border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.1); }
+.ssc-filter-bar.is-active {
+    border-color: color-mix(in srgb, var(--ssc-accent) 45%, var(--ssc-border));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--ssc-accent) 15%, transparent);
+    background: color-mix(in srgb, var(--ssc-accent-soft) 30%, transparent);
+}
 .ssc-filter { min-width:140px; }
 .ssc-filter label { font-weight:var(--ssc-font-weight-semibold); display:block; margin-bottom:var(--ssc-space-050); color:var(--ssc-muted); }
 .ssc-filter input,
@@ -181,8 +226,24 @@
 .ssc-revision-diff { margin-top:var(--ssc-space-lg); border-top:1px solid var(--ssc-border); padding-top:var(--ssc-space-md); }
 .ssc-revision-diff h3 { margin-top:0; }
 .ssc-diff-controls { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
-.ssc-diff-output { margin-top:var(--ssc-space-md); padding:var(--ssc-space-md); border:1px dashed var(--ssc-border); border-radius:var(--ssc-radius-md); min-height:120px; background:rgba(15,23,42,0.02); color:var(--ssc-muted); font-family:monospace; white-space:pre-wrap; overflow:auto; }
-.ssc-diff-output.has-diff { border-style:solid; background:#0f172a; color:#e5e7eb; }
+.ssc-diff-output {
+    margin-top: var(--ssc-space-md);
+    padding: var(--ssc-space-md);
+    border: 1px dashed var(--ssc-border);
+    border-radius: var(--ssc-radius-md);
+    min-height: 120px;
+    background: color-mix(in srgb, var(--ssc-text) 6%, transparent);
+    color: var(--ssc-muted);
+    font-family: monospace;
+    white-space: pre-wrap;
+    overflow: auto;
+}
+.ssc-diff-output.has-diff {
+    border-style: solid;
+    background: color-mix(in srgb, var(--ssc-text) 14%, var(--ssc-card) 86%);
+    color: color-mix(in srgb, var(--ssc-text) 92%, var(--ssc-card) 8%);
+    box-shadow: inset 0 1px 0 var(--ssc-border-subtle);
+}
 .ssc-diff-output table.diff { width:100%; font-size:13px; }
 .ssc-diff-output table.diff td { font-family:monospace; }
 
@@ -511,7 +572,7 @@ body[class*="page_supersede-css-jlg"] .ssc-layout .ssc-main-content {
 
 .ssc-metric-badge--primary {
     background: color-mix(in srgb, var(--ssc-accent) 20%, transparent);
-    color: color-mix(in srgb, var(--ssc-accent) 65%, #0f172a 35%);
+    color: color-mix(in srgb, var(--ssc-accent) 65%, var(--ssc-text) 35%);
 }
 
 .ssc-metric-sample {

--- a/supersede-css-jlg-enhanced/assets/css/foundation.css
+++ b/supersede-css-jlg-enhanced/assets/css/foundation.css
@@ -8,20 +8,26 @@
  */
 
 :root {
-    /* Color palette */
-    --ssc-bg: #f8fafc;
+    /* Color palette inspired by Radix UI */
+    --ssc-bg: #fdfcfe;
     --ssc-card: #ffffff;
-    --ssc-border: #e5e7eb;
-    --ssc-text: #0f172a;
-    --ssc-muted: #64748b;
-    --ssc-accent: #4f46e5;
-    --ssc-accent-soft: color-mix(in srgb, var(--ssc-accent) 18%, #ffffff 82%);
-    --ssc-success: #15803d;
-    --ssc-danger: #b91c1c;
-    --ssc-warning: #92400e;
-    --ssc-info: #2563eb;
-    --ssc-surface-muted: color-mix(in srgb, var(--ssc-card) 92%, var(--ssc-border) 8%);
-    --ssc-focus-ring: rgba(79, 70, 229, 0.18);
+    --ssc-surface-muted: #f5f2ff;
+    --ssc-border: #e4e1f4;
+    --ssc-border-subtle: #edeafd;
+    --ssc-border-strong: #c9c4e8;
+    --ssc-text: #1f1d2b;
+    --ssc-text-contrast: #ffffff;
+    --ssc-muted: #6f6c8f;
+    --ssc-muted-soft: color-mix(in srgb, var(--ssc-muted) 22%, var(--ssc-card) 78%);
+    --ssc-accent: #6e56cf;
+    --ssc-accent-hover: #5b3fc4;
+    --ssc-accent-active: #4a32b6;
+    --ssc-accent-soft: #f4f0ff;
+    --ssc-success: #30a46c;
+    --ssc-danger: #e54d2e;
+    --ssc-warning: #f9a826;
+    --ssc-info: #3e63dd;
+    --ssc-focus-ring: rgba(94, 82, 175, 0.28);
 
     /* Typography scale */
     --ssc-font-family-base: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
@@ -73,36 +79,45 @@
 
     /* Radii & elevation */
     --ssc-radius-sm: 6px;
-    --ssc-radius-md: 10px;
-    --ssc-radius-lg: 12px;
+    --ssc-radius-md: 12px;
+    --ssc-radius-lg: 16px;
     --ssc-radius-pill: 999px;
-    --ssc-shadow-soft: 0 16px 32px rgba(15, 23, 42, 0.08);
-    --ssc-shadow-elevated: 0 20px 40px rgba(15, 23, 42, 0.12);
+    --ssc-shadow-soft: 0 24px 55px rgba(45, 32, 89, 0.12);
+    --ssc-shadow-elevated: 0 30px 70px rgba(45, 32, 89, 0.18);
 }
 
 .ssc-dark:root,
 .ssc-dark {
-    --ssc-bg: #030712;
-    --ssc-card: #111827;
-    --ssc-border: #374151;
-    --ssc-text: #e5e7eb;
-    --ssc-muted: #d1d5db;
-    --ssc-accent: #a5b4fc;
-    --ssc-accent-soft: color-mix(in srgb, var(--ssc-accent) 22%, #020617 78%);
-    --ssc-success: #34d399;
-    --ssc-danger: #f87171;
-    --ssc-warning: #f59e0b;
-    --ssc-info: #60a5fa;
-    --ssc-surface-muted: color-mix(in srgb, var(--ssc-card) 86%, var(--ssc-border) 14%);
-    --ssc-focus-ring: rgba(165, 180, 252, 0.22);
+    --ssc-bg: #121019;
+    --ssc-card: #1c162c;
+    --ssc-surface-muted: #1a1327;
+    --ssc-border: #312a45;
+    --ssc-border-subtle: #251d36;
+    --ssc-border-strong: #403558;
+    --ssc-text: #ede9ff;
+    --ssc-text-contrast: #150d24;
+    --ssc-muted: #b8a7e5;
+    --ssc-muted-soft: color-mix(in srgb, var(--ssc-muted) 22%, #1a1327 78%);
+    --ssc-accent: #b1a6ff;
+    --ssc-accent-hover: #c0b6ff;
+    --ssc-accent-active: #d7cbff;
+    --ssc-accent-soft: color-mix(in srgb, var(--ssc-accent) 28%, #0f0d17 72%);
+    --ssc-success: #3dd68c;
+    --ssc-danger: #f16a50;
+    --ssc-warning: #f5b74a;
+    --ssc-info: #6a8af6;
+    --ssc-focus-ring: rgba(177, 166, 255, 0.32);
+    --ssc-shadow-soft: 0 24px 55px rgba(8, 6, 16, 0.65);
+    --ssc-shadow-elevated: 0 34px 80px rgba(12, 9, 24, 0.7);
 }
 
 /* Surface primitives ----------------------------------------------------- */
 /* Use .ssc-surface on new containers to reuse these shared styles. */
 
 :where(.ssc-surface, .ssc-pane, .ssc-panel, .ssc-preview-surface) {
-    background: var(--ssc-card);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--ssc-card) 92%, var(--ssc-surface-muted) 8%), var(--ssc-card));
     border: 1px solid var(--ssc-border);
+    box-shadow: 0 1px 0 var(--ssc-border-subtle), var(--ssc-shadow-soft);
 }
 
 :where(.ssc-surface, .ssc-pane, .ssc-panel) {
@@ -153,7 +168,7 @@
     transition: background 0.3s ease;
 }
 .ssc-preview-area--tall { min-height: 250px; }
-.ssc-preview-area--dark { background: #0b1020; }
+.ssc-preview-area--dark { background: #1c172c; }
 .ssc-preview-box {
     width: 100px;
     height: 100px;
@@ -161,7 +176,7 @@
     background: var(--ssc-accent);
     display: grid;
     place-items: center;
-    color: #fff;
+    color: var(--ssc-text-contrast);
     font-weight: var(--ssc-font-weight-semibold);
 }
 .ssc-preview-box--avatar {
@@ -179,8 +194,9 @@
     place-items: center;
     border: 1px solid var(--ssc-border);
     border-radius: var(--ssc-radius-lg);
-    background: #fff;
+    background: var(--ssc-card);
     transition: all 0.2s ease;
+    box-shadow: var(--ssc-shadow-soft);
 }
 
 /* Form helpers */

--- a/supersede-css-jlg-enhanced/assets/css/utilities.css
+++ b/supersede-css-jlg-enhanced/assets/css/utilities.css
@@ -47,18 +47,20 @@
 #ssc-picker-overlay {
     position: absolute;
     inset: 0;
-    background: rgba(79, 70, 229, 0.2);
+    background: color-mix(in srgb, var(--ssc-accent) 24%, transparent);
     z-index: 9998;
     display: none;
     cursor: crosshair;
+    backdrop-filter: blur(2px);
 }
 
 #ssc-picker-tooltip {
     position: fixed;
-    background: #0f172a;
-    color: white;
+    background: color-mix(in srgb, var(--ssc-text) 80%, var(--ssc-card) 20%);
+    color: var(--ssc-text-contrast);
     padding: 4px 8px;
-    border-radius: 4px;
+    border-radius: 6px;
+    border: 1px solid var(--ssc-border-strong);
     font-size: 12px;
     z-index: 9999;
     white-space: nowrap;

--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -16,10 +16,12 @@
     display: flex;
     align-items: center;
     gap: var(--ssc-space-xs);
-    background: var(--ssc-card);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--ssc-card) 88%, var(--ssc-surface-muted) 12%), var(--ssc-card));
     border-bottom: 1px solid var(--ssc-border);
     padding: var(--ssc-space-xs) var(--ssc-space-md);
     margin: 0;
+    backdrop-filter: blur(18px) saturate(140%);
+    box-shadow: 0 1px 0 var(--ssc-border-subtle);
 }
 
 .ssc-topbar .ssc-title {
@@ -92,13 +94,14 @@ body.ssc-no-scroll {
     top: 69px; /* Ajusté pour l'espace sous la topbar */
     align-self: flex-start;
     width: 220px;
-    background: var(--ssc-card);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--ssc-card) 82%, var(--ssc-surface-muted) 18%), var(--ssc-card));
     border: 1px solid var(--ssc-border);
     border-radius: var(--ssc-radius-md);
     padding: var(--ssc-space-xs);
     display: flex;
     flex-direction: column;
     gap: var(--ssc-space-2xs);
+    box-shadow: var(--ssc-shadow-soft);
 }
 
 .ssc-sidebar a {
@@ -112,14 +115,22 @@ body.ssc-no-scroll {
     border: 1px solid transparent;
     font-size: var(--ssc-font-size-200);
     line-height: var(--ssc-line-height-snug);
+    transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.ssc-sidebar a:hover {
+    background: color-mix(in srgb, var(--ssc-accent-soft) 45%, transparent);
+    border-color: var(--ssc-border-subtle);
+    transform: translateX(2px);
 }
 
 .ssc-sidebar a.active,
 .ssc-sidebar a[aria-current="page"] {
-    background: rgba(165, 180, 252, 0.1);
-    border-color: var(--ssc-border);
+    background: color-mix(in srgb, var(--ssc-accent-soft) 65%, transparent);
+    border-color: color-mix(in srgb, var(--ssc-accent) 35%, var(--ssc-border));
     color: var(--ssc-accent);
     font-weight: var(--ssc-font-weight-semibold);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ssc-accent) 22%, transparent);
 }
 
 .ssc-layout {
@@ -231,7 +242,7 @@ body.ssc-no-scroll {
     display: none;
     align-items: flex-start;
     justify-content: center;
-    background: rgba(2, 6, 23, 0.5);
+    background: color-mix(in srgb, var(--ssc-text) 12%, transparent);
     z-index: 9999;
 }
 
@@ -245,7 +256,7 @@ body.ssc-no-scroll {
     background: var(--ssc-card);
     border: 1px solid var(--ssc-border);
     border-radius: var(--ssc-radius-md);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    box-shadow: var(--ssc-shadow-elevated);
     overflow: hidden;
 }
 
@@ -267,12 +278,13 @@ body.ssc-no-scroll {
 }
 
 #ssc-cmdp li a:hover {
-    background: rgba(165, 180, 252, 0.1);
+    background: color-mix(in srgb, var(--ssc-accent-soft) 45%, transparent);
 }
 
 #ssc-cmdp li a.is-active,
 #ssc-cmdp li a.is-active:hover {
-    background: rgba(165, 180, 252, 0.2);
+    background: color-mix(in srgb, var(--ssc-accent-soft) 70%, transparent);
+    color: var(--ssc-accent);
 }
 
 #ssc-toasts {
@@ -291,7 +303,7 @@ body.ssc-no-scroll {
     border: 1px solid var(--ssc-border);
     border-radius: 10px;
     padding: 10px 12px;
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--ssc-shadow-soft);
     opacity: 0;
     transform: translateY(10px);
     animation: ssc-toast-in 0.3s ease forwards;


### PR DESCRIPTION
## Summary
- refresh the global design tokens with a Radix UI inspired palette, shadows, and radii updates
- modernize navigation, command palette, and toast surfaces with soft gradients and accent-driven interactions
- align admin badges, filters, and diff surfaces with the new theme and token-driven colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54f02da38832e9295c0c23d9a8fa4