### PR TITLE
Improve admin shell accessibility strings

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -277,6 +277,11 @@ body.ssc-no-scroll {
     font-size: var(--ssc-font-size-200);
 }
 
+#ssc-cmdp li a:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--ssc-accent) 65%, transparent);
+    outline-offset: 2px;
+}
+
 #ssc-cmdp li a:hover {
     background: color-mix(in srgb, var(--ssc-accent-soft) 45%, transparent);
 }
@@ -285,6 +290,18 @@ body.ssc-no-scroll {
 #ssc-cmdp li a.is-active:hover {
     background: color-mix(in srgb, var(--ssc-accent-soft) 70%, transparent);
     color: var(--ssc-accent);
+}
+
+#ssc-cmdp .ssc-cmdp-empty {
+    padding: 14px var(--ssc-space-sm);
+    text-align: center;
+    color: var(--ssc-muted);
+    border-bottom: 1px solid var(--ssc-border);
+    font-size: var(--ssc-font-size-200);
+}
+
+#ssc-cmdp .ssc-cmdp-empty:last-child {
+    border-bottom: none;
 }
 
 #ssc-toasts {

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -288,6 +288,11 @@ final class Admin
                 'commandPaletteTitle' => esc_attr__('Supersede CSS command palette', 'supersede-css-jlg'),
                 'commandPaletteSearchPlaceholder' => esc_attr__('Navigate or run an action…', 'supersede-css-jlg'),
                 'commandPaletteSearchLabel' => esc_html__('Command palette search', 'supersede-css-jlg'),
+                'commandPaletteResultsAnnouncement' => esc_html__('%d résultat(s) disponibles.', 'supersede-css-jlg'),
+                'commandPaletteEmptyState' => esc_html__('Aucun résultat ne correspond à votre recherche.', 'supersede-css-jlg'),
+                'mobileMenuShowLabel' => esc_attr__('Afficher le menu', 'supersede-css-jlg'),
+                'mobileMenuHideLabel' => esc_attr__('Masquer le menu', 'supersede-css-jlg'),
+                'mobileMenuToggleSrLabel' => esc_html__('Menu', 'supersede-css-jlg'),
             ],
         ]);
     }

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -310,18 +310,27 @@ class Layout {
                 'supersede-css-jlg-debug-center'   => 'Debug Center',
             ],
         ];
+        $back_to_admin_aria_label = esc_attr__('Retourner sur le tableau de bord WordPress', 'supersede-css-jlg');
+        $back_to_admin_label = esc_html__('WP Admin', 'supersede-css-jlg');
+        $theme_button_label = esc_html__('Thème', 'supersede-css-jlg');
+        $theme_button_aria_label = esc_attr__('Basculer le thème clair ou sombre', 'supersede-css-jlg');
+        $command_button_label = esc_html__('Commande', 'supersede-css-jlg');
+        $command_button_aria_label = esc_attr__('Ouvrir la palette de commandes', 'supersede-css-jlg');
+        $mobile_menu_show_label = esc_attr__('Afficher le menu', 'supersede-css-jlg');
+        $mobile_menu_sr_label = esc_html__('Menu', 'supersede-css-jlg');
+
         ?>
         <div class="ssc-viewport">
             <div class="ssc-shell">
                 <header class="ssc-topbar">
-                <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="Retourner sur le tableau de bord WordPress">
+                <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="<?php echo $back_to_admin_aria_label; ?>">
                     <span class="dashicons dashicons-arrow-left-alt" aria-hidden="true"></span>
-                    <span class="ssc-topbar-label">WP Admin</span>
+                    <span class="ssc-topbar-label"><?php echo $back_to_admin_label; ?></span>
                 </a>
                 <span class="ssc-title">Supersede CSS</span><span class="ssc-spacer"></span>
-                <button type="button" class="button" id="ssc-theme" aria-label="Basculer le thème clair ou sombre" aria-pressed="false">
+                <button type="button" class="button" id="ssc-theme" aria-label="<?php echo $theme_button_aria_label; ?>" aria-pressed="false">
                     <span aria-hidden="true">🌓</span>
-                    <span class="ssc-topbar-label">Thème</span>
+                    <span class="ssc-topbar-label"><?php echo $theme_button_label; ?></span>
                 </button>
                 <button
                     type="button"
@@ -330,14 +339,14 @@ class Layout {
                     aria-expanded="false"
                     aria-controls="ssc-sidebar"
                     aria-haspopup="true"
-                    aria-label="Afficher le menu"
+                    aria-label="<?php echo $mobile_menu_show_label; ?>"
                 >
                     <span class="dashicons dashicons-menu" aria-hidden="true"></span>
-                    <span class="screen-reader-text">Menu</span>
+                    <span class="screen-reader-text"><?php echo $mobile_menu_sr_label; ?></span>
                 </button>
-                <button type="button" class="button button-primary" id="ssc-cmdk" aria-label="Ouvrir la palette de commandes">
+                <button type="button" class="button button-primary" id="ssc-cmdk" aria-label="<?php echo $command_button_aria_label; ?>">
                     <span aria-hidden="true">⌘K</span>
-                    <span class="ssc-topbar-label">Commande</span>
+                    <span class="ssc-topbar-label"><?php echo $command_button_label; ?></span>
                 </button>
             </header>
             <div class="ssc-shell-overlay" hidden></div>


### PR DESCRIPTION
## Summary
- localize top bar controls and mobile menu labels so dynamic aria text respects translations
- enhance the command palette to announce empty results, mark the list as busy, and keep list semantics accessible
- add focus outline styling and empty-state visuals to the palette results for better keyboard UX

## Testing
- npm run test:ui:shell *(fails: Docker is not running in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e551eddec4832e8a8e892ca1323994