### PR TITLE
Improve uninstall cleanup logging and silence REST test warnings

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/AuthorizationTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/AuthorizationTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 use SSC\Infra\Rest\TokensController;
-use WP_REST_Request;
 
 final class AuthorizationTest extends WP_UnitTestCase
 {

--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/CssControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/CssControllerTest.php
@@ -4,8 +4,6 @@ use SSC\Infra\Import\Sanitizer;
 use SSC\Infra\Rest\CssController;
 use SSC\Support\CssSanitizer;
 use SSC\Support\TokenRegistry;
-use WP_REST_Request;
-use WP_REST_Response;
 
 final class CssControllerTest extends WP_UnitTestCase
 {

--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/ImportExportControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/ImportExportControllerTest.php
@@ -3,8 +3,6 @@
 use SSC\Infra\Import\Sanitizer;
 use SSC\Infra\Rest\ImportExportController;
 use SSC\Support\CssSanitizer;
-use WP_REST_Request;
-use WP_REST_Response;
 
 final class ImportExportControllerTest extends WP_UnitTestCase
 {

--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/PresetsControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/PresetsControllerTest.php
@@ -2,8 +2,6 @@
 
 use SSC\Infra\Rest\PresetsController;
 use SSC\Support\CssSanitizer;
-use WP_REST_Request;
-use WP_REST_Response;
 
 final class PresetsControllerTest extends WP_UnitTestCase
 {

--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/SystemControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/SystemControllerTest.php
@@ -2,7 +2,6 @@
 
 use SSC\Infra\Rest\SystemController;
 use SSC\Support\TokenRegistry;
-use WP_REST_Response;
 
 final class SystemControllerTest extends WP_UnitTestCase
 {

--- a/supersede-css-jlg-enhanced/tests/Infra/Rest/TokensControllerTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Rest/TokensControllerTest.php
@@ -2,8 +2,6 @@
 
 use SSC\Infra\Rest\TokensController;
 use SSC\Support\TokenRegistry;
-use WP_REST_Request;
-use WP_REST_Response;
 
 final class TokensControllerTest extends WP_UnitTestCase
 {

--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -28,6 +28,10 @@ $ssc_options_to_delete = [
 // Supprime les options du site courant
 foreach ($ssc_options_to_delete as $option_name) {
     delete_option($option_name);
+
+    if (isset($GLOBALS['ssc_deleted_options']) && is_array($GLOBALS['ssc_deleted_options'])) {
+        $GLOBALS['ssc_deleted_options'][] = $option_name;
+    }
 }
 
 if (!is_multisite()) {
@@ -50,6 +54,10 @@ foreach ($site_ids as $site_id) {
 
     foreach ($ssc_options_to_delete as $option_name) {
         delete_option($option_name);
+
+        if (isset($GLOBALS['ssc_deleted_options']) && is_array($GLOBALS['ssc_deleted_options'])) {
+            $GLOBALS['ssc_deleted_options'][] = $option_name;
+        }
     }
 
     restore_current_blog();


### PR DESCRIPTION
## Summary
- record deletions performed during uninstall so the uninstall cleanup test can observe them
- drop redundant WP REST `use` statements from REST controller tests to eliminate runtime warnings during PHPUnit runs

## Testing
- vendor/bin/phpunit --testsuite Infra --filter UninstallCleanupTest *(fails: WordPress test suite cannot connect to its database in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5618d48b4832eb05e1a6f2d6515b7