### PR TITLE
Add WP-CLI command for CSS cache management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supersede CSS JLG (Enhanced)
 
-**Version:** 10.0.6
+**Version:** 10.0.7
 **Author:** JLG (Enhanced by AI)
 
 Supersede CSS JLG (Enhanced) est une boîte à outils visuelle pour accélérer la création de styles WordPress. Elle combine des éditeurs temps réel, des générateurs de presets et un moteur de tokens pour produire un CSS cohérent sans écrire de code à la main.
@@ -13,6 +13,7 @@ Supersede CSS JLG (Enhanced) est une boîte à outils visuelle pour accélérer 
 - [Architecture du plugin](#architecture-du-plugin)
 - [Commandes npm utiles](#commandes-npm-utiles)
 - [Tests](#tests)
+- [Commandes WP-CLI](#commandes-wp-cli)
 - [Hooks](#hooks)
 - [Licence](#licence)
 - [Contribuer](#contribuer)
@@ -161,6 +162,17 @@ npx playwright test
 ```
 
 La commande démarre automatiquement `wp-env`, exécute les tests, puis arrête et détruit les conteneurs. Vous pouvez aussi gérer l’environnement manuellement avec `npm run env:start`, `npm run env:stop` et `npm run env:destroy`.
+
+## Commandes WP-CLI
+
+Administrez le cache CSS Supersede depuis vos scripts de déploiement ou lors d’une maintenance ponctuelle :
+
+```bash
+wp ssc css flush           # Vide le cache inline généré par le plugin
+wp ssc css flush --rebuild # Vide puis reconstruit immédiatement le cache assaini
+```
+
+L’option `--rebuild` force l’exécution de `ssc_get_cached_css()` après invalidation afin de recalculer un CSS cohérent avec les options `ssc_active_css` et `ssc_tokens_css`.
 
 ## Hooks
 

--- a/supersede-css-jlg-enhanced/readme.txt
+++ b/supersede-css-jlg-enhanced/readme.txt
@@ -1,5 +1,5 @@
 === Supersede CSS JLG (Enhanced) ===
-Stable tag: 10.0.6
+Stable tag: 10.0.7
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -16,6 +16,10 @@ Cette version a été entièrement refactorisée pour améliorer la stabilité, 
 * Scénario manuel : ajouter un bloc CSS contenant `background-image: url("data:image/svg+xml;base64,PHN2Zy4uLg==");` puis un autre avec `background-image: url("javascript:alert(1)");`. Après sauvegarde, vérifier que la première propriété est intacte tandis que la seconde est supprimée du CSS généré dans l'interface.
 
 == Changelog ==
+= 10.0.7 =
+* NEW: Commande `wp ssc css flush` pour vider manuellement le cache CSS généré par le plugin.
+* IMPROVEMENT: Option `--rebuild` pour régénérer immédiatement un CSS assaini lors des déploiements automatisés.
+
 = 10.0.6 =
 * NEW: Module "CSS Performance Analyzer" pour visualiser le poids total, les doublons de sélecteurs et recevoir des recommandations d’optimisation.
 * IMPROVEMENT: Ajout de cartes de métriques et de callouts cohérents avec la nouvelle fondation design.

--- a/supersede-css-jlg-enhanced/src/Infra/Cli/CssCacheCommand.php
+++ b/supersede-css-jlg-enhanced/src/Infra/Cli/CssCacheCommand.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace SSC\Infra\Cli;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class CssCacheCommand
+{
+    /**
+     * Registers the command output through WP-CLI if available.
+     *
+     * @param array<int, string> $args      Positional arguments (unused).
+     * @param array<string, mixed> $assocArgs Associative arguments coming from WP-CLI.
+     */
+    public function __invoke(array $args, array $assocArgs): void
+    {
+        $result = $this->execute($assocArgs);
+
+        if (!class_exists('\\WP_CLI')) {
+            return;
+        }
+
+        $method = $result['status'] === 'success' ? 'success' : 'warning';
+        \WP_CLI::$method($result['message']);
+    }
+
+    /**
+     * @param array<string, mixed> $assocArgs
+     *
+     * @return array{
+     *     status: 'success'|'warning',
+     *     message: string,
+     *     had_cache: bool,
+     *     rebuilt: bool,
+     *     size: int
+     * }
+     */
+    public function execute(array $assocArgs = []): array
+    {
+        $rebuild = $this->shouldRebuild($assocArgs);
+        $hadCache = $this->hasCache();
+
+        if (function_exists('ssc_invalidate_css_cache')) {
+            ssc_invalidate_css_cache();
+        }
+
+        $rebuilt = false;
+        $size = 0;
+
+        if ($rebuild && function_exists('ssc_get_cached_css')) {
+            $css = ssc_get_cached_css();
+            $rebuilt = $css !== '';
+            $size = strlen($css);
+        }
+
+        $messages = [];
+        $messages[] = $hadCache ? 'Cache CSS vidé.' : 'Cache CSS déjà vide.';
+
+        if ($rebuild) {
+            $messages[] = $rebuilt
+                ? sprintf('Nouveau cache généré (%d caractères).', $size)
+                : 'Aucun CSS actif à mettre en cache.';
+        } else {
+            $messages[] = 'Utilisez --rebuild pour régénérer le cache immédiatement.';
+        }
+
+        return [
+            'status' => $rebuild && !$rebuilt ? 'warning' : 'success',
+            'message' => implode(' ', $messages),
+            'had_cache' => $hadCache,
+            'rebuilt' => $rebuilt,
+            'size' => $size,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $assocArgs
+     */
+    private function shouldRebuild(array $assocArgs): bool
+    {
+        if (!array_key_exists('rebuild', $assocArgs)) {
+            return false;
+        }
+
+        $value = $assocArgs['rebuild'];
+
+        if ($value === null) {
+            return true;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            if ($normalized === '') {
+                return true;
+            }
+
+            if (in_array($normalized, ['0', 'false', 'no', 'off'], true)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return (bool) $value;
+    }
+
+    private function hasCache(): bool
+    {
+        $cache = get_option('ssc_css_cache', false);
+
+        return is_string($cache) && trim($cache) !== '';
+    }
+}

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Supersede CSS JLG (Enhanced)
  * Description: Boîte à outils visuelle pour CSS avec presets, éditeurs live, tokens, et un centre de débogage amélioré.
- * Version: 10.0.6
+ * Version: 10.0.7
  * Requires PHP: 8.0
  * Author: JLG (Enhanced by AI)
  * Text Domain: supersede-css-jlg
@@ -11,9 +11,10 @@
 if (!defined('ABSPATH')) { exit; }
 
 use SSC\Blocks\TokenPreview;
+use SSC\Infra\Cli\CssCacheCommand;
 use SSC\Support\CssSanitizer;
 
-define('SSC_VERSION','10.0.6');
+define('SSC_VERSION','10.0.7');
 define('SSC_PLUGIN_FILE', __FILE__);
 define('SSC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 // CORRECTION : Déclaration de l'URL plus robuste pour éviter les erreurs 404.
@@ -196,6 +197,16 @@ add_action('enqueue_block_editor_assets', 'ssc_enqueue_block_editor_inline_css')
 add_action('plugins_loaded', function() {
     load_plugin_textdomain('supersede-css-jlg', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
+
+if (defined('WP_CLI') && WP_CLI) {
+    add_action('cli_init', static function (): void {
+        if (!class_exists('\\WP_CLI')) {
+            return;
+        }
+
+        \WP_CLI::add_command('ssc css flush', new CssCacheCommand());
+    });
+}
 
 if (!function_exists('ssc_register_blocks')) {
     function ssc_register_blocks(): void

--- a/supersede-css-jlg-enhanced/tests/Infra/Cli/CssCacheCommandTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/Cli/CssCacheCommandTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+use SSC\Infra\Cli\CssCacheCommand;
+
+final class CssCacheCommandTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        delete_option('ssc_css_cache');
+        delete_option('ssc_css_cache_meta');
+        delete_option('ssc_active_css');
+        delete_option('ssc_tokens_css');
+    }
+
+    public function test_execute_without_existing_cache_does_not_rebuild(): void
+    {
+        $command = new CssCacheCommand();
+
+        $result = $command->execute();
+
+        $this->assertSame('success', $result['status']);
+        $this->assertFalse($result['had_cache']);
+        $this->assertFalse($result['rebuilt']);
+        $this->assertSame(0, $result['size']);
+        $this->assertFalse(get_option('ssc_css_cache'));
+        $this->assertFalse(get_option('ssc_css_cache_meta'));
+        $this->assertStringContainsString('--rebuild', $result['message']);
+    }
+
+    public function test_execute_with_rebuild_regenerates_cache(): void
+    {
+        update_option('ssc_active_css', 'body { color: red; }', false);
+
+        $command = new CssCacheCommand();
+
+        $result = $command->execute(['rebuild' => true]);
+
+        $expectedCss = 'body {color:red}';
+
+        $this->assertSame('success', $result['status']);
+        $this->assertFalse($result['had_cache']);
+        $this->assertTrue($result['rebuilt']);
+        $this->assertSame(strlen($expectedCss), $result['size']);
+        $this->assertSame($expectedCss, get_option('ssc_css_cache'));
+        $this->assertSame(['version' => SSC_VERSION], get_option('ssc_css_cache_meta'));
+        $this->assertStringContainsString('Nouveau cache généré', $result['message']);
+    }
+
+    public function test_execute_with_existing_cache_and_rebuild_replaces_value(): void
+    {
+        update_option('ssc_css_cache', 'old-cache', false);
+        update_option('ssc_css_cache_meta', ['version' => '1.0'], false);
+        update_option('ssc_active_css', '.card { color: blue; }', false);
+
+        $command = new CssCacheCommand();
+
+        $result = $command->execute(['rebuild' => 'yes']);
+
+        $expectedCss = '.card {color:blue}';
+
+        $this->assertSame('success', $result['status']);
+        $this->assertTrue($result['had_cache']);
+        $this->assertTrue($result['rebuilt']);
+        $this->assertSame($expectedCss, get_option('ssc_css_cache'));
+        $this->assertSame(['version' => SSC_VERSION], get_option('ssc_css_cache_meta'));
+        $this->assertStringContainsString('Cache CSS vidé.', $result['message']);
+    }
+
+    public function test_execute_with_rebuild_and_no_css_returns_warning(): void
+    {
+        $command = new CssCacheCommand();
+
+        $result = $command->execute(['rebuild' => 'false']);
+
+        $this->assertSame('success', $result['status']);
+        $this->assertFalse($result['rebuilt']);
+
+        $result = $command->execute(['rebuild' => true]);
+
+        $this->assertSame('warning', $result['status']);
+        $this->assertFalse($result['rebuilt']);
+        $this->assertSame(0, $result['size']);
+        $this->assertStringContainsString('Aucun CSS actif', $result['message']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a WP-CLI command to flush the Supersede CSS cache with an optional --rebuild flag
- register the command during cli_init, bump the plugin version, and document the usage in README files
- cover the new behaviour with PHPUnit tests exercising cache invalidation and rebuild scenarios

## Testing
- composer install --no-interaction --no-progress
- vendor/bin/phpunit *(fails: WordPress test suite cannot connect to the MySQL server in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e568340400832ea34403b03a8179b3