### PR TITLE
Fix animation preview class assignment

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/animation-studio.js
+++ b/supersede-css-jlg-enhanced/assets/js/animation-studio.js
@@ -67,7 +67,7 @@
         $target.replaceWith($clone);
 
         const $newTarget = $(selector);
-        $newTarget.addClass(['ssc-animated', preset.name]);
+        $newTarget.addClass('ssc-animated ' + preset.name);
     }
 
     function generateAnimationCSS() {


### PR DESCRIPTION
## Summary
- ensure animation preview targets receive both animation classes by passing a space-separated string to `addClass`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5798b100c832e80d428f4ecf961f4