### PR TITLE
Improve dashboard layout and accessibility

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/dashboard.css
+++ b/supersede-css-jlg-enhanced/assets/css/dashboard.css
@@ -1,0 +1,184 @@
+.ssc-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-lg);
+}
+
+.ssc-dashboard-intro {
+    max-width: 760px;
+    color: var(--ssc-muted);
+    font-size: var(--ssc-font-size-200);
+    line-height: var(--ssc-line-height-relaxed);
+}
+
+.ssc-dashboard-grid {
+    display: grid;
+    gap: var(--ssc-space-md);
+}
+
+@media (min-width: 960px) {
+    .ssc-dashboard-grid {
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+    }
+
+    .ssc-dashboard-card:nth-child(1) {
+        grid-column: span 5;
+    }
+
+    .ssc-dashboard-card:nth-child(2) {
+        grid-column: span 3;
+    }
+
+    .ssc-dashboard-card:nth-child(3) {
+        grid-column: span 4;
+    }
+}
+
+.ssc-dashboard-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-sm);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--ssc-card) 90%, var(--ssc-surface-muted) 10%), var(--ssc-card));
+    border: 1px solid var(--ssc-border);
+    border-radius: var(--ssc-radius-lg);
+    padding: var(--ssc-space-lg);
+    box-shadow: 0 1px 0 var(--ssc-border-subtle), var(--ssc-shadow-soft);
+    min-height: 100%;
+}
+
+.ssc-dashboard-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-2xs);
+}
+
+.ssc-dashboard-card__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ssc-space-2xs);
+    padding: 0 var(--ssc-space-xs);
+    height: 28px;
+    border-radius: var(--ssc-radius-pill);
+    background: color-mix(in srgb, var(--ssc-info) 18%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ssc-info) 30%, var(--ssc-border));
+    color: color-mix(in srgb, var(--ssc-info) 70%, var(--ssc-text) 30%);
+    font-size: var(--ssc-font-size-xs);
+    font-weight: var(--ssc-font-weight-semibold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.ssc-dashboard-card p {
+    margin: 0;
+    color: var(--ssc-muted);
+    line-height: var(--ssc-line-height-relaxed);
+}
+
+.ssc-dashboard-actions {
+    display: grid;
+    gap: var(--ssc-space-xs);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ssc-dashboard-actions li {
+    margin: 0;
+}
+
+.ssc-dashboard-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    text-decoration: none;
+    font-weight: var(--ssc-font-weight-semibold);
+    letter-spacing: 0.01em;
+}
+
+.ssc-dashboard-action .dashicons {
+    font-size: 16px;
+    opacity: 0.7;
+}
+
+.ssc-dashboard-action:focus-visible {
+    box-shadow: 0 0 0 3px var(--ssc-focus-ring);
+}
+
+.ssc-dashboard-note {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--ssc-space-xs);
+    padding: var(--ssc-space-xs) var(--ssc-space-sm);
+    border-radius: var(--ssc-radius-md);
+    border: 1px dashed var(--ssc-border);
+    background: color-mix(in srgb, var(--ssc-muted) 12%, transparent);
+    color: var(--ssc-muted);
+    font-size: var(--ssc-font-size-200);
+}
+
+.ssc-dashboard-note .dashicons {
+    color: var(--ssc-accent);
+    margin-top: 2px;
+}
+
+.ssc-dashboard-steps {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ssc-space-sm);
+    counter-reset: ssc-step;
+}
+
+.ssc-dashboard-steps > li {
+    counter-increment: ssc-step;
+    background: color-mix(in srgb, var(--ssc-accent-soft) 50%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ssc-accent) 25%, var(--ssc-border));
+    border-radius: var(--ssc-radius-md);
+    padding: var(--ssc-space-sm);
+    list-style: none;
+    position: relative;
+}
+
+.ssc-dashboard-steps > li::before {
+    content: counter(ssc-step);
+    position: absolute;
+    top: var(--ssc-space-sm);
+    left: var(--ssc-space-sm);
+    width: 28px;
+    height: 28px;
+    border-radius: var(--ssc-radius-pill);
+    background: var(--ssc-accent);
+    color: var(--ssc-text-contrast);
+    display: grid;
+    place-items: center;
+    font-weight: var(--ssc-font-weight-semibold);
+    font-size: var(--ssc-font-size-sm);
+}
+
+.ssc-dashboard-steps > li > *:first-child {
+    margin-left: calc(var(--ssc-space-sm) + 32px);
+}
+
+.ssc-dashboard-steps strong {
+    display: inline-block;
+    color: var(--ssc-text);
+    font-weight: var(--ssc-font-weight-semibold);
+}
+
+.ssc-dashboard-steps em {
+    display: block;
+    margin-top: var(--ssc-space-2xs);
+    color: var(--ssc-muted);
+}
+
+.ssc-dashboard-steps code {
+    font-size: var(--ssc-font-size-200);
+}
+
+@media (max-width: 782px) {
+    .ssc-dashboard-card {
+        padding: var(--ssc-space-md);
+    }
+}

--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -9,6 +9,27 @@
     position: relative;
 }
 
+.ssc-skip-link {
+    position: absolute;
+    left: var(--ssc-space-md);
+    top: var(--ssc-space-2xs);
+    z-index: 2000;
+    padding: var(--ssc-space-2xs) var(--ssc-space-sm);
+    background: var(--ssc-card);
+    color: var(--ssc-text);
+    border-radius: var(--ssc-radius-sm);
+    border: 2px solid var(--ssc-accent);
+    font-weight: var(--ssc-font-weight-semibold);
+    text-decoration: none;
+    transform: translateY(-150%);
+    transition: transform 0.2s ease;
+}
+
+.ssc-skip-link:focus-visible {
+    transform: translateY(0);
+    box-shadow: 0 0 0 3px var(--ssc-focus-ring);
+}
+
 .ssc-topbar {
     position: sticky;
     top: 0;
@@ -56,6 +77,11 @@
     display: inline-flex;
     align-items: center;
     gap: var(--ssc-space-2xs);
+}
+
+.ssc-topbar .button:focus-visible {
+    outline: 3px solid var(--ssc-focus-ring);
+    outline-offset: 2px;
 }
 
 .ssc-mobile-menu-toggle {
@@ -131,6 +157,13 @@ body.ssc-no-scroll {
     color: var(--ssc-accent);
     font-weight: var(--ssc-font-weight-semibold);
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ssc-accent) 22%, transparent);
+}
+
+.ssc-sidebar a:focus-visible {
+    outline: 3px solid var(--ssc-focus-ring);
+    outline-offset: 2px;
+    background: color-mix(in srgb, var(--ssc-accent-soft) 65%, transparent);
+    border-color: color-mix(in srgb, var(--ssc-accent) 35%, var(--ssc-border));
 }
 
 .ssc-layout {
@@ -260,6 +293,25 @@ body.ssc-no-scroll {
     overflow: hidden;
 }
 
+#ssc-cmdp .ssc-cmdp-search {
+    width: 100%;
+    padding: var(--ssc-space-sm) var(--ssc-space-md);
+    border: 0;
+    border-bottom: 1px solid var(--ssc-border);
+    font-size: var(--ssc-font-size-300);
+    background: var(--ssc-card);
+    color: var(--ssc-text);
+}
+
+#ssc-cmdp .ssc-cmdp-search:focus-visible {
+    outline: 3px solid var(--ssc-focus-ring);
+    outline-offset: -2px;
+}
+
+#ssc-cmdp .ssc-cmdp-search::placeholder {
+    color: var(--ssc-muted);
+}
+
 #ssc-cmdp ul {
     max-height: 50vh;
     overflow: auto;
@@ -278,8 +330,9 @@ body.ssc-no-scroll {
 }
 
 #ssc-cmdp li a:focus-visible {
-    outline: 2px solid color-mix(in srgb, var(--ssc-accent) 65%, transparent);
-    outline-offset: 2px;
+    outline: 3px solid var(--ssc-focus-ring);
+    outline-offset: -2px;
+    background: color-mix(in srgb, var(--ssc-accent-soft) 65%, transparent);
 }
 
 #ssc-cmdp li a:hover {

--- a/supersede-css-jlg-enhanced/assets/js/ux.js
+++ b/supersede-css-jlg-enhanced/assets/js/ux.js
@@ -389,7 +389,17 @@
             <div id="ssc-cmdp" role="dialog" aria-modal="true" aria-hidden="true" aria-label="${commandPaletteTitle}" tabindex="-1">
                 <div class="panel" role="document">
                     <label for="ssc-cmdp-search" class="screen-reader-text">${commandPaletteSearchLabel}</label>
-                    <input type="text" id="ssc-cmdp-search" placeholder="${commandPaletteSearchPlaceholder}" style="width: 100%; padding: 12px; border: none; border-bottom: 1px solid var(--ssc-border); font-size: 16px;" autocomplete="off" autocapitalize="none" spellcheck="false" aria-controls="ssc-cmdp-results" aria-autocomplete="list">
+                    <input
+                        type="search"
+                        id="ssc-cmdp-search"
+                        class="ssc-cmdp-search"
+                        placeholder="${commandPaletteSearchPlaceholder}"
+                        autocomplete="off"
+                        autocapitalize="none"
+                        spellcheck="false"
+                        aria-controls="ssc-cmdp-results"
+                        aria-autocomplete="list"
+                    >
                     <ul id="ssc-cmdp-results" role="listbox" aria-live="polite"></ul>
                 </div>
             </div>`;

--- a/supersede-css-jlg-enhanced/src/Admin/Admin.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Admin.php
@@ -236,6 +236,7 @@ final class Admin
         ];
 
         $styles_by_page = [
+            $this->slug                     => ['dashboard'],
             $this->slug.'-utilities'        => ['utilities'],
             $this->slug.'-layout-builder'   => ['page-layout-builder'],
             $this->slug.'-tokens'           => ['tokens'],

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -322,6 +322,7 @@ class Layout {
         ?>
         <div class="ssc-viewport">
             <div class="ssc-shell">
+                <a class="ssc-skip-link" href="#ssc-main-content"><?php echo esc_html__('Passer au contenu principal', 'supersede-css-jlg'); ?></a>
                 <header class="ssc-topbar">
                 <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="<?php echo $back_to_admin_aria_label; ?>">
                     <span class="dashicons dashicons-arrow-left-alt" aria-hidden="true"></span>
@@ -370,7 +371,7 @@ class Layout {
                     <?php endforeach; ?>
                     </nav>
                 </aside>
-                <main class="ssc-main-content">
+                <main class="ssc-main-content" id="ssc-main-content" tabindex="-1">
                     <?php echo wp_kses( $page_content, self::allowed_tags() ); ?>
                 </main>
             </div>

--- a/supersede-css-jlg-enhanced/views/dashboard.php
+++ b/supersede-css-jlg-enhanced/views/dashboard.php
@@ -4,46 +4,85 @@ if (!defined('ABSPATH')) {
 }
 /** @var array{utilities?:string,tokens?:string,avatar?:string,debug_center?:string} $quick_links */
 ?>
-<div class="ssc-wrap wrap">
+<div class="ssc-app ssc-dashboard">
     <h1><?php echo esc_html__('Supersede CSS — Dashboard', 'supersede-css-jlg'); ?></h1>
-    <p class="description"><?php echo esc_html__('Bienvenue ! Utilisez le menu ou la palette de commande (⌘/Ctrl + K) pour naviguer.', 'supersede-css-jlg'); ?></p>
+    <p class="ssc-dashboard-intro"><?php echo esc_html__('Bienvenue ! Utilisez le menu latéral ou la palette de commande (⌘/Ctrl + K) pour accéder à vos studios créatifs, ou choisissez un raccourci ci-dessous.', 'supersede-css-jlg'); ?></p>
 
-    <div class="ssc-panel" style="margin-top: 24px;">
-        <h2><?php echo esc_html__('Accès Rapide', 'supersede-css-jlg'); ?></h2>
-        <p>
-            <a class="button button-primary" href="<?php echo esc_url($quick_links['utilities'] ?? '#'); ?>"><?php esc_html_e('Éditeur CSS', 'supersede-css-jlg'); ?></a>
-            <a class="button" href="<?php echo esc_url($quick_links['tokens'] ?? '#'); ?>"><?php esc_html_e('Tokens Manager', 'supersede-css-jlg'); ?></a>
-            <a class="button" href="<?php echo esc_url($quick_links['avatar'] ?? '#'); ?>"><?php esc_html_e('Avatar Glow', 'supersede-css-jlg'); ?></a>
-            <a class="button" href="<?php echo esc_url($quick_links['debug_center'] ?? '#'); ?>"><?php esc_html_e('Centre de Débogage', 'supersede-css-jlg'); ?></a>
-        </p>
-    </div>
+    <div class="ssc-dashboard-grid">
+        <section class="ssc-dashboard-card" aria-labelledby="ssc-dashboard-quick-title">
+            <div class="ssc-dashboard-card__header">
+                <h2 id="ssc-dashboard-quick-title"><?php echo esc_html__('Accès rapide', 'supersede-css-jlg'); ?></h2>
+                <p><?php echo esc_html__('Lancez directement les modules les plus utilisés sans quitter le tableau de bord.', 'supersede-css-jlg'); ?></p>
+            </div>
+            <ul class="ssc-dashboard-actions" role="list">
+                <li>
+                    <a class="button button-primary ssc-dashboard-action" href="<?php echo esc_url($quick_links['utilities'] ?? '#'); ?>">
+                        <span><?php esc_html_e('Éditeur CSS responsive', 'supersede-css-jlg'); ?></span>
+                        <span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+                    </a>
+                </li>
+                <li>
+                    <a class="button ssc-dashboard-action" href="<?php echo esc_url($quick_links['tokens'] ?? '#'); ?>">
+                        <span><?php esc_html_e('Tokens Manager', 'supersede-css-jlg'); ?></span>
+                        <span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+                    </a>
+                </li>
+                <li>
+                    <a class="button ssc-dashboard-action" href="<?php echo esc_url($quick_links['avatar'] ?? '#'); ?>">
+                        <span><?php esc_html_e('Avatar Glow Presets', 'supersede-css-jlg'); ?></span>
+                        <span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+                    </a>
+                </li>
+                <li>
+                    <a class="button ssc-dashboard-action" href="<?php echo esc_url($quick_links['debug_center'] ?? '#'); ?>">
+                        <span><?php esc_html_e('Debug Center & Diagnostics', 'supersede-css-jlg'); ?></span>
+                        <span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+                    </a>
+                </li>
+            </ul>
+            <p class="ssc-dashboard-note">
+                <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
+                <span><?php echo esc_html__('Besoin d’un autre module ? Utilisez la palette de commande ou la navigation pour accéder aux générateurs d’effets, layouts et animations.', 'supersede-css-jlg'); ?></span>
+            </p>
+        </section>
 
-    <div class="ssc-panel" style="margin-top: 24px;">
-        <h2><?php esc_html_e('🧩 Nouveau : Bloc « Token Preview »', 'supersede-css-jlg'); ?></h2>
-        <p><?php echo esc_html__('Dans l’éditeur de blocs WordPress, insérez le bloc « Supersede › Token Preview » pour visualiser instantanément les tokens et presets activés (couleurs, espacements, etc.).', 'supersede-css-jlg'); ?></p>
-        <p><?php echo esc_html__('Le bloc injecte automatiquement les mêmes styles que le frontal : plus besoin de copier les classes manuellement, il suffit de placer le bloc à l’endroit voulu pour partager votre bibliothèque de tokens avec l’équipe éditoriale.', 'supersede-css-jlg'); ?></p>
-    </div>
+        <section class="ssc-dashboard-card" aria-labelledby="ssc-dashboard-token-preview">
+            <div class="ssc-dashboard-card__header">
+                <span class="ssc-dashboard-card__eyebrow"><?php echo esc_html__('Nouveauté', 'supersede-css-jlg'); ?></span>
+                <h2 id="ssc-dashboard-token-preview"><?php esc_html_e('Bloc « Token Preview »', 'supersede-css-jlg'); ?></h2>
+            </div>
+            <p><?php echo esc_html__('Dans l’éditeur de blocs WordPress, insérez « Supersede › Token Preview » pour afficher la bibliothèque de tokens (couleurs, espacements, effets) avec les mêmes styles que sur le front.', 'supersede-css-jlg'); ?></p>
+            <p><?php echo esc_html__('Le bloc se met à jour automatiquement quand vous appliquez ou modifiez un preset. Idéal pour partager visuellement votre design system avec l’équipe éditoriale.', 'supersede-css-jlg'); ?></p>
+        </section>
 
-    <div class="ssc-panel" style="margin-top: 24px;">
-        <h2><?php esc_html_e('💡 Comprendre le Workflow (Créer et Activer un Style)', 'supersede-css-jlg'); ?></h2>
-        <p><?php printf(wp_kses_post(__('Pour utiliser efficacement les modules créatifs comme %1$s ou %2$s, suivez ces 3 étapes logiques :', 'supersede-css-jlg')), '<strong>Avatar Glow</strong>', '<strong>Preset Designer</strong>'); ?></p>
-        <ol style="list-style-type: decimal; margin-left: 20px;">
-            <li style="margin-bottom: 15px;">
-                <strong><?php esc_html_e('ÉTAPE 1 : CRÉER ET ENREGISTRER', 'supersede-css-jlg'); ?></strong><br>
-                <?php printf(wp_kses_post(__('Allez dans un module (ex: Avatar Glow). Personnalisez votre effet (couleurs, vitesse...). Donnez-lui un nom et une classe CSS unique (ex: %1$s), puis cliquez sur %2$s.', 'supersede-css-jlg')), '<code>.aura-speciale</code>', '<strong>"Enregistrer le Preset"</strong>'); ?><br>
-                <em><?php printf(wp_kses_post(__('➡️ %1$s La "recette" de votre effet est sauvegardée dans la bibliothèque du plugin. Elle n\'est pas encore visible sur le site.', 'supersede-css-jlg')), '<strong>Résultat :</strong>'); ?></em>
-            </li>
-            <li style="margin-bottom: 15px;">
-                <strong><?php esc_html_e('ÉTAPE 2 : APPLIQUER (Activer)', 'supersede-css-jlg'); ?></strong><br>
-                <?php printf(wp_kses_post(__('Avec votre preset fraîchement enregistré toujours sélectionné, cliquez sur %s.', 'supersede-css-jlg')), '<strong>"Appliquer sur le site"</strong>'); ?><br>
-                <em><?php printf(wp_kses_post(__('➡️ %1$s Le code CSS de votre effet est ajouté à la feuille de style globale de votre site. L\'effet est maintenant "disponible" et prêt à être utilisé.', 'supersede-css-jlg')), '<strong>Résultat :</strong>'); ?></em>
-            </li>
-            <li style="margin-bottom: 15px;">
-                <strong><?php esc_html_e('ÉTAPE 3 : UTILISER', 'supersede-css-jlg'); ?></strong><br>
-                <?php printf(wp_kses_post(__('Vos rédacteurs peuvent maintenant aller dans l\'éditeur de page ou d\'article, sélectionner le conteneur d\'une image et lui ajouter la classe CSS que vous avez définie (%s) dans les réglages avancés du bloc.', 'supersede-css-jlg')), '<code>aura-speciale</code>'); ?><br>
-                <em><?php printf(wp_kses_post(__('➡️ %1$s L\'effet d\'aura apparaît sur l\'image sur le site public !', 'supersede-css-jlg')), '<strong>Résultat :</strong>'); ?></em>
-            </li>
-        </ol>
-        <p><?php printf(wp_kses_post(__('En résumé : %1$s un preset pour le sauvegarder pour le futur, et %2$s pour le rendre utilisable dès maintenant.', 'supersede-css-jlg')), '<strong>On enregistre</strong>', '<strong>on l\'applique</strong>'); ?></p>
+        <section class="ssc-dashboard-card" aria-labelledby="ssc-dashboard-workflow">
+            <div class="ssc-dashboard-card__header">
+                <h2 id="ssc-dashboard-workflow"><?php esc_html_e('Workflow pour activer un style', 'supersede-css-jlg'); ?></h2>
+                <p><?php printf(wp_kses_post(__('Suivez ces trois étapes avec %1$s ou %2$s pour publier rapidement vos créations.', 'supersede-css-jlg')), '<strong>Avatar Glow</strong>', '<strong>Preset Designer</strong>'); ?></p>
+            </div>
+            <ol class="ssc-dashboard-steps">
+                <li>
+                    <div>
+                        <strong><?php esc_html_e('Étape 1 : Créer et enregistrer', 'supersede-css-jlg'); ?></strong>
+                        <p><?php printf(wp_kses_post(__('Ouvrez un module, personnalisez l’effet puis nommez-le avec une classe unique (ex.&nbsp;%1$s) avant de cliquer sur %2$s.', 'supersede-css-jlg')), '<code>.aura-speciale</code>', '<strong>'.esc_html__('« Enregistrer le preset »', 'supersede-css-jlg').'</strong>'); ?></p>
+                        <em><?php echo esc_html__('Résultat : la recette est stockée dans votre bibliothèque Supersede, mais rien n’est encore injecté sur le site.', 'supersede-css-jlg'); ?></em>
+                    </div>
+                </li>
+                <li>
+                    <div>
+                        <strong><?php esc_html_e('Étape 2 : Appliquer (activer)', 'supersede-css-jlg'); ?></strong>
+                        <p><?php printf(wp_kses_post(__('Avec le preset sélectionné, cliquez sur %s pour ajouter le CSS au front office.', 'supersede-css-jlg')), '<strong>'.esc_html__('« Appliquer sur le site »', 'supersede-css-jlg').'</strong>'); ?></p>
+                        <em><?php echo esc_html__('Résultat : la classe devient disponible pour toute l’équipe sur WordPress.', 'supersede-css-jlg'); ?></em>
+                    </div>
+                </li>
+                <li>
+                    <div>
+                        <strong><?php esc_html_e('Étape 3 : Utiliser sur vos contenus', 'supersede-css-jlg'); ?></strong>
+                        <p><?php printf(wp_kses_post(__('Dans l’éditeur de blocs, vos rédacteurs ajoutent la classe (%s) sur l’élément ciblé pour voir l’effet publié.', 'supersede-css-jlg')), '<code>aura-speciale</code>'); ?></p>
+                        <em><?php echo esc_html__('Résultat : l’animation ou le style est visible sur le site public instantanément.', 'supersede-css-jlg'); ?></em>
+                    </div>
+                </li>
+            </ol>
+        </section>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- refactor the Supersede dashboard into accessible cards with contextual quick actions and workflow guidance
- introduce a dedicated dashboard stylesheet plus skip links and focus-visible styles to support WCAG 2.2 expectations
- update the command palette markup and asset loading to remove inline styles and load the new CSS bundle

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e578f4d3bc832ea5b627865453dce8