### PR TITLE
Ensure uninstall routine tracks cache option deletions

### DIFF
--- a/supersede-css-jlg-enhanced/uninstall.php
+++ b/supersede-css-jlg-enhanced/uninstall.php
@@ -7,18 +7,19 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 if (!function_exists('ssc_record_deleted_option')) {
     function ssc_record_deleted_option(string $option_name): void
     {
-        $recorded = false;
-
-        if (isset($GLOBALS['ssc_deleted_options']) && is_array($GLOBALS['ssc_deleted_options'])) {
-            $GLOBALS['ssc_deleted_options'][] = $option_name;
-            $recorded = true;
+        if (!isset($GLOBALS['ssc_deleted_options']) || !is_array($GLOBALS['ssc_deleted_options'])) {
+            $GLOBALS['ssc_deleted_options'] = [];
         }
+
+        $GLOBALS['ssc_deleted_options'][] = $option_name;
 
         global $ssc_deleted_options;
 
-        if (!$recorded && isset($ssc_deleted_options) && is_array($ssc_deleted_options)) {
-            $ssc_deleted_options[] = $option_name;
+        if (!is_array($ssc_deleted_options ?? null)) {
+            $ssc_deleted_options = [];
         }
+
+        $ssc_deleted_options[] = $option_name;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the uninstall helper always initialises the deletion log before recording option keys

## Testing
- php tests/Infra/UninstallCleanupTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e587eb27a4832ea1bf78e5fbabcdac