### PR TITLE
Fix apostrophe handling in visual effects JS strings

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/visual-effects.js
+++ b/supersede-css-jlg-enhanced/assets/js/visual-effects.js
@@ -1210,7 +1210,7 @@ ${reduceMotionBlock}`;
 
             if (type === 'gradient') {
                 if (!latestGradientResult) {
-                    const errorToast = __('Corrigez les erreurs du dégradé avant d'appliquer.', 'supersede-css-jlg');
+                    const errorToast = __("Corrigez les erreurs du dégradé avant d'appliquer.", 'supersede-css-jlg');
                     window.sscToast(errorToast, { politeness: 'assertive' });
                     return;
                 }
@@ -1222,7 +1222,7 @@ ${reduceMotionBlock}`;
                 return;
             }
 
-            const errorMessage = __('Échec de l'enregistrement du fond animé.', 'supersede-css-jlg');
+            const errorMessage = __("Échec de l'enregistrement du fond animé.", 'supersede-css-jlg');
             const originalText = $applyButton.text();
 
             applyBusy = true;


### PR DESCRIPTION
## Summary
- escape apostrophes in translated strings to avoid JavaScript syntax errors
- ensure visual effects controls initialize correctly for ECG and scanline tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e595e2bdc4832e97ea0840ffb25deb