### PR TITLE
Rework topbar layout for better mobile readability

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/ux.css
+++ b/supersede-css-jlg-enhanced/assets/css/ux.css
@@ -37,21 +37,54 @@
     display: flex;
     align-items: center;
     gap: var(--ssc-space-xs);
-    background: linear-gradient(180deg, color-mix(in srgb, var(--ssc-card) 88%, var(--ssc-surface-muted) 12%), var(--ssc-card));
-    border-bottom: 1px solid var(--ssc-border);
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--ssc-card) 94%, var(--ssc-surface-muted) 6%),
+        color-mix(in srgb, var(--ssc-card) 86%, var(--ssc-bg) 14%)
+    );
+    border-bottom: 1px solid color-mix(in srgb, var(--ssc-border) 70%, var(--ssc-border-strong) 30%);
     padding: var(--ssc-space-xs) var(--ssc-space-md);
     margin: 0;
     backdrop-filter: blur(18px) saturate(140%);
-    box-shadow: 0 1px 0 var(--ssc-border-subtle);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.ssc-dark .ssc-topbar {
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--ssc-card) 82%, rgba(15, 11, 28, 0.35)),
+        color-mix(in srgb, var(--ssc-card) 68%, var(--ssc-bg) 32%)
+    );
+    border-bottom-color: color-mix(in srgb, var(--ssc-border-strong) 60%, transparent);
+    box-shadow: 0 10px 32px rgba(10, 8, 20, 0.28);
 }
 
 .ssc-topbar .ssc-title {
     font-weight: var(--ssc-font-weight-bold);
     font-size: var(--ssc-font-size-400);
+    color: var(--ssc-text);
 }
 
-.ssc-topbar .ssc-spacer {
-    flex: 1;
+.ssc-topbar__title {
+    flex: 1 1 auto;
+    display: flex;
+    justify-content: center;
+    text-align: center;
+}
+
+.ssc-topbar__cluster {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ssc-space-xs);
+}
+
+.ssc-topbar__cluster--left {
+    flex: 0 0 auto;
+}
+
+.ssc-topbar__cluster--right {
+    margin-left: auto;
+    flex: 0 0 auto;
 }
 
 .ssc-topbar .ssc-topbar-label {
@@ -73,10 +106,20 @@
     line-height: 1;
 }
 
+
 .ssc-topbar .button {
     display: inline-flex;
     align-items: center;
     gap: var(--ssc-space-2xs);
+    background: color-mix(in srgb, var(--ssc-card) 80%, transparent 20%);
+    border-color: color-mix(in srgb, var(--ssc-border) 80%, var(--ssc-border-strong) 20%);
+    color: var(--ssc-text);
+}
+
+.ssc-dark .ssc-topbar .button {
+    background: color-mix(in srgb, var(--ssc-card) 58%, rgba(16, 12, 35, 0.55));
+    border-color: color-mix(in srgb, var(--ssc-border) 65%, rgba(255, 255, 255, 0.18));
+    color: var(--ssc-text);
 }
 
 .ssc-topbar .button:focus-visible {
@@ -198,13 +241,15 @@ body.ssc-no-scroll {
         row-gap: var(--ssc-space-2xs);
     }
 
-    .ssc-topbar .ssc-title {
-        flex: 1 0 100%;
-        margin-top: var(--ssc-space-2xs);
+    .ssc-topbar__cluster--right {
+        margin-left: auto;
     }
 
-    .ssc-topbar .ssc-spacer {
-        display: none;
+    .ssc-topbar__title {
+        order: 3;
+        flex: 1 0 100%;
+        justify-content: flex-start;
+        margin-top: var(--ssc-space-2xs);
     }
 
     .ssc-mobile-menu-toggle {
@@ -256,6 +301,10 @@ body.ssc-no-scroll {
 }
 
 @media (max-width: 782px) {
+    .ssc-topbar__cluster {
+        gap: var(--ssc-space-2xs);
+    }
+
     .ssc-topbar .ssc-topbar-label {
         display: none;
     }

--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -324,32 +324,38 @@ class Layout {
             <div class="ssc-shell">
                 <a class="ssc-skip-link" href="#ssc-main-content"><?php echo esc_html__('Passer au contenu principal', 'supersede-css-jlg'); ?></a>
                 <header class="ssc-topbar">
-                <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="<?php echo $back_to_admin_aria_label; ?>">
-                    <span class="dashicons dashicons-arrow-left-alt" aria-hidden="true"></span>
-                    <span class="ssc-topbar-label"><?php echo $back_to_admin_label; ?></span>
-                </a>
-                <span class="ssc-title">Supersede CSS</span><span class="ssc-spacer"></span>
-                <button type="button" class="button" id="ssc-theme" aria-label="<?php echo $theme_button_aria_label; ?>" aria-pressed="false">
-                    <span aria-hidden="true">🌓</span>
-                    <span class="ssc-topbar-label"><?php echo $theme_button_label; ?></span>
-                </button>
-                <button
-                    type="button"
-                    class="button ssc-mobile-menu-toggle"
-                    id="ssc-mobile-menu"
-                    aria-expanded="false"
-                    aria-controls="ssc-sidebar"
-                    aria-haspopup="true"
-                    aria-label="<?php echo $mobile_menu_show_label; ?>"
-                >
-                    <span class="dashicons dashicons-menu" aria-hidden="true"></span>
-                    <span class="screen-reader-text"><?php echo $mobile_menu_sr_label; ?></span>
-                </button>
-                <button type="button" class="button button-primary" id="ssc-cmdk" aria-label="<?php echo $command_button_aria_label; ?>">
-                    <span aria-hidden="true">⌘K</span>
-                    <span class="ssc-topbar-label"><?php echo $command_button_label; ?></span>
-                </button>
-            </header>
+                    <div class="ssc-topbar__cluster ssc-topbar__cluster--left">
+                        <a href="<?php echo esc_url(admin_url('index.php')); ?>" class="ssc-back-to-admin button" aria-label="<?php echo $back_to_admin_aria_label; ?>">
+                            <span class="dashicons dashicons-arrow-left-alt" aria-hidden="true"></span>
+                            <span class="ssc-topbar-label"><?php echo $back_to_admin_label; ?></span>
+                        </a>
+                        <button
+                            type="button"
+                            class="button ssc-mobile-menu-toggle"
+                            id="ssc-mobile-menu"
+                            aria-expanded="false"
+                            aria-controls="ssc-sidebar"
+                            aria-haspopup="true"
+                            aria-label="<?php echo $mobile_menu_show_label; ?>"
+                        >
+                            <span class="dashicons dashicons-menu" aria-hidden="true"></span>
+                            <span class="screen-reader-text"><?php echo $mobile_menu_sr_label; ?></span>
+                        </button>
+                    </div>
+                    <div class="ssc-topbar__title">
+                        <span class="ssc-title">Supersede CSS</span>
+                    </div>
+                    <div class="ssc-topbar__cluster ssc-topbar__cluster--right">
+                        <button type="button" class="button" id="ssc-theme" aria-label="<?php echo $theme_button_aria_label; ?>" aria-pressed="false">
+                            <span aria-hidden="true">🌓</span>
+                            <span class="ssc-topbar-label"><?php echo $theme_button_label; ?></span>
+                        </button>
+                        <button type="button" class="button button-primary" id="ssc-cmdk" aria-label="<?php echo $command_button_aria_label; ?>">
+                            <span aria-hidden="true">⌘K</span>
+                            <span class="ssc-topbar-label"><?php echo $command_button_label; ?></span>
+                        </button>
+                    </div>
+                </header>
             <div class="ssc-shell-overlay" hidden></div>
             <div class="ssc-layout">
                 <aside>


### PR DESCRIPTION
## Summary
- restructure the Supersede CSS admin topbar into left, title, and right clusters so the menu toggle stays on the left while the theme and action buttons stay on the right
- refresh the topbar styling to increase contrast and button legibility across light and dark themes
- tune responsive behavior to keep the header readable on mobile breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e596e053c4832e881d314c6407d88c