### PR TITLE
Fix context sanitizer regex escaping

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -192,7 +192,11 @@ final class TokenRegistry
         }
 
         $value = preg_replace('/\s+/', ' ', $value) ?? $value;
-        $value = preg_replace('/[^A-Za-z0-9_\-\s:#\.\[\]=\"\'\\]/', '', $value) ?? $value;
+        $value = preg_replace(
+            "~[^A-Za-z0-9_\\-:#\\.\\[\\]= \"'\\\\]~",
+            '',
+            $value
+        ) ?? $value;
         $value = trim($value);
 
         if ($value === '') {


### PR DESCRIPTION
## Summary
- fix the sanitizeContext whitelist regex so it can include literal brackets and backslashes without compilation warnings
- keep whitespace normalization before applying the whitelist filter

## Testing
- php -l supersede-css-jlg-enhanced/src/Support/TokenRegistry.php

------
https://chatgpt.com/codex/tasks/task_e_68e599266e1c832e854cbb8740c285ff