### PR TITLE
Improve CSS cache invalidation resilience

### DIFF
--- a/supersede-css-jlg-enhanced/tests/Infra/CssCacheInvalidationHooksTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/CssCacheInvalidationHooksTest.php
@@ -6,6 +6,9 @@ final class CssCacheInvalidationHooksTest extends WP_UnitTestCase
     {
         parent::setUp();
 
+        global $ssc_css_runtime_cache;
+
+        $ssc_css_runtime_cache = null;
         delete_option('ssc_css_cache');
         delete_option('ssc_css_cache_meta');
         delete_option('ssc_active_css');
@@ -48,6 +51,26 @@ final class CssCacheInvalidationHooksTest extends WP_UnitTestCase
         $this->primeCache();
 
         delete_option('ssc_active_css');
+
+        $this->assertFalse(get_option('ssc_css_cache'));
+        $this->assertFalse(get_option('ssc_css_cache_meta'));
+    }
+
+    public function test_cache_is_invalidated_when_theme_switches(): void
+    {
+        $this->primeCache();
+
+        do_action('switch_theme');
+
+        $this->assertFalse(get_option('ssc_css_cache'));
+        $this->assertFalse(get_option('ssc_css_cache_meta'));
+    }
+
+    public function test_cache_is_invalidated_when_customizer_saves(): void
+    {
+        $this->primeCache();
+
+        do_action('customize_save_after', null);
 
         $this->assertFalse(get_option('ssc_css_cache'));
         $this->assertFalse(get_option('ssc_css_cache_meta'));

--- a/supersede-css-jlg-enhanced/tests/Infra/CssCacheRuntimeTest.php
+++ b/supersede-css-jlg-enhanced/tests/Infra/CssCacheRuntimeTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+final class CssCacheRuntimeTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $ssc_css_runtime_cache;
+
+        $ssc_css_runtime_cache = null;
+        delete_option('ssc_css_cache');
+        delete_option('ssc_css_cache_meta');
+        delete_option('ssc_active_css');
+        delete_option('ssc_tokens_css');
+    }
+
+    public function test_runtime_cache_short_circuits_option_lookups(): void
+    {
+        update_option('ssc_active_css', 'body { color: red; }', false);
+        update_option('ssc_tokens_css', '', false);
+
+        $first = ssc_get_cached_css();
+        $this->assertStringContainsString('body', $first);
+
+        add_filter('pre_option_ssc_css_cache', [$this, 'failOnOptionAccess']);
+        add_filter('pre_option_ssc_css_cache_meta', [$this, 'failOnOptionAccess']);
+
+        $second = ssc_get_cached_css();
+        $this->assertSame($first, $second);
+
+        remove_filter('pre_option_ssc_css_cache', [$this, 'failOnOptionAccess']);
+        remove_filter('pre_option_ssc_css_cache_meta', [$this, 'failOnOptionAccess']);
+
+        ssc_invalidate_css_cache();
+        update_option('ssc_active_css', 'body { color: blue; }', false);
+
+        $third = ssc_get_cached_css();
+        $this->assertStringContainsString('blue', $third);
+    }
+
+    public function failOnOptionAccess(): void
+    {
+        $this->fail('Runtime cache should prevent option lookups once primed.');
+    }
+}


### PR DESCRIPTION
## Summary
- cache the sanitized CSS inline payload in memory to avoid repeated option lookups during a single request
- ensure cache invalidation also clears the runtime cache and fires when the theme changes or the Customizer saves
- extend PHPUnit coverage for the new runtime cache and invalidation hooks

## Testing
- vendor/bin/phpunit *(fails: Unable to download WordPress from https://wordpress.org/wordpress-6.8.2-no-content.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68e63a0275e4832e86d8a8d02c7d771c