### PR TITLE
Allow filtering CSS revision retention and localize token defaults

### DIFF
--- a/supersede-css-jlg-enhanced/assets/js/tokens.js
+++ b/supersede-css-jlg-enhanced/assets/js/tokens.js
@@ -110,7 +110,7 @@
             window.wp.a11y.speak(message, politeness || 'polite');
         }
     }
-    const defaultGroupName = 'Général';
+    const defaultGroupName = translate('defaultGroupName', 'Général');
     const diacriticRegex = /[\u0300-\u036f]/g;
     const hasStringNormalize = typeof ''.normalize === 'function';
     const localUiState = {

--- a/supersede-css-jlg-enhanced/docs/code-review-2024-11-21.md
+++ b/supersede-css-jlg-enhanced/docs/code-review-2024-11-21.md
@@ -1,0 +1,11 @@
+# Revue de code — 21 novembre 2024
+
+## Points forts
+- Le pipeline de `CssSanitizer` supprime systématiquement les balises HTML, neutralise les `@import`/URLs risqués et reconstruit les blocs de manière sûre avant de fournir le CSS nettoyé, ce qui réduit considérablement la surface d’attaque côté éditeur et frontend.【F:src/Support/CssSanitizer.php†L13-L119】
+- Les contrôleurs REST héritent d’une autorisation partagée qui vérifie nonce, authentification hors cookies et capacité requise, ce qui homogénéise la sécurité des endpoints personnalisés du plugin.【F:src/Infra/Rest/BaseController.php†L13-L67】
+- La gestion des révisions CSS nettoie chaque entrée, synchronise les segments (desktop/tablette/mobile) et invalide le cache automatiquement, apportant une piste d’audit utile pour les équipes éditoriales.【F:src/Support/CssRevisions.php†L20-L83】【F:src/Support/CssRevisions.php†L118-L171】
+
+## Axes d’amélioration proposés
+- Les libellés par défaut de l’éditeur de tokens côté JavaScript sont codés en dur en français ; s’appuyer sur la fonction `translate()` (alimentée par `wp_localize_script`) pour ces chaînes permettrait d’exposer facilement des traductions ou du contenu sur-mesure.【F:assets/js/tokens.js†L5-L113】
+- Le nombre maximum de révisions était figé à 20 ; l’introduction d’un filtre pour ajuster cette limite selon la volumétrie du site (gros médias vs petits sites) sécurise mieux les besoins de rétention ou de conformité.【F:src/Support/CssRevisions.php†L44-L67】
+- Les tests d’intégration autour des révisions gagnent à valider le comportement lorsque la limite est filtrée, pour éviter toute régression dans les environnements qui personnalisent la valeur par défaut.【F:tests/Support/CssRevisionsTest.php†L303-L331】

--- a/supersede-css-jlg-enhanced/src/Support/CssRevisions.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssRevisions.php
@@ -53,11 +53,31 @@ final class CssRevisions
         }
 
         array_unshift($stored, $revision);
-        if (count($stored) > self::MAX_REVISIONS) {
-            $stored = array_slice($stored, 0, self::MAX_REVISIONS);
+        $maxRevisions = self::getMaxRevisions();
+        if ($maxRevisions > 0 && count($stored) > $maxRevisions) {
+            $stored = array_slice($stored, 0, $maxRevisions);
         }
 
         update_option(self::OPTION, array_values($stored), false);
+    }
+
+    private static function getMaxRevisions(): int
+    {
+        $max = self::MAX_REVISIONS;
+
+        if (function_exists('apply_filters')) {
+            $filtered = apply_filters('ssc_css_revisions_max', $max);
+
+            if (is_numeric($filtered)) {
+                $max = (int) $filtered;
+            }
+        }
+
+        if ($max < 1) {
+            return self::MAX_REVISIONS;
+        }
+
+        return $max;
     }
 
     /**

--- a/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Support/TokenRegistry.php
@@ -392,7 +392,7 @@ final class TokenRegistry
             : '';
         $group = isset($token['group']) ? sanitize_text_field((string) $token['group']) : '';
         if ($group === '') {
-            $group = 'Général';
+            $group = __('Général', 'supersede-css-jlg');
         }
 
         $context = self::sanitizeContext($token['context'] ?? self::DEFAULT_CONTEXT);

--- a/supersede-css-jlg-enhanced/views/tokens.php
+++ b/supersede-css-jlg-enhanced/views/tokens.php
@@ -46,6 +46,7 @@ if (function_exists('wp_localize_script')) {
             'emptyState' => __('Aucun token pour le moment. Utilisez le bouton ci-dessous pour commencer.', 'supersede-css-jlg'),
             'emptyFilteredState' => __('Aucun token ne correspond à votre recherche ou filtre actuel.', 'supersede-css-jlg'),
             'groupLabel' => __('Groupe', 'supersede-css-jlg'),
+            'defaultGroupName' => __('Général', 'supersede-css-jlg'),
             'nameLabel' => __('Nom', 'supersede-css-jlg'),
             'valueLabel' => __('Valeur', 'supersede-css-jlg'),
             'typeLabel' => __('Type', 'supersede-css-jlg'),


### PR DESCRIPTION
## Summary
- allow integrators to tune CSS revision retention through a new `ssc_css_revisions_max` filter with a safe fallback
- make the default token group label translatable across PHP and JavaScript surfaces
- document the current plugin review to capture strengths and next steps

## Testing
- composer test *(fails: network is unreachable when downloading WordPress fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e639fd7594832e92f641eef88d4f41