### PR TITLE
Load plugin classes through Composer autoloader

### DIFF
--- a/supersede-css-jlg-enhanced/src/autoload-fallback.php
+++ b/supersede-css-jlg-enhanced/src/autoload-fallback.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+spl_autoload_register(
+    static function (string $class): void {
+        $prefix = 'SSC\\';
+        $baseDir = __DIR__ . '/';
+        $length = strlen($prefix);
+
+        if (strncmp($prefix, $class, $length) !== 0) {
+            return;
+        }
+
+        $relativeClass = substr($class, $length);
+        $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+        if (is_readable($file)) {
+            require $file;
+        }
+    }
+);

--- a/supersede-css-jlg-enhanced/supersede-css-jlg.php
+++ b/supersede-css-jlg-enhanced/supersede-css-jlg.php
@@ -21,19 +21,13 @@ define('SSC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 // CORRECTION : Déclaration de l'URL plus robuste pour éviter les erreurs 404.
 define('SSC_PLUGIN_URL', plugins_url('/', __FILE__));
 
-spl_autoload_register(function($class){
-    $prefix = 'SSC\\';
-    $base_dir = __DIR__ . '/src/';
-    $len = strlen($prefix);
-    if (strncmp($prefix, $class, $len) !== 0) {
-        return;
-    }
-    $relative_class = substr($class, $len);
-    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
-    if (file_exists($file)) {
-        require $file;
-    }
-});
+$composerAutoload = __DIR__ . '/vendor/autoload.php';
+
+if (file_exists($composerAutoload)) {
+    require $composerAutoload;
+} else {
+    require __DIR__ . '/src/autoload-fallback.php';
+}
 
 if (!function_exists('ssc_get_required_capability')) {
     /**


### PR DESCRIPTION
## Summary
- load the plugin classes through Composer's autoloader when vendor files are available
- keep a lightweight fallback autoloader for development builds that do not ship vendor dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6560d4424832eaccc5f281527cd64