### PR TITLE
Fix wp-env core source for Playwright tests

### DIFF
--- a/supersede-css-jlg-enhanced/.wp-env.json
+++ b/supersede-css-jlg-enhanced/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "latest",
+  "core": "https://wordpress.org/latest.zip",
   "phpVersion": "8.2",
   "plugins": [
     "."


### PR DESCRIPTION
## Summary
- replace the deprecated `latest` core reference with the official latest WordPress zip URL so wp-env can start

## Testing
- npx playwright test *(fails: Could not connect to Docker. Is it running?)*

------
https://chatgpt.com/codex/tasks/task_e_68e66113721c832ea0d18c0ce821663d