### PR TITLE
Ensure CSS revisions capture current user when available

### DIFF
--- a/supersede-css-jlg-enhanced/src/Support/CssRevisions.php
+++ b/supersede-css-jlg-enhanced/src/Support/CssRevisions.php
@@ -91,10 +91,6 @@ final class CssRevisions
             return '';
         }
 
-        if (method_exists($user, 'exists') && !$user->exists()) {
-            return '';
-        }
-
         $candidates = [];
 
         if (isset($user->user_login) && is_string($user->user_login)) {
@@ -119,6 +115,10 @@ final class CssRevisions
             if ($candidate !== '') {
                 return $candidate;
             }
+        }
+
+        if (method_exists($user, 'exists') && !$user->exists()) {
+            return '';
         }
 
         return '';


### PR DESCRIPTION
## Summary
- adjust CssRevisions author resolution to prefer available user fields before bailing on non-existent users

## Testing
- vendor/bin/phpunit (fails to download WordPress, falls back to offline bootstrap)

------
https://chatgpt.com/codex/tasks/task_e_68e660e51ea0832e97517c8e24a3794c