### PR TITLE
Centralize admin module manifest and streamline asset loading

### DIFF
--- a/supersede-css-jlg-enhanced/src/Admin/Layout.php
+++ b/supersede-css-jlg-enhanced/src/Admin/Layout.php
@@ -281,35 +281,7 @@ class Layout {
     public static function render(string $page_content, string $current_page_slug): void {
         $page_content = self::sanitize_style_blocks($page_content);
         
-        $menu_items = [
-            'Fondamentaux' => [
-                'supersede-css-jlg'                => 'Dashboard',
-                'supersede-css-jlg-utilities'      => 'Utilities (Éditeur CSS)',
-                'supersede-css-jlg-tokens'         => 'Tokens Manager',
-                'supersede-css-jlg-preset'         => 'Preset Designer',
-            ],
-            'Générateurs Visuels' => [
-                'supersede-css-jlg-layout-builder' => 'Maquettage de Page',
-                'supersede-css-jlg-grid'           => 'Grid Editor',
-                'supersede-css-jlg-shadow'         => 'Shadow Editor',
-                'supersede-css-jlg-gradient'       => 'Gradient Editor',
-                'supersede-css-jlg-typography'     => 'Typographie Fluide',
-                'supersede-css-jlg-clip-path'      => 'Découpe (Clip-Path)',
-                'supersede-css-jlg-filters'        => 'Filtres & Verre',
-            ],
-            'Effets & Animations' => [
-                'supersede-css-jlg-anim'           => 'Animation Studio',
-                'supersede-css-jlg-effects'        => 'Effets Visuels',
-                'supersede-css-jlg-tron'           => 'Tron Grid',
-                'supersede-css-jlg-avatar'         => 'Avatar Glow',
-            ],
-            'Outils & Maintenance' => [
-                'supersede-css-jlg-scope'          => 'Scope Builder',
-                'supersede-css-jlg-css-viewer'     => 'Visualiseur CSS',
-                'supersede-css-jlg-import'         => 'Import/Export',
-                'supersede-css-jlg-debug-center'   => 'Debug Center',
-            ],
-        ];
+        $menu_items = ModuleRegistry::groupedMenu();
         $back_to_admin_aria_label = esc_attr__('Retourner sur le tableau de bord WordPress', 'supersede-css-jlg');
         $back_to_admin_label = esc_html__('WP Admin', 'supersede-css-jlg');
         $theme_button_label = esc_html__('Thème', 'supersede-css-jlg');

--- a/supersede-css-jlg-enhanced/src/Admin/ModuleRegistry.php
+++ b/supersede-css-jlg-enhanced/src/Admin/ModuleRegistry.php
@@ -1,0 +1,414 @@
+<?php declare(strict_types=1);
+
+namespace SSC\Admin;
+
+if (!defined('ABSPATH')) { exit; }
+
+final class ModuleRegistry
+{
+    public const BASE_SLUG = 'supersede-css-jlg';
+
+    /**
+     * Returns the manifest describing all admin modules.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function modules(): array
+    {
+        return [
+            'dashboard' => [
+                'slug'      => '',
+                'page_slug' => self::BASE_SLUG,
+                'label'     => __('Dashboard', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\Dashboard',
+                'group'     => 'fundamentals',
+                'assets'    => [
+                    'styles' => [
+                        [
+                            'path' => 'assets/css/dashboard.css',
+                        ],
+                    ],
+                ],
+            ],
+            'utilities' => [
+                'slug'      => 'utilities',
+                'page_slug' => self::BASE_SLUG . '-utilities',
+                'label'     => __('Utilities (Éditeur CSS)', 'supersede-css-jlg'),
+                'menu_label' => __('Utilities', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\Utilities',
+                'group'     => 'fundamentals',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path'         => 'assets/js/utilities.js',
+                            'deps'         => ['jquery', 'wp-i18n'],
+                            'translations' => true,
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/utilities.css',
+                        ],
+                    ],
+                ],
+            ],
+            'tokens' => [
+                'slug'      => 'tokens',
+                'page_slug' => self::BASE_SLUG . '-tokens',
+                'label'     => __('Tokens Manager', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\Tokens',
+                'group'     => 'fundamentals',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/tokens.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/tokens.css',
+                        ],
+                    ],
+                ],
+            ],
+            'preset' => [
+                'slug'      => 'preset',
+                'page_slug' => self::BASE_SLUG . '-preset',
+                'label'     => __('Preset Designer', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\PresetDesigner',
+                'group'     => 'fundamentals',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/preset-designer.js',
+                        ],
+                    ],
+                ],
+            ],
+            'layout-builder' => [
+                'slug'      => 'layout-builder',
+                'page_slug' => self::BASE_SLUG . '-layout-builder',
+                'label'     => __('Maquettage de Page', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\PageLayoutBuilder',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/page-layout-builder.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/page-layout-builder.css',
+                        ],
+                    ],
+                ],
+            ],
+            'grid' => [
+                'slug'      => 'grid',
+                'page_slug' => self::BASE_SLUG . '-grid',
+                'label'     => __('Grid Editor', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\GridEditor',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/grid-editor.js',
+                        ],
+                    ],
+                ],
+            ],
+            'shadow' => [
+                'slug'      => 'shadow',
+                'page_slug' => self::BASE_SLUG . '-shadow',
+                'label'     => __('Shadow Editor', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\ShadowEditor',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/shadow-editor.js',
+                        ],
+                        [
+                            'handle' => 'ssc-sortable',
+                            'path'   => 'assets/js/Sortable.min.js',
+                            'deps'   => [],
+                        ],
+                    ],
+                ],
+            ],
+            'gradient' => [
+                'slug'      => 'gradient',
+                'page_slug' => self::BASE_SLUG . '-gradient',
+                'label'     => __('Gradient Editor', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\GradientEditor',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/gradient-editor.js',
+                        ],
+                    ],
+                ],
+            ],
+            'typography' => [
+                'slug'      => 'typography',
+                'page_slug' => self::BASE_SLUG . '-typography',
+                'label'     => __('Typographie Fluide', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\TypographyEditor',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/typography-editor.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/typography-editor.css',
+                        ],
+                    ],
+                ],
+            ],
+            'clip-path' => [
+                'slug'      => 'clip-path',
+                'page_slug' => self::BASE_SLUG . '-clip-path',
+                'label'     => __('Découpe (Clip-Path)', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\ClipPathEditor',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/clip-path-editor.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/clip-path-editor.css',
+                        ],
+                    ],
+                ],
+            ],
+            'filters' => [
+                'slug'      => 'filters',
+                'page_slug' => self::BASE_SLUG . '-filters',
+                'label'     => __('Filtres & Verre', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\FilterEditor',
+                'group'     => 'visual-builders',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/filter-editor.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/filter-editor.css',
+                        ],
+                    ],
+                ],
+            ],
+            'anim' => [
+                'slug'      => 'anim',
+                'page_slug' => self::BASE_SLUG . '-anim',
+                'label'     => __('Animation Studio', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\AnimationStudio',
+                'group'     => 'effects',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/animation-studio.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/animation-studio.css',
+                        ],
+                    ],
+                ],
+            ],
+            'effects' => [
+                'slug'          => 'effects',
+                'page_slug'     => self::BASE_SLUG . '-effects',
+                'label'         => __('Effets Visuels', 'supersede-css-jlg'),
+                'class'         => '\\SSC\\Admin\\Pages\\VisualEffects',
+                'group'         => 'effects',
+                'enqueue_media' => true,
+                'assets'        => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/visual-effects.js',
+                        ],
+                    ],
+                    'styles'  => [
+                        [
+                            'path' => 'assets/css/visual-effects.css',
+                        ],
+                    ],
+                ],
+            ],
+            'tron' => [
+                'slug'      => 'tron',
+                'page_slug' => self::BASE_SLUG . '-tron',
+                'label'     => __('Tron Grid', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\TronGrid',
+                'group'     => 'effects',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/tron-grid.js',
+                        ],
+                    ],
+                ],
+            ],
+            'avatar' => [
+                'slug'          => 'avatar',
+                'page_slug'     => self::BASE_SLUG . '-avatar',
+                'label'         => __('Avatar Glow', 'supersede-css-jlg'),
+                'class'         => '\\SSC\\Admin\\Pages\\AvatarGlow',
+                'group'         => 'effects',
+                'enqueue_media' => true,
+                'assets'        => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/effects-avatar.js',
+                        ],
+                    ],
+                ],
+            ],
+            'scope' => [
+                'slug'      => 'scope',
+                'page_slug' => self::BASE_SLUG . '-scope',
+                'label'     => __('Scope Builder', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\ScopeBuilder',
+                'group'     => 'tools',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path' => 'assets/js/scope-builder.js',
+                        ],
+                    ],
+                ],
+            ],
+            'css-viewer' => [
+                'slug'      => 'css-viewer',
+                'page_slug' => self::BASE_SLUG . '-css-viewer',
+                'label'     => __('Visualiseur CSS', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\CssViewer',
+                'group'     => 'tools',
+            ],
+            'import' => [
+                'slug'      => 'import',
+                'page_slug' => self::BASE_SLUG . '-import',
+                'label'     => __('Import/Export', 'supersede-css-jlg'),
+                'menu_label' => __('Import / Export', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\ImportExport',
+                'group'     => 'tools',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path'         => 'assets/js/import-export.js',
+                            'deps'         => ['jquery', 'wp-i18n'],
+                            'translations' => true,
+                        ],
+                    ],
+                ],
+            ],
+            'css-performance' => [
+                'slug'      => 'css-performance',
+                'page_slug' => self::BASE_SLUG . '-css-performance',
+                'label'     => __('Analyse Performance CSS', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\CssPerformance',
+                'group'     => 'tools',
+            ],
+            'debug-center' => [
+                'slug'      => 'debug-center',
+                'page_slug' => self::BASE_SLUG . '-debug-center',
+                'label'     => __('Debug Center', 'supersede-css-jlg'),
+                'class'     => '\\SSC\\Admin\\Pages\\DebugCenter',
+                'group'     => 'tools',
+                'assets'    => [
+                    'scripts' => [
+                        [
+                            'path'         => 'assets/js/debug-center.js',
+                            'deps'         => ['jquery', 'wp-i18n'],
+                            'translations' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Returns the ordered list of menu groups.
+     *
+     * @return array<string, string>
+     */
+    public static function menuGroups(): array
+    {
+        return [
+            'fundamentals'  => __('Fondamentaux', 'supersede-css-jlg'),
+            'visual-builders' => __('Générateurs Visuels', 'supersede-css-jlg'),
+            'effects'       => __('Effets & Animations', 'supersede-css-jlg'),
+            'tools'         => __('Outils & Maintenance', 'supersede-css-jlg'),
+        ];
+    }
+
+    /**
+     * Returns modules indexed by their page slug.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function modulesByPage(): array
+    {
+        $by_page = [];
+        foreach (self::modules() as $module) {
+            $by_page[$module['page_slug']] = $module;
+        }
+
+        return $by_page;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function submenuModules(): array
+    {
+        return array_values(array_filter(self::modules(), static fn(array $module): bool => $module['slug'] !== ''));
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public static function groupedMenu(): array
+    {
+        $groups = self::menuGroups();
+        $grouped = [];
+
+        foreach ($groups as $key => $label) {
+            $grouped[$label] = [];
+        }
+
+        foreach (self::modules() as $module) {
+            $group_key = $module['group'] ?? null;
+            if ($group_key === null || !isset($groups[$group_key])) {
+                continue;
+            }
+
+            $group_label = $groups[$group_key];
+            if (!isset($grouped[$group_label])) {
+                $grouped[$group_label] = [];
+            }
+
+            $grouped[$group_label][$module['page_slug']] = $module['label'];
+        }
+
+        return $grouped;
+    }
+
+    public static function findByPageSlug(string $page_slug): ?array
+    {
+        return self::modulesByPage()[$page_slug] ?? null;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize admin module metadata and asset requirements in a new `ModuleRegistry` manifest
- update the admin bootstrap to register submenus and enqueue scripts/styles directly from the shared manifest
- render the layout navigation from the manifest so modules like CSS Performance automatically appear in the sidebar

## Testing
- php -l supersede-css-jlg-enhanced/src/Admin/Admin.php
- php -l supersede-css-jlg-enhanced/src/Admin/ModuleRegistry.php
- php -l supersede-css-jlg-enhanced/src/Admin/Layout.php

------
https://chatgpt.com/codex/tasks/task_e_68e6561000b0832ea0676d68db6f9fb7