### PR TITLE
Ensure WordPress test bootstrap sets revision tester user

### DIFF
--- a/supersede-css-jlg-enhanced/tests/bootstrap.php
+++ b/supersede-css-jlg-enhanced/tests/bootstrap.php
@@ -34,6 +34,66 @@ if ($wordpressAvailable && file_exists($_tests_dir . '/includes/functions.php'))
 
     require $_tests_dir . '/includes/bootstrap.php';
 
+    if (function_exists('wp_set_current_user')) {
+        $username = 'revision_tester';
+        $user = null;
+
+        if (function_exists('get_user_by')) {
+            $user = get_user_by('login', $username) ?: null;
+        }
+
+        if ($user === null && function_exists('username_exists')) {
+            $existingId = username_exists($username);
+            if (is_int($existingId) && $existingId > 0 && function_exists('get_user_by')) {
+                $user = get_user_by('id', $existingId) ?: null;
+            }
+        }
+
+        if ($user === null && function_exists('wp_insert_user')) {
+            if (function_exists('wp_generate_password')) {
+                $password = wp_generate_password(20, true);
+            } else {
+                try {
+                    $password = bin2hex(random_bytes(12));
+                } catch (Throwable $exception) {
+                    unset($exception);
+                    $password = substr(hash('sha256', (string) microtime(true)), 0, 24);
+                }
+            }
+
+            $createdUserId = wp_insert_user([
+                'user_login' => $username,
+                'user_pass' => $password,
+                'user_email' => $username . '@example.org',
+                'role' => 'administrator',
+            ]);
+
+            if (is_int($createdUserId) && $createdUserId > 0 && function_exists('get_user_by')) {
+                $user = get_user_by('id', $createdUserId) ?: null;
+            }
+
+            if ($user === null) {
+                if (function_exists('is_wp_error') && is_wp_error($createdUserId)) {
+                    $existingLogin = $createdUserId->get_error_data('existing_user_login');
+                    if (is_string($existingLogin) && $existingLogin !== '' && function_exists('get_user_by')) {
+                        $user = get_user_by('login', $existingLogin) ?: null;
+                    }
+                }
+
+                if ($user === null && function_exists('username_exists')) {
+                    $existingId = username_exists($username);
+                    if (is_int($existingId) && $existingId > 0 && function_exists('get_user_by')) {
+                        $user = get_user_by('id', $existingId) ?: null;
+                    }
+                }
+            }
+        }
+
+        if ($user instanceof WP_User) {
+            wp_set_current_user($user->ID);
+        }
+    }
+
     return;
 }
 


### PR DESCRIPTION
## Summary
- harden the PHPUnit bootstrap so it reliably provisions the `revision_tester` account
- reuse existing users or create one with a locally generated password when WordPress helpers are unavailable
- guarantee the logged-in author is set for revision-related tests

## Testing
- WP_TESTS_DB_USER=wp WP_TESTS_DB_PASSWORD=password vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e661038a34832e9b2b0aa2b9be81d1