### PR TITLE
Add accessible label for import file input

### DIFF
--- a/supersede-css-jlg-enhanced/views/import-export.php
+++ b/supersede-css-jlg-enhanced/views/import-export.php
@@ -83,6 +83,9 @@ if (function_exists('wp_set_script_translations')) {
         </div>
         <div class="ssc-pane">
             <h3><?php esc_html_e('Importer', 'supersede-css-jlg'); ?></h3><p><?php esc_html_e('Importez un fichier de configuration (.json).', 'supersede-css-jlg'); ?></p>
+            <label for="ssc-import-file" class="screen-reader-text">
+                <?php echo esc_html__('Importer un fichier de configuration Supersede CSS', 'supersede-css-jlg'); ?>
+            </label>
             <input type="file" id="ssc-import-file" accept=".json">
             <button id="ssc-import-btn" class="button"><?php esc_html_e('Importer', 'supersede-css-jlg'); ?></button>
             <div id="ssc-import-msg" class="ssc-muted"></div>


### PR DESCRIPTION
## Summary
- add a screen-reader-only label describing the import file control in the import/export view
- ensure the label text uses translation helpers to stay localizable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd6f5d6364832ea1b28128ef327f4a