### PR TITLE
Improve accessibility of CRT preview canvas

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/visual-effects.css
+++ b/supersede-css-jlg-enhanced/assets/css/visual-effects.css
@@ -77,6 +77,18 @@
     height: 100%;
 }
 
+.ssc-ve-preview-box .ssc-crt-canvas-description {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    border: 0;
+}
+
 .ssc-ecg-path {
     fill: none;
     stroke-width: 2;

--- a/supersede-css-jlg-enhanced/views/visual-effects.php
+++ b/supersede-css-jlg-enhanced/views/visual-effects.php
@@ -42,7 +42,18 @@ if (!defined('ABSPATH')) {
             </div>
             <div class="ssc-pane">
                 <h3><?php esc_html_e('Aperçu', 'supersede-css-jlg'); ?></h3>
-                <div class="ssc-ve-preview-box"><canvas id="ssc-crt-canvas"></canvas></div>
+                <?php
+                $crt_preview_label = esc_html__('Aperçu simulé d\'un écran cathodique avec lignes de balayage animées.', 'supersede-css-jlg');
+                $crt_preview_fallback = esc_html__('Votre navigateur ne prend pas en charge le canevas HTML. L\'aperçu de l\'effet CRT présente normalement un écran sombre parcouru de lignes de balayage vertes et ponctué de bruit vidéo.', 'supersede-css-jlg');
+                ?>
+                <div class="ssc-ve-preview-box">
+                    <canvas id="ssc-crt-canvas" role="img" aria-labelledby="ssc-crt-canvas-description">
+                        <?php echo $crt_preview_fallback; ?>
+                    </canvas>
+                    <p id="ssc-crt-canvas-description" class="screen-reader-text ssc-crt-canvas-description">
+                        <?php echo $crt_preview_label; ?>
+                    </p>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a screen-reader description and fallback copy to the CRT preview canvas
- expose the description via appropriate ARIA attributes with translatable strings
- hide the descriptive paragraph visually while leaving it available to assistive technologies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd6f5ece60832e878a159988249d87