### PR TITLE
Fix Supersede admin menu contrast

### DIFF
--- a/supersede-css-jlg-enhanced/assets/css/admin.css
+++ b/supersede-css-jlg-enhanced/assets/css/admin.css
@@ -1532,6 +1532,31 @@ body[class*="page_supersede-css-jlg"] .ssc-layout .ssc-main-content {
     padding-right: 16px;
     min-height: 0;
 }
+
+/* Keep the WordPress sidebar legible on Supersede pages -------------------- */
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg > a,
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg > a .wp-menu-name {
+    color: #f0f0f1;
+}
+
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg > a .wp-menu-image:before {
+    color: #f0f0f1;
+}
+
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg.wp-has-current-submenu > a,
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg.wp-has-current-submenu > a .wp-menu-name {
+    color: #fff;
+    font-weight: 600;
+}
+
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg .wp-submenu a {
+    color: #d4d6d8;
+}
+
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg .wp-submenu a:hover,
+body[class*="page_supersede-css-jlg"] #adminmenu .toplevel_page_supersede-css-jlg .wp-submenu a:focus {
+    color: #fff;
+}
 @media (max-width: 960px) {
     body[class*="page_supersede-css-jlg"] .ssc-viewport {
         margin-top: 12px;


### PR DESCRIPTION
## Summary
- ensure the Supersede CSS top-level admin menu keeps WordPress default colors while viewing plugin pages
- align submenu hover/focus states so the entries remain legible against the WP sidebar background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff70be98dc832ea03763a8e8efbc30